### PR TITLE
Add image-push and image-dev Makefile targets (HYPERFLEET-311)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,9 @@ hyperfleet-adapter/
 | `make test-all` | Run all tests (unit + integration) |
 | `make test-coverage` | Generate test coverage report |
 | `make lint` | Run golangci-lint |
-| `make docker-build` | Build Docker image |
-| `make docker-push` | Push Docker image |
+| `make image` | Build container image |
+| `make image-push` | Build and push container image to registry |
+| `make image-dev` | Build and push to personal Quay registry (requires QUAY_USER) |
 | `make fmt` | Format code |
 | `make mod-tidy` | Tidy Go module dependencies |
 | `make clean` | Clean build artifacts |
@@ -156,19 +157,22 @@ helm delete hyperfleet-adapter
 
 For detailed Helm chart documentation, see [charts/README.md](./charts/README.md).
 
-### Docker Image
+### Container Image
 
-Build and push Docker images:
+Build and push container images:
 
 ```bash
-# Build Docker image
-make docker-build
+# Build container image
+make image
 
 # Build with custom tag
-make docker-build IMAGE_TAG=v1.0.0
+make image IMAGE_TAG=v1.0.0
 
-# Push Docker image
-make docker-push
+# Build and push to default registry
+make image-push
+
+# Build and push to personal Quay registry (for development)
+QUAY_USER=myuser make image-dev
 ```
 
 Default image: `quay.io/openshift-hyperfleet/hyperfleet-adapter:latest`

--- a/configs/adapter.yaml
+++ b/configs/adapter.yaml
@@ -1,0 +1,87 @@
+# HyperFleet Adapter Framework Configuration (Default/Fallback)
+#
+# This is a minimal default configuration packaged with the container image.
+# In production, this should be overridden via:
+#   1. CONFIG_FILE environment variable (highest priority)
+#   2. ConfigMap mounted at /etc/adapter/config/adapter.yaml
+#
+# See configs/adapter-config-template.yaml for full configuration options.
+
+apiVersion: hyperfleet.redhat.com/v1alpha1
+kind: AdapterConfig
+metadata:
+  name: hyperfleet-adapter
+  namespace: hyperfleet-system
+  labels:
+    hyperfleet.io/component: adapter
+
+spec:
+  adapter:
+    version: "0.0.1"
+
+  hyperfleetApi:
+    timeout: 2s
+    retryAttempts: 3
+    retryBackoff: exponential
+
+  kubernetes:
+    apiVersion: "v1"
+
+  # Global params - these should be provided via environment variables or ConfigMap
+  params:
+    - name: "hyperfleetApiBaseUrl"
+      source: "env.HYPERFLEET_API_BASE_URL"
+      type: "string"
+      description: "Base URL for the HyperFleet API"
+      required: true
+
+    - name: "hyperfleetApiVersion"
+      source: "env.HYPERFLEET_API_VERSION"
+      type: "string"
+      default: "v1"
+      description: "API version to use"
+      required: true
+
+    - name: "hyperfleetApiToken"
+      source: "env.HYPERFLEET_API_TOKEN"
+      type: "string"
+      description: "Authentication token for API access"
+      required: true
+
+    - name: "clusterId"
+      source: "event.cluster_id"
+      type: "string"
+      description: "Unique identifier for the target cluster"
+      required: true
+
+    - name: "resourceId"
+      source: "event.resource_id"
+      type: "string"
+      description: "Unique identifier for the resource"
+      required: true
+
+    - name: "resourceType"
+      source: "event.resource_type"
+      type: "string"
+      description: "Type of the resource being managed"
+      required: true
+
+    - name: "eventGenerationId"
+      source: "event.generation"
+      type: "string"
+      description: "Event generation ID for idempotency checks"
+      required: true
+
+    - name: "eventHref"
+      source: "event.href"
+      type: "string"
+      description: "Reference URL for the resource"
+      required: true
+
+  # Preconditions, resources, and post-processing should be defined
+  # in a production configuration mounted via ConfigMap
+  preconditions: []
+  resources: []
+  post:
+    payloads: []
+    postActions: []


### PR DESCRIPTION
## Summary
- Add `make image-push` target to build and push to configured registry
- Add `make image-dev` target to build and push to personal Quay registry (`quay.io/$QUAY_USER/hyperfleet-adapter:dev-<commit>`)
- Add `QUAY_USER` and `DEV_TAG` variables for dev image configuration
- Update `make image` to use full registry path (`IMAGE_REGISTRY/PROJECT_NAME:IMAGE_TAG`)
- Update README.md with new image targets documentation

## Test plan
- [x] `make help` shows new targets (image-push, image-dev)
- [x] `make image-dev` without `QUAY_USER` shows helpful error message
- [x] `make -n image` shows correct full registry path
- [x] `QUAY_USER=croche make -n image-dev` shows correct commands
- [x] Existing `image` target continues to work

## Usage
```bash
# Build and push to default registry
make image-push

# Build and push to personal registry
QUAY_USER=myuser make image-dev
```

Closes: https://issues.redhat.com/browse/HYPERFLEET-311

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a development image workflow to build and push dev-tagged container images to a personal registry.
  * Added a target to push built images to a container registry.
  * Introduced a default adapter configuration for Kubernetes-based deployments.

* **Improvements**
  * Image build now tags images with registry-aware paths and prints the registry path on success.

* **Documentation**
  * Updated README guidance to reflect new image build/push/dev commands and registry usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->