### PR TITLE
HYPERFLEET-390 | refactor:  refator evaluator to support jsonPATH and cel expression.

### DIFF
--- a/configs/adapter-config-template.yaml
+++ b/configs/adapter-config-template.yaml
@@ -98,7 +98,20 @@ spec:
   # ============================================================================
   # Global Preconditions
   # ============================================================================
-  # These preconditions run sequentially and validate cluster state before resource operations
+  # These preconditions run sequentially and validate cluster state before resource operations.
+  #
+  # DATA SCOPES:
+  # ============
+  # Capture scope (field/expression): API response data only
+  #   - Access: status.phase, items[0].name, etc.
+  #
+  # Conditions scope (conditions/expression): Full execution context
+  #   - params.*             : Original extracted params
+  #   - <precondition-name>.*: Full API response (e.g., clusterStatus.status.phase)
+  #   - capturedField        : Explicitly captured values
+  #   - adapter.*            : Adapter metadata
+  #   - resources.*          : Created resources (empty during preconditions)
+  #
   preconditions:
     # ==========================================================================
     # Step 1: Get cluster status
@@ -112,17 +125,49 @@ spec:
         retryAttempts: 3
         retryBackoff: "exponential"
       # Capture fields from the API response. Captured values become variables for use in resources section.
+      # SCOPE: API response data only
+      # Supports two modes:
+      #   - field: Simple dot notation or JSONPath expression for extracting values
+      #   - expression: CEL expression for computed values
+      # Only one of 'field' or 'expression' can be set per capture.
       capture:
+        # Simple dot notation
         - name: "clusterName"
           field: "name"
         - name: "clusterPhase"
           field: "status.phase"
         - name: "generationId"
           field: "generation"
+        
+        # JSONPath for complex extraction (filter by field value)
+        # See: https://kubernetes.io/docs/reference/kubectl/jsonpath/
+        # - name: "lzNamespaceStatus"
+        #   field: "{.items[?(@.adapter=='landing-zone-adapter')].data.namespace.status}"
+        
+        # CEL expression for computed values
+        # - name: "activeItemCount"
+        #   expression: "items.filter(i, i.status == 'active').size()"
+      
+      # Conditions to check. SCOPE: Full execution context
+      # You can access:
+      #   - Captured values: clusterPhase, clusterName, etc.
+      #   - Full API response: clusterStatus.status.phase, clusterStatus.spec.nodeCount
+      #   - Params: clusterId, hyperfleetApiBaseUrl, etc.
       conditions:
+        # Using captured value
         - field: "clusterPhase"
           operator: "equals"
           value: "NotReady"
+        
+        # Or dig directly into API response using precondition name
+        # - field: "clusterStatus.status.nodeCount"
+        #   operator: "greaterThan"
+        #   value: 0
+      
+      # Alternative: CEL expression with full access
+      # expression: |
+      #   clusterStatus.status.phase == "Ready" && 
+      #   clusterStatus.spec.nodeCount > 0
   
   # ============================================================================
   # Resources (Create/Update Resources)
@@ -217,8 +262,7 @@ spec:
             expression: "generationId"
             
           # Use Go template with now and date functions for timestamps
-          observed_time:
-            value: "{{ now | date \"2006-01-02T15:04:05Z07:00\" }}"
+          observed_time: "{{ now | date \"2006-01-02T15:04:05Z07:00\" }}"
 
           # Optional data field for adapter-specific metrics extracted from resources
           data:

--- a/internal/criteria/cel_evaluator_test.go
+++ b/internal/criteria/cel_evaluator_test.go
@@ -3,7 +3,6 @@ package criteria
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/logger"
 	"github.com/stretchr/testify/assert"
@@ -15,7 +14,7 @@ func TestNewCELEvaluator(t *testing.T) {
 	ctx.Set("status", "Ready")
 	ctx.Set("replicas", 3)
 
-	evaluator, err := newCELEvaluator(context.Background(), ctx, logger.NewTestLogger())
+	evaluator, err := newCELEvaluator(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, evaluator)
 }
@@ -27,7 +26,7 @@ func TestCELEvaluatorEvaluate(t *testing.T) {
 	ctx.Set("provider", "aws")
 	ctx.Set("enabled", true)
 
-	evaluator, err := newCELEvaluator(context.Background(), ctx, logger.NewTestLogger())
+	evaluator, err := newCELEvaluator(ctx)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -131,7 +130,7 @@ func TestCELEvaluatorWithNestedData(t *testing.T) {
 		},
 	})
 
-	evaluator, err := newCELEvaluator(context.Background(), ctx, logger.NewTestLogger())
+	evaluator, err := newCELEvaluator(ctx)
 	require.NoError(t, err)
 
 	// Test nested field access
@@ -156,17 +155,15 @@ func TestCELEvaluatorEvaluateSafe(t *testing.T) {
 	})
 	ctx.Set("nullValue", nil)
 
