### PR TITLE
HYPERFLEET-388 - feat: easier debug in containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+ARG BASE_IMAGE=gcr.io/distroless/static-debian12:nonroot
+
 # Build stage
 FROM golang:1.25-alpine AS builder
 
@@ -13,7 +15,7 @@ RUN go mod tidy && go mod verify
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o adapter ./cmd/adapter
 
 # Runtime stage
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM ${BASE_IMAGE}
 
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ ifeq ($(CONTAINER_RUNTIME),none)
 	@exit 1
 else
 	@echo "Building dev image quay.io/$(QUAY_USER)/$(PROJECT_NAME):$(DEV_TAG)..."
-	$(CONTAINER_CMD) build --platform linux/amd64 -t quay.io/$(QUAY_USER)/$(PROJECT_NAME):$(DEV_TAG) .
+	$(CONTAINER_CMD) build --platform linux/amd64 --build-arg BASE_IMAGE=alpine:3.21 -t quay.io/$(QUAY_USER)/$(PROJECT_NAME):$(DEV_TAG) .
 	@echo "Pushing dev image..."
 	$(CONTAINER_CMD) push quay.io/$(QUAY_USER)/$(PROJECT_NAME):$(DEV_TAG)
 	@echo ""


### PR DESCRIPTION
This can be linked to this issue

https://issues.redhat.com/browse/HYPERFLEET-388

For development it is convenient to have a shell available in containers, but our container images use the base image `gcr.io/distroless/static-debian12:nonroot` which doesn't contain any shell

This this PR we use a build variable when performing `QUAY_USER=xxx make image-dev` to select an alternate `alpine` based image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Runtime image base is now configurable at build time, enabling greater flexibility in deployment options.
  * Development build environment updated to Alpine 3.21.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->