### PR TITLE
HYPERFLEET-642 - fix: name from config, not from task

### DIFF
--- a/internal/config_loader/loader_test.go
+++ b/internal/config_loader/loader_test.go
@@ -94,8 +94,8 @@ spec:
 	// Verify merged config fields
 	assert.Equal(t, "hyperfleet.redhat.com/v1alpha1", config.APIVersion)
 	assert.Equal(t, "Config", config.Kind)
-	// Metadata comes from task config
-	assert.Equal(t, "test-adapter", config.Metadata.Name)
+	// Metadata comes from adapter config (takes precedence)
+	assert.Equal(t, "deployment-config", config.Metadata.Name)
 	// Adapter info comes from adapter config
 	assert.Equal(t, "0.1.0", config.Spec.Adapter.Version)
 	// Clients config comes from adapter config
@@ -619,8 +619,8 @@ func TestMergeConfigs(t *testing.T) {
 	// Verify merged config
 	assert.Equal(t, "hyperfleet.redhat.com/v1alpha1", merged.APIVersion)
 	assert.Equal(t, "Config", merged.Kind)
-	// Metadata comes from task config
-	assert.Equal(t, "task-processor", merged.Metadata.Name)
+	// Metadata comes from adapter config
+	assert.Equal(t, "adapter-deployment", merged.Metadata.Name)
 	// Adapter info from adapter config
 	assert.Equal(t, "1.0.0", merged.Spec.Adapter.Version)
 	// Clients from adapter config

--- a/internal/config_loader/types.go
+++ b/internal/config_loader/types.go
@@ -48,7 +48,7 @@ func (c *Config) GetMetadata() Metadata {
 }
 
 // Merge combines AdapterConfig (deployment) and AdapterTaskConfig (task) into a unified Config.
-// The metadata is taken from the task config since it contains the adapter task name.
+// The metadata is taken from the adapter config since it takes precedence.
 // The adapter info and clients come from the deployment config.
 // The params, preconditions, resources, and post-processing come from the task config.
 func Merge(adapterCfg *AdapterConfig, taskCfg *AdapterTaskConfig) *Config {
@@ -59,7 +59,7 @@ func Merge(adapterCfg *AdapterConfig, taskCfg *AdapterTaskConfig) *Config {
 	return &Config{
 		APIVersion: adapterCfg.APIVersion,
 		Kind:       ExpectedKindConfig,
-		Metadata:   taskCfg.Metadata, // Use task metadata for adapter name
+		Metadata:   adapterCfg.Metadata, // Adapter config takes precedence
 		Spec: ConfigSpec{
 			// From deployment config
 			Adapter:     adapterCfg.Spec.Adapter,

--- a/test/integration/config-loader/loader_template_test.go
+++ b/test/integration/config-loader/loader_template_test.go
@@ -58,8 +58,8 @@ func TestLoadSplitConfig(t *testing.T) {
 	assert.Equal(t, "hyperfleet.redhat.com/v1alpha1", config.APIVersion)
 	assert.Equal(t, "Config", config.Kind)
 
-	// Metadata comes from task config
-	assert.Equal(t, "example-adapter", config.Metadata.Name)
+	// Metadata comes from adapter config (takes precedence)
+	assert.Equal(t, "test-adapter", config.Metadata.Name)
 
 	// Adapter info comes from adapter config
 	assert.Equal(t, "0.1.0", config.Spec.Adapter.Version)


### PR DESCRIPTION
https://issues.redhat.com/browse/HYPERFLEET-642

Adapters have 2 configuration files:
- adapter-config.yaml
- adapter-task-config.yaml

This PR uses the name on the adapter-config.yaml to be the name used by the adapter to report back status to the API.
This makes more sense since adapter-config.yaml is more related to the adapter itself (deployment), and the task config is more concerned with the job that the adapter has to do.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed configuration merging to prioritize adapter configuration metadata over task configuration when determining the metadata name. This ensures correct precedence in multi-component configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->