-	evaluator, err := newCELEvaluator(context.Background(), ctx, logger.NewTestLogger())
+	evaluator, err := newCELEvaluator(ctx)
 	require.NoError(t, err)
 
 	t.Run("successful evaluation", func(t *testing.T) {
 		result, err := evaluator.EvaluateSafe(`cluster.status.phase == "Ready"`)
 		require.NoError(t, err, "EvaluateSafe should not return error for valid expression")
-		assert.True(t, result.IsSuccess())
 		assert.False(t, result.HasError())
 		assert.True(t, result.Matched)
 		assert.Nil(t, result.Error)
-		assert.Empty(t, result.ErrorReason)
 	})
 
 	t.Run("missing field returns error in result (safe)", func(t *testing.T) {
@@ -174,10 +171,9 @@ func TestCELEvaluatorEvaluateSafe(t *testing.T) {
 		result, err := evaluator.EvaluateSafe(`cluster.nonexistent.field == "test"`)
 		require.NoError(t, err, "EvaluateSafe should not return error for evaluation errors")
 		assert.True(t, result.HasError())
-		assert.False(t, result.IsSuccess())
 		assert.False(t, result.Matched)
 		assert.NotNil(t, result.Error)
-		assert.Contains(t, result.ErrorReason, "no such key")
+		assert.Contains(t, result.Error.Error(), "no such key")
 	})
 
 	t.Run("access field on null returns error in result (safe)", func(t *testing.T) {
@@ -195,14 +191,14 @@ func TestCELEvaluatorEvaluateSafe(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, result.HasError())
 		assert.False(t, result.Matched)
-		assert.Contains(t, result.ErrorReason, "no such key")
+		assert.Contains(t, result.Error.Error(), "no such key")
 	})
 
 	t.Run("has() on existing intermediate key returns false for missing leaf", func(t *testing.T) {
 		// has(cluster.status.missing) - cluster.status exists, but missing doesn't
 		result, err := evaluator.EvaluateSafe(`has(cluster.status.missing)`)
 		require.NoError(t, err)
-		assert.True(t, result.IsSuccess())
+		assert.True(t, !result.HasError())
 		assert.False(t, result.Matched) // false because field doesn't exist
 		assert.Nil(t, result.Error)
 	})
@@ -210,7 +206,7 @@ func TestCELEvaluatorEvaluateSafe(t *testing.T) {
 	t.Run("empty expression returns true", func(t *testing.T) {
 		result, err := evaluator.EvaluateSafe("")
 		require.NoError(t, err)
-		assert.True(t, result.IsSuccess())
+		assert.True(t, !result.HasError())
 		assert.True(t, result.Matched)
 	})
 
@@ -224,7 +220,7 @@ func TestCELEvaluatorEvaluateSafe(t *testing.T) {
 
 		if result.HasError() {
 			finalValue = nil
-			reason = result.ErrorReason
+			reason = result.Error.Error()
 		} else {
 			finalValue = result.Value
 			reason = ""
@@ -247,7 +243,7 @@ func TestCELEvaluatorEvaluateBool(t *testing.T) {
 	ctx := NewEvaluationContext()
 	ctx.Set("status", "Ready")
 
-	evaluator, err := newCELEvaluator(context.Background(), ctx, logger.NewTestLogger())
+	evaluator, err := newCELEvaluator(ctx)
 	require.NoError(t, err)
 
 	// True result
@@ -266,7 +262,7 @@ func TestCELEvaluatorEvaluateString(t *testing.T) {
 	ctx.Set("status", "Ready")
 	ctx.Set("name", "test-cluster")
 
-	evaluator, err := newCELEvaluator(context.Background(), ctx, logger.NewTestLogger())
+	evaluator, err := newCELEvaluator(ctx)
 	require.NoError(t, err)
 
 	// String result
@@ -278,162 +274,6 @@ func TestCELEvaluatorEvaluateString(t *testing.T) {
 	result, err = evaluator.EvaluateString(`name + "-suffix"`)
 	require.NoError(t, err)
 	assert.Equal(t, "test-cluster-suffix", result)
-}
-
-func TestConditionToCEL(t *testing.T) {
-	tests := []struct {
-		name     string
-		field    string
-		operator string
-		value    interface{}
-		want     string
-		wantErr  bool
-	}{
-		{
-			name:     "equals string",
-			field:    "status",
-			operator: "equals",
-			value:    "Ready",
-			want:     `status == "Ready"`,
-		},
-		{
-			name:     "notEquals string",
-			field:    "status",
-			operator: "notEquals",
-			value:    "Failed",
-			want:     `status != "Failed"`,
-		},
-		{
-			name:     "greaterThan number",
-			field:    "replicas",
-			operator: "greaterThan",
-			value:    2,
-			want:     `replicas > 2`,
-		},
-		{
-			name:     "lessThan number",
-			field:    "count",
-			operator: "lessThan",
-			value:    10,
-			want:     `count < 10`,
-		},
-		{
-			name:     "in list",
-			field:    "provider",
-			operator: "in",
-			value:    []string{"aws", "gcp"},
-			want:     `provider in ["aws", "gcp"]`,
-		},
-		{
-			name:     "notIn list",
-			field:    "provider",
-			operator: "notIn",
-			value:    []string{"azure"},
-			want:     `!(provider in ["azure"])`,
-		},
-		{
-			name:     "contains",
-			field:    "name",
-			operator: "contains",
-			value:    "test",
-			want:     `name.contains("test")`,
-		},
-		{
-			name:     "exists simple nested",
-			field:    "metadata.name",
-			operator: "exists",
-			value:    nil,
-			want:     `has(metadata.name)`,
-		},
-		{
-			name:     "exists deeply nested",
-			field:    "cluster.status.phase",
-			operator: "exists",
-			value:    nil,
-			want:     `has(cluster.status.phase)`,
-		},
-		{
-			name:     "exists very deeply nested",
-			field:    "a.b.c.d",
-			operator: "exists",
-			value:    nil,
-			want:     `has(a.b.c.d)`,
-		},
-		{
-			name:     "exists top level",
-			field:    "name",
-			operator: "exists",
-			value:    nil,
-			want:     `(name != null && name != "")`,
-		},
-		{
-			name:     "invalid operator",
-			field:    "status",
-			operator: "invalid",
-			value:    "Ready",
-			wantErr:  true,
-		},
-		// Nested field tests - direct expressions without null-safe wrapping
-		// (errors are handled by EvaluateSafe at a higher level)
-		{
-			name:     "equals nested field",
-			field:    "cluster.status.phase",
-			operator: "equals",
-			value:    "Ready",
-			want:     `cluster.status.phase == "Ready"`,
-		},
-		{
-			name:     "in nested field",
-			field:    "metadata.labels.env",
-			operator: "in",
-			value:    []string{"prod", "staging"},
-			want:     `metadata.labels.env in ["prod", "staging"]`,
-		},
-		{
-			name:     "greaterThan nested field",
-			field:    "status.replicas",
-			operator: "greaterThan",
-			value:    0,
-			want:     `status.replicas > 0`,
-		},
-		{
-			name:     "contains nested field",
-			field:    "spec.containers.name",
-			operator: "contains",
-			value:    "app",
-			want:     `spec.containers.name.contains("app")`,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := ConditionToCEL(tt.field, tt.operator, tt.value)
-			if tt.wantErr {
-				assert.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-			assert.Equal(t, tt.want, result)
-		})
-	}
-}
-
-func TestConditionsToCEL(t *testing.T) {
-	conditions := []ConditionDef{
-		{Field: "status", Operator: "equals", Value: "Ready"},
-		{Field: "replicas", Operator: "greaterThan", Value: 0},
-		{Field: "provider", Operator: "in", Value: []string{"aws", "gcp"}},
-	}
-
-	result, err := ConditionsToCEL(conditions)
-	require.NoError(t, err)
-	expected := `(status == "Ready") && (replicas > 0) && (provider in ["aws", "gcp"])`
-	assert.Equal(t, expected, result)
-
-	// Empty conditions
-	result, err = ConditionsToCEL([]ConditionDef{})
-	require.NoError(t, err)
-	assert.Equal(t, "true", result)
 }
 
 func TestEvaluatorCELIntegration(t *testing.T) {
@@ -448,78 +288,6 @@ func TestEvaluatorCELIntegration(t *testing.T) {
 	result, err := evaluator.EvaluateCEL(`status == "Ready" && replicas > 1`)
 	require.NoError(t, err)
 	assert.True(t, result.Matched)
-
-	// Test EvaluateCELBool
-	matched, err := evaluator.EvaluateCELBool(`provider == "aws"`)
-	require.NoError(t, err)
-	assert.True(t, matched)
-
-	// Test EvaluateConditionAsCEL
-	result, err = evaluator.EvaluateConditionAsCEL("status", OperatorEquals, "Ready")
-	require.NoError(t, err)
-	assert.True(t, result.Matched)
-
-	// Test EvaluateConditionsAsCEL
-	conditions := []ConditionDef{
-		{Field: "status", Operator: "equals", Value: "Ready"},
-		{Field: "replicas", Operator: "greaterThan", Value: 1},
-	}
-	result, err = evaluator.EvaluateConditionsAsCEL(conditions)
-	require.NoError(t, err)
-	assert.True(t, result.Matched)
-}
-
-func TestGetCELExpression(t *testing.T) {
-	ctx := NewEvaluationContext()
-	evaluator, err := NewEvaluator(context.Background(), ctx, logger.NewTestLogger())
-	require.NoError(t, err)
-	// Single condition
-	expr, err := evaluator.GetCELExpression("status", OperatorEquals, "Ready")
-	require.NoError(t, err)
-	assert.Equal(t, `status == "Ready"`, expr)
-
-	// Multiple conditions
-	conditions := []ConditionDef{
-		{Field: "status", Operator: "equals", Value: "Ready"},
-		{Field: "replicas", Operator: "greaterThan", Value: 0},
-	}
-	expr, err = evaluator.GetCELExpressionForConditions(conditions)
-	require.NoError(t, err)
-	assert.Equal(t, `(status == "Ready") && (replicas > 0)`, expr)
-}
-
-func TestFormatCELValue(t *testing.T) {
-	tests := []struct {
-		name    string
-		value   interface{}
-		want    string
-		wantErr bool
-	}{
-		{"nil", nil, "null", false},
-		{"string", "hello", `"hello"`, false},
-		{"string with quotes", `say "hi"`, `"say \"hi\""`, false},
-		{"bool true", true, "true", false},
-		{"bool false", false, "false", false},
-		{"int", 42, "42", false},
-		{"float", 3.14, "3.14", false},
-		{"string slice", []string{"a", "b"}, `["a", "b"]`, false},
-		{"custom int type", time.Second, "", true}, // time.Duration is now unsupported (type alias not handled)
-		{"unsupported channel", make(chan int), "", true},
-		{"unsupported map", map[string]string{"a": "b"}, "", true},
-		{"unsupported func", func() {}, "", true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := formatCELValue(tt.value)
-			if tt.wantErr {
-				assert.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-			assert.Equal(t, tt.want, result)
-		})
-	}
 }
 
 // TestEvaluateSafeErrorHandling tests how EvaluateSafe handles various error scenarios
@@ -534,7 +302,7 @@ func TestEvaluateSafeErrorHandling(t *testing.T) {
 		},
 	})
 
-	evaluator, err := newCELEvaluator(context.Background(), ctx, logger.NewTestLogger())
+	evaluator, err := newCELEvaluator(ctx)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -542,7 +310,7 @@ func TestEvaluateSafeErrorHandling(t *testing.T) {
 		expression  string
 		wantSuccess bool
 		wantMatched bool
-		wantReason  string // substring to match in ErrorReason
+		wantReason  string // substring to match in Error
 	}{
 		{
 			name:        "existing nested field",
@@ -588,11 +356,11 @@ func TestEvaluateSafeErrorHandling(t *testing.T) {
 			require.NoError(t, err, "EvaluateSafe should not return parse/program errors for valid expressions")
 
 			if tt.wantSuccess {
-				assert.True(t, result.IsSuccess(), "expected success but got error: %v", result.Error)
+				assert.True(t, !result.HasError(), "expected success but got error: %v", result.Error)
 				assert.Equal(t, tt.wantMatched, result.Matched)
 			} else {
 				assert.True(t, result.HasError(), "expected error but got success")
-				assert.Contains(t, result.ErrorReason, tt.wantReason)
+				assert.Contains(t, result.Error.Error(), tt.wantReason)
 			}
 		})
 	}

--- a/internal/criteria/evaluator.go
+++ b/internal/criteria/evaluator.go
@@ -2,7 +2,6 @@ package criteria
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -82,7 +81,7 @@ func (e *Evaluator) getCELEvaluator() (*CELEvaluator, error) {
 
 	// Recreate CEL evaluator if context changed or not yet created
 	if e.celEval == nil || e.celEvalVersion != currentVersion {
-		celEval, err := newCELEvaluator(e.ctx, e.evalCtx, e.log)
+		celEval, err := newCELEvaluator(e.evalCtx)
 		if err != nil {
 			return nil, err
 		}
@@ -93,65 +92,30 @@ func (e *Evaluator) getCELEvaluator() (*CELEvaluator, error) {
 	return e.celEval, nil
 }
 
-// GetField extracts a field value from the context using dot notation
-func (e *Evaluator) GetField(field string) (interface{}, error) {
-	return e.evalCtx.GetNestedField(field)
+// EvaluateField extracts a field from the evaluation context using JSONPath.
+//
+// Supports both simple dot notation and full JSONPath syntax:
+//   - Simple: "metadata.name", "status.phase"
+//   - JSONPath: "{.items[*].metadata.name}"
+//   - JSONPath with filter: "{.items[?(@.adapter=='landing-zone-adapter')].data.namespace.status}"
+//
+// Returns *FieldResult containing the extracted value or error.
+// This is the field extraction counterpart to EvaluateCEL.
+func (e *Evaluator) EvaluateField(field string) (*FieldResult, error) {
+	return ExtractField(e.evalCtx.Data(), field)
 }
 
-// GetFieldOrDefault extracts a field value or returns a default if not found or null
-func (e *Evaluator) GetFieldOrDefault(field string, defaultValue interface{}) interface{} {
-	value, err := e.evalCtx.GetNestedField(field)
-	if err != nil || value == nil {
-		return defaultValue
-	}
-	return value
-}
-
-// GetFieldSafe extracts a field value, returning nil for any error (null-safe)
-func (e *Evaluator) GetFieldSafe(field string) interface{} {
-	value, _ := e.evalCtx.GetNestedField(field)
-	return value
-}
-
-// HasField checks if a field exists and is not null
-func (e *Evaluator) HasField(field string) bool {
-	value, err := e.evalCtx.GetNestedField(field)
-	return err == nil && value != nil
-}
-
-// EvaluateCondition evaluates a single condition (backward compatible)
-func (e *Evaluator) EvaluateCondition(field string, operator Operator, value interface{}) (bool, error) {
-	result, err := e.EvaluateConditionWithResult(field, operator, value)
-	if err != nil {
-		return false, err
-	}
-	return result.Matched, nil
-}
-
-// EvaluateConditionSafe evaluates a condition, returning false for null/missing fields (no error)
-func (e *Evaluator) EvaluateConditionSafe(field string, operator Operator, value interface{}) bool {
-	result, err := e.EvaluateConditionWithResult(field, operator, value)
-	if err != nil || result == nil {
-		return false
-	}
-	return result.Matched
-}
-
-// EvaluateConditionWithResult evaluates a single condition and returns detailed result
-func (e *Evaluator) EvaluateConditionWithResult(field string, operator Operator, value interface{}) (*EvaluationResult, error) {
+// EvaluateCondition evaluates a single condition and returns detailed result
+func (e *Evaluator) EvaluateCondition(field string, operator Operator, value interface{}) (*EvaluationResult, error) {
 	// Get the field value from context
-	fieldValue, err := e.evalCtx.GetNestedField(field)
+	fieldResult, err := e.evalCtx.GetField(field)
 	if err != nil {
-		return nil, &EvaluationError{
-			Field:   field,
-			Message: "failed to retrieve field",
-			Err:     err,
-		}
+		return nil, err
 	}
 
 	result := &EvaluationResult{
 		Field:         field,
-		FieldValue:    fieldValue,
+		FieldValue:    fieldResult.Value,
 		Operator:      operator,
 		ExpectedValue: value,
 	}
@@ -160,9 +124,9 @@ func (e *Evaluator) EvaluateConditionWithResult(field string, operator Operator,
 	var matched bool
 	if operator == OperatorExists {
 		// Exists is special - only checks fieldValue, no expected value
-		matched = evaluateExists(fieldValue)
+		matched = evaluateExists(fieldResult.Value)
 	} else if evalFn, ok := operatorFuncs[operator]; ok {
-		matched, err = evalFn(fieldValue, value)
+		matched, err = evalFn(fieldResult.Value, value)
 		if err != nil {
 			return nil, err
 		}
@@ -177,17 +141,8 @@ func (e *Evaluator) EvaluateConditionWithResult(field string, operator Operator,
 	return result, nil
 }
 
-// EvaluateConditions evaluates multiple conditions (AND logic) - backward compatible
-func (e *Evaluator) EvaluateConditions(conditions []ConditionDef) (bool, error) {
-	result, err := e.EvaluateConditionsWithResult(conditions)
-	if err != nil {
-		return false, err
-	}
-	return result.Matched, nil
-}
-
-// EvaluateConditionsWithResult evaluates multiple conditions and returns detailed results
-func (e *Evaluator) EvaluateConditionsWithResult(conditions []ConditionDef) (*ConditionsResult, error) {
+// EvaluateConditions evaluates multiple conditions and returns detailed results
+func (e *Evaluator) EvaluateConditions(conditions []ConditionDef) (*ConditionsResult, error) {
 	result := &ConditionsResult{
 		Matched:         true,
 		Results:         make([]EvaluationResult, 0, len(conditions)),
@@ -196,7 +151,7 @@ func (e *Evaluator) EvaluateConditionsWithResult(conditions []ConditionDef) (*Co
 	}
 
 	for i, cond := range conditions {
-		evalResult, err := e.EvaluateConditionWithResult(cond.Field, cond.Operator, cond.Value)
+		evalResult, err := e.EvaluateCondition(cond.Field, cond.Operator, cond.Value)
 		if err != nil {
 			return nil, err
 		}
@@ -213,37 +168,68 @@ func (e *Evaluator) EvaluateConditionsWithResult(conditions []ConditionDef) (*Co
 	return result, nil
 }
 
-// ExtractFields extracts multiple field values from the context.
-// Returns an error if any field is not found. Use ExtractFieldsSafe for null-safe extraction.
-func (e *Evaluator) ExtractFields(fields []string) (map[string]interface{}, error) {
-	extracted := make(map[string]interface{})
-	for _, field := range fields {
-		value, err := e.GetField(field)
+// ExtractValueResult contains the result of value extraction
+type ExtractValueResult struct {
+	Value  interface{} // Extracted value
+	Source string      // The field path or expression used
+	Error  error       // Error if extraction failed
+}
+
+// ExtractValue extracts a value from the context using either field (JSONPath) or expression (CEL).
+// Only one of field or expression should be non-empty.
+//
+// This provides a unified extraction interface for captures, conditions, and payload building.
+//
+//   - field: Uses JSONPath/dot notation to extract from context data
+//   - expression: Uses CEL expression to compute/extract value
+//
+// Example:
+//
+//	result := evaluator.ExtractValue("status.phase", "")           // JSONPath
+//	result := evaluator.ExtractValue("", "items.size() > 0")       // CEL
+//	result := evaluator.ExtractValue("{.items[0].name}", "")       // Full JSONPath
+func (e *Evaluator) ExtractValue(field, expression string) (*ExtractValueResult, error) {
+	result := &ExtractValueResult{}
+	field = strings.TrimSpace(field)
+	expression = strings.TrimSpace(expression)
+	// Enforce mutual exclusivity
+	if field != "" && expression != "" {
+		return result, fmt.Errorf("field and expression are mutually exclusive; only one should be specified")
+	}
+	if expression != "" {
+		// CEL expression mode
+		celResult, err := e.EvaluateCEL(expression)
 		if err != nil {
-			return nil, err
+			return result, fmt.Errorf("CEL evaluation failed: %w", err)
 		}
-		extracted[field] = value
+		if celResult.Error != nil {
+			// Caller should handle logging based on CELResult.Error
+			// This is NOT a parse error, so we don't return error - caller can use default
+			// Only caught field missing or empty value as warn log
+			e.log.Warnf(e.ctx, "CEL evaluation failed for %q: %v", expression, celResult.Error)
+		}
+		result.Value = celResult.Value
+		result.Source = expression
+		return result, nil
+	} else if field != "" {
+		// Field extraction mode (JSONPath)
+		fieldResult, err := e.EvaluateField(field)
+		if err != nil {
+			// Parse error - fail fast (indicates bug in config)
+			return result, fmt.Errorf("field extraction failed: %w", err)
+		}
+		// Field not found or empty result - return nil value (allows default to be used)
+		// fieldResult.Error indicates runtime extraction error (e.g., field not found)
+		// This is NOT a parse error, so we don't return error - caller can use default
+		if fieldResult.Error != nil {
+			e.log.Warnf(e.ctx, "failed to extract field %s: %v", field, fieldResult.Error)
+		}
+		result.Value = fieldResult.Value
+		result.Source = field
+		return result, nil
 	}
-	return extracted, nil
-}
 
-// ExtractFieldsSafe extracts multiple field values, returning nil for missing fields (null-safe).
-// This never returns an error - missing or inaccessible fields are set to nil.
-func (e *Evaluator) ExtractFieldsSafe(fields []string) map[string]interface{} {
-	extracted := make(map[string]interface{})
-	for _, field := range fields {
-		extracted[field] = e.GetFieldSafe(field)
-	}
-	return extracted
-}
-
-// ExtractFieldsOrDefault extracts multiple fields, using default for missing ones
-func (e *Evaluator) ExtractFieldsOrDefault(fields map[string]interface{}) map[string]interface{} {
-	extracted := make(map[string]interface{})
-	for field, defaultValue := range fields {
-		extracted[field] = e.GetFieldOrDefault(field, defaultValue)
-	}
-	return extracted
+	return result, fmt.Errorf("neither field nor expression defined")
 }
 
 // withCELEvaluator gets the CEL evaluator and applies a function to it
@@ -261,97 +247,6 @@ func (e *Evaluator) EvaluateCEL(expression string) (*CELResult, error) {
 	return withCELEvaluator(e, func(c *CELEvaluator) (*CELResult, error) {
 		return c.EvaluateSafe(expression)
 	})
-}
-
-// EvaluateCELBool evaluates a CEL expression that returns a boolean.
-// Returns (false, error) on failure - ignore the error for safe default.
-func (e *Evaluator) EvaluateCELBool(expression string) (bool, error) {
-	return withCELEvaluator(e, func(c *CELEvaluator) (bool, error) {
-		return c.EvaluateBool(expression)
-	})
-}
-
-// EvaluateCELString evaluates a CEL expression that returns a string.
-// Returns ("", error) on failure - ignore the error for safe default.
-func (e *Evaluator) EvaluateCELString(expression string) (string, error) {
-	return withCELEvaluator(e, func(c *CELEvaluator) (string, error) {
-		return c.EvaluateString(expression)
-	})
-}
-
-// Expression/Value definition keys
-const (
-	ExpressionKey = "expression"
-	DefaultKey    = "default"
-	ValueKey      = "value"
-)
-
-// EvaluateExpressionDef evaluates an expression definition map.
-// The map should contain:
-//   - "expression": CEL expression string (required)
-//   - "default": default value on failure (optional)
-//
-// Behavior:
-//   - No default → returns whatever type CEL expression returns (nil on failure)
-//   - With default → returns default value on evaluation failure
-func (e *Evaluator) EvaluateExpressionDef(def map[string]any) (any, bool) {
-	expr, ok := def[ExpressionKey].(string)
-	if !ok || expr == "" {
-		return nil, false
-	}
-
-	exprStr := strings.TrimSpace(expr)
-	defaultVal, hasDefault := def[DefaultKey]
-
-	// Evaluate CEL expression
-	result, err := e.EvaluateCEL(exprStr)
-	if err != nil || result.HasError() || result.Value == nil {
-		// On failure, return default if specified
-		if hasDefault {
-			return defaultVal, true
-		}
-		return nil, true
-	}
-
-	return result.Value, true
-}
-
-// GetValueDef extracts a value from a value definition map.
-// The map should contain:
-//   - "value": the value to return (required)
-//
-// Returns the value and true if found, nil and false otherwise.
-func GetValueDef(def map[string]any) (any, bool) {
-	value, ok := def[ValueKey]
-	return value, ok
-}
-
-// EvaluateConditionAsCEL converts a condition to CEL and evaluates it
-func (e *Evaluator) EvaluateConditionAsCEL(field string, operator Operator, value interface{}) (*CELResult, error) {
-	celExpr, err := ConditionToCEL(field, string(operator), value)
-	if err != nil {
-		return nil, err
-	}
-	return e.EvaluateCEL(celExpr)
-}
-
-// EvaluateConditionsAsCEL converts conditions to CEL and evaluates them
-func (e *Evaluator) EvaluateConditionsAsCEL(conditions []ConditionDef) (*CELResult, error) {
-	celExpr, err := ConditionsToCEL(conditions)
-	if err != nil {
-		return nil, err
-	}
-	return e.EvaluateCEL(celExpr)
-}
-
-// GetCELExpression returns the CEL expression equivalent for a condition
-func (e *Evaluator) GetCELExpression(field string, operator Operator, value interface{}) (string, error) {
-	return ConditionToCEL(field, string(operator), value)
-}
-
-// GetCELExpressionForConditions returns the CEL expression for multiple conditions
-func (e *Evaluator) GetCELExpressionForConditions(conditions []ConditionDef) (string, error) {
-	return ConditionsToCEL(conditions)
 }
 
 // ConditionDef defines a condition to evaluate
@@ -580,122 +475,4 @@ func toFloat64(value interface{}) (float64, error) {
 	default:
 		return 0, fmt.Errorf("cannot convert %T to float64", value)
 	}
-}
-
-// getNestedField retrieves a nested field from a map using dot notation
-func getNestedField(data map[string]interface{}, path string) (interface{}, error) {
-	return getFieldRecursive(data, path, strings.Split(path, "."), 0)
-}
-
-// getFieldRecursive recursively traverses the data structure to find a field
-func getFieldRecursive(current interface{}, fullPath string, parts []string, depth int) (interface{}, error) {
-	// Base case: no more parts to traverse
-	if depth >= len(parts) {
-		return current, nil
-	}
-
-	field := parts[depth]
-	currentPath := strings.Join(parts[:depth+1], ".")
-
-	// Handle nil/null
-	if current == nil {
-		return nil, &FieldNotFoundError{
-			Path:    currentPath,
-			Field:   field,
-			Message: fmt.Sprintf("cannot access '%s': parent is null", currentPath),
-		}
-	}
-
-	// Get the next value based on current type
-	next, err := getFieldValue(current, field, currentPath)
-	if err != nil {
-		return nil, err
-	}
-
-	// Recurse to next level
-	return getFieldRecursive(next, fullPath, parts, depth+1)
-}
-
-// getFieldValue extracts a single field from a value (map or struct)
-func getFieldValue(current interface{}, field, path string) (interface{}, error) {
-	switch v := current.(type) {
-	case map[string]interface{}:
-		val, ok := v[field]
-		if !ok {
-			return nil, &FieldNotFoundError{Path: path, Field: field,
-				Message: fmt.Sprintf("field '%s' not found", path)}
-		}
-		return val, nil
-
-	case map[interface{}]interface{}:
-		val, ok := v[field]
-		if !ok {
-			return nil, &FieldNotFoundError{Path: path, Field: field,
-				Message: fmt.Sprintf("field '%s' not found", path)}
-		}
-		return val, nil
-
-	default:
-		return getStructField(current, field, path)
-	}
-}
-
-// getStructField extracts a field from a struct using reflection
-func getStructField(current interface{}, field, path string) (interface{}, error) {
-	rv := reflect.ValueOf(current)
-
-	// Handle invalid or nil pointer
-	if !rv.IsValid() || (rv.Kind() == reflect.Ptr && rv.IsNil()) {
-		return nil, &FieldNotFoundError{Path: path, Field: field,
-			Message: fmt.Sprintf("cannot access '%s': value is null", path)}
-	}
-
-	// Dereference pointer
-	if rv.Kind() == reflect.Ptr {
-		rv = rv.Elem()
-	}
-
-	// Must be a struct
-	if rv.Kind() != reflect.Struct {
-		return nil, &FieldNotFoundError{Path: path, Field: field,
-			Message: fmt.Sprintf("cannot access '%s': not a map or struct (got %T)", path, current)}
-	}
-
-	// Try exact match first, then case-insensitive
-	f := rv.FieldByName(field)
-	if !f.IsValid() {
-		f = rv.FieldByNameFunc(func(n string) bool {
-			return strings.EqualFold(n, field)
-		})
-	}
-
-	if !f.IsValid() {
-		return nil, &FieldNotFoundError{Path: path, Field: field,
-			Message: fmt.Sprintf("field '%s' not found in struct", path)}
-	}
-
-	if !f.CanInterface() {
-		return nil, &FieldNotFoundError{Path: path, Field: field,
-			Message: fmt.Sprintf("field '%s' is not accessible (unexported)", path)}
-	}
-
-	return f.Interface(), nil
-}
-
-// FieldNotFoundError represents a field not found during path traversal
-type FieldNotFoundError struct {
-	Path    string
-	Field   string
-	Message string
-}
-
-func (e *FieldNotFoundError) Error() string {
-	return e.Message
-}
-
-// IsFieldNotFound checks if an error is or wraps a FieldNotFoundError.
-// It uses errors.As to unwrap nested errors (e.g., FieldNotFoundError wrapped in EvaluationError).
-func IsFieldNotFound(err error) bool {
-	var target *FieldNotFoundError
-	return errors.As(err, &target)
 }

--- a/internal/criteria/evaluator_version_test.go
+++ b/internal/criteria/evaluator_version_test.go
@@ -23,7 +23,7 @@ func TestContextVersionTracking(t *testing.T) {
 	require.NoError(t, err1)
 	require.NotNil(t, result1)
 	assert.True(t, result1.Matched)
-	assert.True(t, result1.IsSuccess())
+	assert.False(t, result1.HasError())
 
 	// Add new variable AFTER first evaluation
 	ctx.Set("replicas", 3)
@@ -34,14 +34,14 @@ func TestContextVersionTracking(t *testing.T) {
 	require.NoError(t, err2)
 	require.NotNil(t, result2)
 	assert.True(t, result2.Matched)
-	assert.True(t, result2.IsSuccess(), "Should recreate CEL env and recognize new variable")
+	assert.False(t, result2.HasError(), "Should recreate CEL env and recognize new variable")
 
 	// Verify both old and new variables work
 	result3, err3 := evaluator.EvaluateCEL("status == 'Ready' && replicas == 3")
 	require.NoError(t, err3)
 	require.NotNil(t, result3)
 	assert.True(t, result3.Matched)
-	assert.True(t, result3.IsSuccess())
+	assert.False(t, result3.HasError())
 }
 
 // TestSetVariablesFromMapVersionTracking verifies version tracking with SetVariablesFromMap
@@ -71,7 +71,7 @@ func TestSetVariablesFromMapVersionTracking(t *testing.T) {
 	require.NoError(t, err2)
 	require.NotNil(t, result2)
 	assert.True(t, result2.Matched)
-	assert.True(t, result2.IsSuccess(), "Should recognize variables added via SetVariablesFromMap")
+	assert.False(t, result2.HasError(), "Should recognize variables added via SetVariablesFromMap")
 }
 
 // TestMergeVersionTracking verifies version tracking with Merge
@@ -99,7 +99,7 @@ func TestMergeVersionTracking(t *testing.T) {
 	require.NoError(t, err2)
 	require.NotNil(t, result2)
 	assert.True(t, result2.Matched)
-	assert.True(t, result2.IsSuccess(), "Should recognize variables from merged context")
+	assert.False(t, result2.HasError(), "Should recognize variables from merged context")
 }
 
 // TestVersionIncrements verifies that version increments correctly

--- a/internal/criteria/field_evaluator.go
+++ b/internal/criteria/field_evaluator.go
@@ -1,0 +1,93 @@
+package criteria
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"k8s.io/client-go/util/jsonpath"
+)
+
+type FieldResult struct {
+	Value interface{}
+	Error error
+}
+
+// ExtractField extracts a field from any data structure using JSONPath.
+//
+// Supports both simple dot notation and full JSONPath syntax:
+//   - Simple: "metadata.name", "status.phase"
+//   - JSONPath: "{.items[*].metadata.name}"
+//   - JSONPath with filter: "{.items[?(@.adapter=='landing-zone-adapter')].data.namespace.status}"
+//
+// Simple paths are auto-converted to JSONPath (e.g., "metadata.name" → "{.metadata.name}")
+func ExtractField(data interface{}, field string) (*FieldResult, error) {
+	result := &FieldResult{}
+	originalField := field
+	field = strings.TrimSpace(field)
+	if field == "" {
+		return result, fmt.Errorf("empty field path")
+	}
+
+	// Convert simple dot notation to JSONPath format
+	// e.g., "metadata.name" → "{.metadata.name}"
+	jsonPath := field
+	if !strings.HasPrefix(jsonPath, "{") {
+		if !strings.HasPrefix(jsonPath, ".") {
+			jsonPath = "." + jsonPath
+		}
+		jsonPath = "{" + jsonPath + "}"
+	}
+
+	// Create JSONPath parser
+	// AllowMissingKeys(false) ensures we get errors for missing fields (backward compatible)
+	jp := jsonpath.New("field-extractor").AllowMissingKeys(false)
+
+	// Parse the JSONPath
+	if err := jp.Parse(jsonPath); err != nil {
+		return result, fmt.Errorf("invalid field path '%s': %w", originalField, err)
+	}
+
+	// Execute the query to check if the path is valid and exists
+	var buf bytes.Buffer
+	if err := jp.Execute(&buf, data); err != nil {
+		result.Error = fmt.Errorf("failed to execute JSONPath: %w", err)
+		return result, nil
+	}
+
+	// Check if the result is empty (field not found or empty value)
+	if strings.TrimSpace(buf.String()) == "" {
+		// result.Value remains nil
+		return result, nil
+	}
+
+	// Use FindResults to get typed values (not just string representation)
+	results, err := jp.FindResults(data)
+	if err != nil {
+		result.Error = fmt.Errorf("failed to find results for '%s': %w", originalField, err)
+		// result.Value remains nil - don't mix string from Execute with error
+		return result, nil
+	}
+
+	// Flatten results
+	var values []interface{}
+	for _, r := range results {
+		for _, v := range r {
+			if v.CanInterface() {
+				values = append(values, v.Interface())
+			}
+		}
+	}
+
+	// Set result value based on count
+	switch len(values) {
+	case 0:
+		// result.Value remains nil
+	case 1:
+		result.Value = values[0]
+	default:
+		result.Value = values
+	}
+
+	return result, nil
+}

--- a/internal/criteria/types.go
+++ b/internal/criteria/types.go
@@ -112,12 +112,12 @@ func (c *EvaluationContext) Get(key string) (interface{}, bool) {
 	return val, ok
 }
 
-// GetNestedField retrieves a nested field using dot notation (e.g., "status.phase").
+// GetField retrieves a field using dot notation or JSONPath (e.g., "status.phase").
 // This method is safe for concurrent use.
-func (c *EvaluationContext) GetNestedField(path string) (interface{}, error) {
+func (c *EvaluationContext) GetField(path string) (*FieldResult, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return getNestedField(c.data, path)
+	return ExtractField(c.data, path)
 }
 
 // Merge merges another context into this one.

--- a/internal/executor/post_action_executor_test.go
+++ b/internal/executor/post_action_executor_test.go
@@ -167,32 +167,6 @@ func TestBuildMapPayload(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "value definition",
-			input: map[string]interface{}{
-				"field": map[string]interface{}{
-					"value": "static value",
-				},
-			},
-			params: map[string]interface{}{},
-			expected: map[string]interface{}{
-				"field": "static value",
-			},
-		},
-		{
-			name: "value definition with template",
-			input: map[string]interface{}{
-				"field": map[string]interface{}{
-					"value": "cluster-{{ .id }}",
-				},
-			},
-			params: map[string]interface{}{
-				"id": "123",
-			},
-			expected: map[string]interface{}{
-				"field": "cluster-123",
-			},
-		},
 	}
 
 	for _, tt := range tests {
@@ -274,22 +248,6 @@ func TestProcessValue(t *testing.T) {
 			params:      map[string]interface{}{},
 			evalCtxData: map[string]interface{}{"count": 5},
 			expected:    int64(10),
-		},
-		{
-			name: "value definition",
-			value: map[string]interface{}{
-				"value": "static",
-			},
-			params:   map[string]interface{}{},
-			expected: "static",
-		},
-		{
-			name: "value definition with non-string",
-			value: map[string]interface{}{
-				"value": 123,
-			},
-			params:   map[string]interface{}{},
-			expected: 123,
 		},
 		{
 			name:     "slice processing",


### PR DESCRIPTION
In this commit I
- Removed useless code and the testing code
- Refactored evaluator to support cel expression and jsonPATH field
- Supported default value when field and cel expression match failure
- Supported expression and complex field in capture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Capture configs support two modes: JSONPath field extraction or CEL expressions (mutually exclusive).
  * Unified value extraction used across preconditions, evaluations, and post-action payloads.

* **Documentation**
  * Expanded guides with examples for Data Scopes, capture modes, JSONPath, CEL, and accessing captured/API values.
  * Updated post-action and payload examples to use direct string fields (including observed_time) and single-line expressions.

* **Configuration Changes**
  * observed_time is now a direct string field (not a nested value object).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->