### PR TITLE
Add OWNERS file and README repository access information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # hyperfleet-adapter
-HyperFleet Adapter Framework - Event-driven adapter services for HyperFleet cluster provisioning. Handles CloudEvents    consumption, AdapterConfig CRD integration, precondition evaluation, Kubernetes Job creation/monitoring, and status reporting    via API. Supports GCP Pub/Sub, RabbitMQ broker abstraction.
+
+HyperFleet Adapter Framework - Event-driven adapter services for HyperFleet cluster provisioning. Handles CloudEvents consumption, AdapterConfig CRD integration, precondition evaluation, Kubernetes Job creation/monitoring, and status reporting via API. Supports GCP Pub/Sub, RabbitMQ broker abstraction.
+
+## Repository Access
+
+All members of the **hyperfleet** team have write access to this repository.
+
+### Steps to Apply for Repository Access
+
+If you're a team member and need access to this repository:
+
+1. **Verify Organization Membership**: Ensure you're a member of the `openshift-hyperfleet` organization
+2. **Check Team Assignment**: Confirm you're added to the hyperfleet team within the organization
+3. **Repository Permissions**: All hyperfleet team members automatically receive write access
+4. **OWNERS File**: Code reviews and approvals are managed through the OWNERS file
+
+For access issues, contact a repository administrator or organization owner.


### PR DESCRIPTION
## Summary
- Add OWNERS file with complete list of hyperfleet team members as approvers
- Update README with repository descriptions and access information  
- Include clear steps for repository access and team membership requirements
- Reference hyperfleet team instead of individual usernames for cleaner documentation

## Test plan
- [x] Verify OWNERS file contains all team members from organization
- [x] Validate YAML syntax is correct
- [x] Confirm README follows clean documentation standards
- [x] Test that repository access information is clear and actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)