### PR TITLE
Fix the error from 'make lint'

### DIFF
--- a/cmd/adapter/main.go
+++ b/cmd/adapter/main.go
@@ -84,7 +84,9 @@ func run() error {
 
 		done := make(chan struct{})
 		go func() {
-			subscriber.Close()
+			if err := subscriber.Close(); err != nil {
+				log.Error(fmt.Sprintf("Error closing subscriber: %v", err))
+			}
 			close(done)
 		}()
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/cloudevents/sdk-go/v2 v2.16.2
-	github.com/docker/docker v28.5.1+incompatible
+	github.com/docker/go-connections v0.6.0
 	github.com/golang/glog v1.2.5
 	github.com/google/uuid v1.6.0
 	github.com/openshift-hyperfleet/hyperfleet-broker v0.0.1
@@ -40,7 +40,7 @@ require (
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/distribution/reference v0.6.0 // indirect
-	github.com/docker/go-connections v0.6.0 // indirect
+	github.com/docker/docker v28.5.1+incompatible // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ebitengine/purego v0.8.4 // indirect
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect

--- a/test/integration/broker_consumer/testutil_publisher.go
+++ b/test/integration/broker_consumer/testutil_publisher.go
@@ -22,7 +22,11 @@ func publishTestMessages(t *testing.T, topic string, count int) {
 	// Create publisher from environment variables
 	publisher, err := broker.NewPublisher()
 	require.NoError(t, err, "Failed to create publisher")
-	defer publisher.Close()
+	defer func() {
+		if err := publisher.Close(); err != nil {
+			t.Errorf("Error closing publisher: %v", err)
+		}
+	}()
 
 	t.Logf("Publishing %d test messages to topic: %s", count, topic)
 


### PR DESCRIPTION
fix the error from 'make lint'
https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/pr-logs/pull/openshift_release/71991/rehearse-71991-pull-ci-openshift-hyperfleet-hyperfleet-adapter-main-lint/1995340821385187328
```

make lint                                         
Running golangci-lint...
0 issues.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during shutdown and cleanup: resource closure errors are now captured and logged instead of being ignored.

* **Tests**
  * Hardened integration tests with assertion-wrapped environment operations, guarded cleanup, and surfaced close-time errors for clearer failures.

* **Chores**
  * Adjusted dependency declarations to reorganize indirect/direct requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->