### PR TITLE
HYPERFLEET-482 - fix: remove references to old WIF

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -53,6 +53,7 @@ helm delete hyperfleet-adapter
 | `config.adapterYaml` | Adapter YAML config content | `""` |
 
 When `config.adapterYaml` is set:
+
 - Creates `adapter.yaml` key in ConfigMap
 - Mounts at `/etc/adapter/adapter.yaml`
 - Sets `ADAPTER_CONFIG_PATH=/etc/adapter/adapter.yaml`
@@ -72,6 +73,7 @@ When `config.adapterYaml` is set:
 | `broker.envKeys` | Specific keys to mount (empty = all via envFrom) | `[]` |
 
 When `broker.yaml` is set:
+
 - Creates `broker.yaml` key in ConfigMap
 - Mounts at `/etc/broker/broker.yaml`
 - Sets `BROKER_CONFIG_FILE=/etc/broker/broker.yaml`
@@ -163,8 +165,7 @@ helm install hyperfleet-adapter ./charts/ \
   --set broker.create=true \
   --set broker.type=googlepubsub \
   --set broker.subscriptionId=my-subscription \
-  --set broker.topic=my-topic \
-  --set 'serviceAccount.annotations.iam\.gke\.io/gcp-service-account=adapter@PROJECT.iam.gserviceaccount.com'
+  --set broker.topic=my-topic
 ```
 
 ### Using Existing ServiceAccount
@@ -191,8 +192,7 @@ replicaCount: 2
 
 serviceAccount:
   create: true
-  annotations:
-    iam.gke.io/gcp-service-account: adapter@my-project.iam.gserviceaccount.com
+  name: my-adapter
 
 hyperfleetApi:
   baseUrl: https://api.hyperfleet.example.com

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -54,8 +54,6 @@ serviceAccount:
   # Specifies whether a service account should be created
   create: true
   # Annotations to add to the service account
-  # For GCP Workload Identity Federation (WIF), add:
-  #   iam.gke.io/gcp-service-account: GSA_NAME@PROJECT_ID.iam.gserviceaccount.com
   annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template


### PR DESCRIPTION
https://issues.redhat.com/browse/HYPERFLEET-482


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration documentation for adapter and broker YAML options in ConfigMap setup
  * Simplified serviceAccount configuration approach in Helm examples

* **Chores**
  * Removed outdated GCP Workload Identity Federation configuration reference

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->