### PR TITLE
HYPERFLEET-372 | fix: Adapter logging is reporting wrong error phase

### DIFF
--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -524,10 +524,8 @@ func TestSequentialExecution_Preconditions(t *testing.T) {
 			result := exec.Execute(ctx, map[string]interface{}{})
 
 			// Verify number of precondition results
-			if len(result.PreconditionResults) != tt.expectedResults {
-				t.Errorf("expected %d precondition results, got %d",
-					tt.expectedResults, len(result.PreconditionResults))
-			}
+			assert.Equal(t, tt.expectedResults, len(result.PreconditionResults),
+				"unexpected precondition result count")
 
 			// Verify last executed precondition name
 			if len(result.PreconditionResults) > 0 {
@@ -629,10 +627,8 @@ func TestSequentialExecution_Resources(t *testing.T) {
 			result := exec.Execute(ctx, map[string]interface{}{})
 
 			// Verify sequential stop-on-failure: number of results should match expected
-			if len(result.ResourceResults) != tt.expectedResults {
-				t.Errorf("expected %d resource results, got %d (sequential execution should stop at failure)",
-					tt.expectedResults, len(result.ResourceResults))
-			}
+			assert.Equal(t, tt.expectedResults, len(result.ResourceResults),
+				"sequential execution should stop at failure")
 
 			// Verify failure status
 			if tt.expectFailure {
@@ -703,14 +699,15 @@ func TestSequentialExecution_PostActions(t *testing.T) {
 			result := exec.Execute(ctx, map[string]interface{}{})
 
 			// Verify number of post action results
-			if len(result.PostActionResults) != tt.expectedResults {
-				t.Errorf("expected %d post action results, got %d",
-					tt.expectedResults, len(result.PostActionResults))
-			}
+			assert.Equal(t, tt.expectedResults, len(result.PostActionResults),
+				"unexpected post action result count")
 
 			// Verify error expectation
-			if tt.expectError && result.Error == nil {
-				t.Error("expected error but got nil")
+			if tt.expectError {
+				assert.NotEmpty(t, result.Errors, "expected errors, got none")
+				assert.NotNil(t, result.Errors[PhasePostActions], "expected post_actions error, got %#v", result.Errors)
+			} else {
+				assert.Empty(t, result.Errors, "expected no errors, got %#v", result.Errors)
 			}
 		})
 	}

--- a/internal/executor/types.go
+++ b/internal/executor/types.go
@@ -78,8 +78,8 @@ type Executor struct {
 type ExecutionResult struct {
 	// Status is the overall execution status (runtime perspective)
 	Status ExecutionStatus
-	// Phase is the phase where execution ended
-	Phase ExecutionPhase
+	// CurrentPhase is the phase where execution ended (or is currently)
+	CurrentPhase ExecutionPhase
 	// Params contains the extracted parameters
 	Params map[string]interface{}
 	// PreconditionResults contains results of precondition evaluations
@@ -88,10 +88,8 @@ type ExecutionResult struct {
 	ResourceResults []ResourceResult
 	// PostActionResults contains results of post-action executions
 	PostActionResults []PostActionResult
-	// Error is the error if Status is StatusFailed (process execution error only)
-	Error error
-	// ErrorReason is a human-readable error reason (process execution error only)
-	ErrorReason string
+	// Errors contains errors keyed by the phase where they occurred
+	Errors map[ExecutionPhase]error
 	// ResourcesSkipped indicates if resources were skipped (business outcome)
 	ResourcesSkipped bool
 	// SkipReason is why resources were skipped (e.g., "precondition not met")


### PR DESCRIPTION
- Moved Phase to CurrentPhase to make the variable clear usage
- Removed ErrorReason as no necessary to wrap the Error
- Changed Error to Errors as a map, each condition can have error happen. A map meet the usage better.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured error reporting to track and report errors per execution phase for improved diagnostics.
  * Enhanced execution phase tracking with clearer visibility into the current execution state and failure points.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->