### PR TITLE
HYPERFLEET-620 - doc: update the adapter examples

### DIFF
--- a/charts/examples/kubernetes/adapter-task-config.yaml
+++ b/charts/examples/kubernetes/adapter-task-config.yaml
@@ -119,7 +119,6 @@ spec:
         namespace: "*"
         bySelectors:
           labelSelector:
-            hyperfleet.io/generation: "{{ .generationSpec }}"
             hyperfleet.io/cluster-id: "{{ .clusterId }}"
             hyperfleet.io/resource-type: "role"
 
@@ -132,9 +131,8 @@ spec:
         namespace: "*"
         bySelectors:
           labelSelector:
-            hyperfleet.io/generation: "{{ .generationSpec }}"
             hyperfleet.io/cluster-id: "{{ .clusterId }}"
-            hyperfleet.io/resource-type: "rolebinding"
+            hyperfleet.io/resource-type: "role-binding"
 
     - name: "jobNamespace"
       transport:
@@ -145,8 +143,8 @@ spec:
         namespace: "*"
         bySelectors:
           labelSelector:
-            hyperfleet.io/generation: "{{ .generationSpec }}"
             hyperfleet.io/cluster-id: "{{ .clusterId }}"
+            hyperfleet.io/resource-type: "job"
 
     # the following configuration is for a deployment that will be created in the cluster
     # in the same namespace as the adapter
@@ -161,7 +159,7 @@ spec:
         namespace: "*"
         bySelectors:
           labelSelector:
-            hyperfleet.io/generation: "{{ .generationSpec }}"
+            hyperfleet.io/resource-type: "deployment"
             hyperfleet.io/cluster-id: "{{ .clusterId }}"
 
   # Post-processing with valid CEL expressions
@@ -176,10 +174,10 @@ spec:
             - type: "Applied"
               status:
                 expression: |
-                  has(resources.jobNamespace.spec) ? "True" : "False"
+                  has(resources.jobNamespace) ? "True" : "False"
               reason:
                 expression: |
-                  has(resources.jobNamespace.spec)
+                  has(resources.jobNamespace)
                     ? "JobApplied"
                     : "JobPending"
               message:
@@ -191,9 +189,9 @@ spec:
             - type: "Available"
               status:
                 expression: |
-                  has(resources.jobNamespace.status.conditions) ?
+                  has(resources.jobNamespace) ?
                    ( resources.?jobNamespace.?status.?conditions.orValue([]).exists(c, c.type == "Available")
-                    ? resources.jobNamespace.status.conditions.filter(c, c.type == "Available")[0].status : "False")
+                    ? resources.jobNamespace.status.conditions.filter(c, c.type == "Available")[0].status : "Unknown")
                    : "Unknown"
               reason:
                 expression: |

--- a/charts/examples/kubernetes/adapter-task-resource-deployment.yaml
+++ b/charts/examples/kubernetes/adapter-task-resource-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: "{{ .namespace }}"
   labels:
     hyperfleet.io/cluster-id: "{{ .clusterId }}"
-    hyperfleet.io/managed-by: "{{ .metadata.name }}"
+    hyperfleet.io/resource-type: "deployment"
   annotations:
     hyperfleet.io/generation: "{{ .generationSpec }}"
 spec:

--- a/charts/examples/kubernetes/adapter-task-resource-job.yaml
+++ b/charts/examples/kubernetes/adapter-task-resource-job.yaml
@@ -13,8 +13,10 @@ kind: Job
 metadata:
   name: example-job
   namespace: "{{ .clusterId }}"                        # <- this gets resolved from adapterconfig params
+  labels:
+    hyperfleet.io/cluster-id: "{{ .clusterId }}"
+    hyperfleet.io/resource-type: "job"
   annotations:
-    hyperfleet.io/cluster-id: "{{ .clusterId }}"       # <- this gets resolved from adapterconfig params
     hyperfleet.io/generation: "{{ .generationSpec }}"  # <- this gets resolved from adapterconfig params
 spec:
   backoffLimit: 0


### PR DESCRIPTION
# Summary

- Remove hyperfleet.io/generation: "{{ .generationSpec }}" from labels and keep it only in annotations.
- Fix the inconsistent resource type for RoleBinding.
- Update the expression to handle cases where API status is nil (e.g., has(resources.jobNamespace.spec) may fail if the Job has not yet been applied).
- Add the missing labels for the Job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes adapter resource labeling scheme from generation-based to resource-type-based identification.
  * Migrated cluster identifier from annotation to label format.
  * Adjusted resource discovery and condition checks to align with new labeling structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->