### PR TITLE
HYPERFLEET-575 | test: Enable createTopicIfMissing and createSubscription

### DIFF
--- a/charts/templates/configmap-broker.yaml
+++ b/charts/templates/configmap-broker.yaml
@@ -34,6 +34,8 @@ data:
         project_id: {{ .Values.broker.googlepubsub.projectId | quote }}
         topic: {{ .Values.broker.googlepubsub.topic | quote }}
         deadLetterTopic: {{ .Values.broker.googlepubsub.deadLetterTopic | quote }}
+        create_topic_if_missing: {{ .Values.broker.googlepubsub.createTopicIfMissing }}
+        create_subscription_if_missing: {{ .Values.broker.googlepubsub.createSubscriptionIfMissing }}
       subscriber:
         parallelism: 1
   {{- else if eq $brokerType "rabbitmq" }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -52,6 +52,10 @@ broker:
     subscriptionId: ""
     topic: ""
     deadLetterTopic: ""
+    # Auto-creation flags (default: false - infrastructure must pre-exist)
+    # Set to true for development/testing; use false in production with pre-provisioned resources
+    createTopicIfMissing: false
+    createSubscriptionIfMissing: false
   # option3: for rabbitmq
   #rabbitmq:
   # url: ""


### PR DESCRIPTION
…tionIfMissing parameter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new configuration options for the Google Pub/Sub broker to control automatic resource creation behavior. Two new boolean settings have been introduced: `createTopicIfMissing` and `createSubscriptionIfMissing`, both defaulting to false. These options enable automatic provisioning of topics and subscriptions when they don't already exist. Use with careful consideration in production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->