### PR TITLE
HYPERFLEET-652 - feat: dry-run mode

### DIFF
--- a/internal/dryrun/discovery_overrides.go
+++ b/internal/dryrun/discovery_overrides.go
@@ -1,0 +1,39 @@
+package dryrun
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// DiscoveryOverrides maps rendered Kubernetes resource names to complete resource
+// objects that replace applied manifests in the in-memory store. This allows
+// dry-run mode to simulate server-populated fields (status, uid, resourceVersion, etc.).
+type DiscoveryOverrides map[string]map[string]interface{}
+
+// LoadDiscoveryOverrides reads a JSON file and returns discovery overrides.
+// Each top-level key is a rendered metadata.name, and each value is a complete
+// Kubernetes-like resource object that must contain at least apiVersion and kind.
+func LoadDiscoveryOverrides(path string) (DiscoveryOverrides, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read discovery overrides file: %w", err)
+	}
+
+	var overrides DiscoveryOverrides
+	if err := json.Unmarshal(data, &overrides); err != nil {
+		return nil, fmt.Errorf("failed to parse discovery overrides JSON: %w", err)
+	}
+
+	// Validate each entry has required fields
+	for name, obj := range overrides {
+		if _, ok := obj["apiVersion"]; !ok {
+			return nil, fmt.Errorf("discovery override %q is missing required field \"apiVersion\"", name)
+		}
+		if _, ok := obj["kind"]; !ok {
+			return nil, fmt.Errorf("discovery override %q is missing required field \"kind\"", name)
+		}
+	}
+
+	return overrides, nil
+}

--- a/internal/dryrun/discovery_overrides_test.go
+++ b/internal/dryrun/discovery_overrides_test.go
@@ -1,0 +1,80 @@
+package dryrun
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeOverrideFile writes content to a file in dir and returns the full path.
+func writeOverrideFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	err := os.WriteFile(p, []byte(content), 0644)
+	require.NoError(t, err)
+	return p
+}
+
+func TestLoadDiscoveryOverrides_ValidFile(t *testing.T) {
+	t.Run("single entry with apiVersion and kind", func(t *testing.T) {
+		dir := t.TempDir()
+		path := writeOverrideFile(t, dir, "overrides.json", `{
+			"my-resource": {
+				"apiVersion": "v1",
+				"kind": "ConfigMap",
+				"metadata": {"name": "my-resource"}
+			}
+		}`)
+
+		overrides, err := LoadDiscoveryOverrides(path)
+
+		require.NoError(t, err)
+		assert.Len(t, overrides, 1)
+		assert.Equal(t, "v1", overrides["my-resource"]["apiVersion"])
+		assert.Equal(t, "ConfigMap", overrides["my-resource"]["kind"])
+	})
+}
+
+func TestLoadDiscoveryOverrides_FileNotFound(t *testing.T) {
+	t.Run("non-existent file returns read error", func(t *testing.T) {
+		_, err := LoadDiscoveryOverrides("/no/such/file.json")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read")
+	})
+}
+
+func TestLoadDiscoveryOverrides_MissingAPIVersion(t *testing.T) {
+	t.Run("entry missing apiVersion returns validation error", func(t *testing.T) {
+		dir := t.TempDir()
+		path := writeOverrideFile(t, dir, "overrides.json", `{
+			"bad-resource": {
+				"kind": "ConfigMap"
+			}
+		}`)
+
+		_, err := LoadDiscoveryOverrides(path)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `missing required field "apiVersion"`)
+	})
+}
+
+func TestLoadDiscoveryOverrides_MissingKind(t *testing.T) {
+	t.Run("entry missing kind returns validation error", func(t *testing.T) {
+		dir := t.TempDir()
+		path := writeOverrideFile(t, dir, "overrides.json", `{
+			"bad-resource": {
+				"apiVersion": "v1"
+			}
+		}`)
+
+		_, err := LoadDiscoveryOverrides(path)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `missing required field "kind"`)
+	})
+}

--- a/internal/dryrun/dryrun_api_client.go
+++ b/internal/dryrun/dryrun_api_client.go
@@ -1,0 +1,187 @@
+package dryrun
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"sync"
+
+	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/hyperfleet_api"
+)
+
+// RequestRecord stores details of an API request made through the dryrun client.
+type RequestRecord struct {
+	Method     string
+	URL        string
+	Headers    map[string]string
+	Body       []byte
+	StatusCode int
+	Response   []byte
+}
+
+// DryrunAPIClient implements hyperfleet_api.Client backed by file-defined dryrun responses.
+// It matches requests by HTTP method and URL regex pattern, returning responses
+// sequentially from a configured array per endpoint. All requests are recorded.
+type DryrunAPIClient struct {
+	endpoints []compiledEndpoint
+	mu        sync.Mutex
+	Requests  []RequestRecord
+}
+
+type compiledEndpoint struct {
+	method  string
+	pattern *regexp.Regexp
+	resps   []DryrunResponse
+	callIdx int
+}
+
+// NewDryrunAPIClient creates a DryrunAPIClient from a DryrunResponsesFile.
+// If mrf is nil, a default client that returns 200 OK for all requests is created.
+func NewDryrunAPIClient(mrf *DryrunResponsesFile) (*DryrunAPIClient, error) {
+	client := &DryrunAPIClient{
+		Requests: make([]RequestRecord, 0),
+	}
+
+	if mrf == nil {
+		return client, nil
+	}
+
+	for i, ep := range mrf.Responses {
+		compiled, err := regexp.Compile(ep.Match.URLPattern)
+		if err != nil {
+			return nil, fmt.Errorf("endpoint %d: invalid urlPattern %q: %w", i, ep.Match.URLPattern, err)
+		}
+		client.endpoints = append(client.endpoints, compiledEndpoint{
+			method:  ep.Match.Method,
+			pattern: compiled,
+			resps:   ep.Responses,
+		})
+	}
+
+	return client, nil
+}
+
+func (c *DryrunAPIClient) findEndpoint(method, url string) *compiledEndpoint {
+	for i := range c.endpoints {
+		ep := &c.endpoints[i]
+		if ep.method != "*" && ep.method != method {
+			continue
+		}
+		if ep.pattern.MatchString(url) {
+			return ep
+		}
+	}
+	return nil
+}
+
+func (c *DryrunAPIClient) nextResponse(ep *compiledEndpoint) DryrunResponse {
+	idx := ep.callIdx
+	if idx >= len(ep.resps) {
+		idx = len(ep.resps) - 1 // repeat last response
+	}
+	ep.callIdx++
+	return ep.resps[idx]
+}
+
+// Do executes a dryrun HTTP request, matching against configured endpoints.
+func (c *DryrunAPIClient) Do(ctx context.Context, req *hyperfleet_api.Request) (*hyperfleet_api.Response, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	ep := c.findEndpoint(req.Method, req.URL)
+
+	var statusCode int
+	var respBody []byte
+
+	if ep == nil {
+		// Default: 200 OK with empty body
+		statusCode = http.StatusOK
+		respBody = []byte("{}")
+	} else {
+		dryrunResp := c.nextResponse(ep)
+		statusCode = dryrunResp.StatusCode
+		if statusCode == 0 {
+			statusCode = http.StatusOK
+		}
+
+		if dryrunResp.Body != nil {
+			var err error
+			respBody, err = json.Marshal(dryrunResp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal dryrun response body: %w", err)
+			}
+		} else {
+			respBody = []byte("{}")
+		}
+	}
+
+	record := RequestRecord{
+		Method:     req.Method,
+		URL:        req.URL,
+		Headers:    req.Headers,
+		Body:       req.Body,
+		StatusCode: statusCode,
+		Response:   respBody,
+	}
+	c.Requests = append(c.Requests, record)
+
+	return &hyperfleet_api.Response{
+		StatusCode: statusCode,
+		Status:     fmt.Sprintf("%d %s", statusCode, http.StatusText(statusCode)),
+		Body:       respBody,
+		Headers:    make(map[string][]string),
+		Attempts:   1,
+	}, nil
+}
+
+// Get performs a dryrun GET request.
+func (c *DryrunAPIClient) Get(ctx context.Context, url string, opts ...hyperfleet_api.RequestOption) (*hyperfleet_api.Response, error) {
+	req := &hyperfleet_api.Request{Method: http.MethodGet, URL: url}
+	for _, opt := range opts {
+		opt(req)
+	}
+	return c.Do(ctx, req)
+}
+
+// Post performs a dryrun POST request.
+func (c *DryrunAPIClient) Post(ctx context.Context, url string, body []byte, opts ...hyperfleet_api.RequestOption) (*hyperfleet_api.Response, error) {
+	req := &hyperfleet_api.Request{Method: http.MethodPost, URL: url, Body: body}
+	for _, opt := range opts {
+		opt(req)
+	}
+	return c.Do(ctx, req)
+}
+
+// Put performs a dryrun PUT request.
+func (c *DryrunAPIClient) Put(ctx context.Context, url string, body []byte, opts ...hyperfleet_api.RequestOption) (*hyperfleet_api.Response, error) {
+	req := &hyperfleet_api.Request{Method: http.MethodPut, URL: url, Body: body}
+	for _, opt := range opts {
+		opt(req)
+	}
+	return c.Do(ctx, req)
+}
+
+// Patch performs a dryrun PATCH request.
+func (c *DryrunAPIClient) Patch(ctx context.Context, url string, body []byte, opts ...hyperfleet_api.RequestOption) (*hyperfleet_api.Response, error) {
+	req := &hyperfleet_api.Request{Method: http.MethodPatch, URL: url, Body: body}
+	for _, opt := range opts {
+		opt(req)
+	}
+	return c.Do(ctx, req)
+}
+
+// Delete performs a dryrun DELETE request.
+func (c *DryrunAPIClient) Delete(ctx context.Context, url string, opts ...hyperfleet_api.RequestOption) (*hyperfleet_api.Response, error) {
+	req := &hyperfleet_api.Request{Method: http.MethodDelete, URL: url}
+	for _, opt := range opts {
+		opt(req)
+	}
+	return c.Do(ctx, req)
+}
+
+// BaseURL returns a placeholder base URL for the dryrun client.
+func (c *DryrunAPIClient) BaseURL() string {
+	return "http://mock-api"
+}

--- a/internal/dryrun/dryrun_api_client_test.go
+++ b/internal/dryrun/dryrun_api_client_test.go
@@ -1,0 +1,340 @@
+package dryrun
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/hyperfleet_api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDryrunAPIClient_NilConfig(t *testing.T) {
+	client, err := NewDryrunAPIClient(nil)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	assert.Empty(t, client.endpoints)
+	assert.Empty(t, client.Requests)
+}
+
+func TestNewDryrunAPIClient_InvalidRegex(t *testing.T) {
+	mrf := &DryrunResponsesFile{
+		Responses: []DryrunEndpoint{
+			{
+				Match: DryrunMatch{
+					Method:     "GET",
+					URLPattern: "[invalid",
+				},
+				Responses: []DryrunResponse{
+					{StatusCode: 200},
+				},
+			},
+		},
+	}
+
+	client, err := NewDryrunAPIClient(mrf)
+	assert.Error(t, err)
+	assert.Nil(t, client)
+	assert.Contains(t, err.Error(), "invalid urlPattern")
+}
+
+func TestDo_MatchesEndpoint(t *testing.T) {
+	expectedBody := map[string]interface{}{"key": "value"}
+
+	mrf := &DryrunResponsesFile{
+		Responses: []DryrunEndpoint{
+			{
+				Match: DryrunMatch{
+					Method:     "GET",
+					URLPattern: "/api/v1/tasks.*",
+				},
+				Responses: []DryrunResponse{
+					{
+						StatusCode: 201,
+						Body:       expectedBody,
+					},
+				},
+			},
+		},
+	}
+
+	client, err := NewDryrunAPIClient(mrf)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	req := &hyperfleet_api.Request{
+		Method: "GET",
+		URL:    "/api/v1/tasks/123",
+	}
+
+	resp, err := client.Do(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, 201, resp.StatusCode)
+	assert.Equal(t, "201 Created", resp.Status)
+	assert.Equal(t, 1, resp.Attempts)
+
+	var body map[string]interface{}
+	err = json.Unmarshal(resp.Body, &body)
+	require.NoError(t, err)
+	assert.Equal(t, "value", body["key"])
+
+	// Verify request was recorded
+	require.Len(t, client.Requests, 1)
+	assert.Equal(t, "GET", client.Requests[0].Method)
+	assert.Equal(t, "/api/v1/tasks/123", client.Requests[0].URL)
+	assert.Equal(t, 201, client.Requests[0].StatusCode)
+}
+
+func TestDo_NoMatchDefaultOK(t *testing.T) {
+	mrf := &DryrunResponsesFile{
+		Responses: []DryrunEndpoint{
+			{
+				Match: DryrunMatch{
+					Method:     "GET",
+					URLPattern: "/specific-path",
+				},
+				Responses: []DryrunResponse{
+					{StatusCode: 404},
+				},
+			},
+		},
+	}
+
+	client, err := NewDryrunAPIClient(mrf)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	req := &hyperfleet_api.Request{
+		Method: "GET",
+		URL:    "/unmatched-path",
+	}
+
+	resp, err := client.Do(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "{}", string(resp.Body))
+}
+
+func TestDo_MethodFiltering(t *testing.T) {
+	mrf := &DryrunResponsesFile{
+		Responses: []DryrunEndpoint{
+			{
+				Match: DryrunMatch{
+					Method:     "POST",
+					URLPattern: "/api/v1/tasks",
+				},
+				Responses: []DryrunResponse{
+					{StatusCode: 201},
+				},
+			},
+		},
+	}
+
+	client, err := NewDryrunAPIClient(mrf)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	req := &hyperfleet_api.Request{
+		Method: "GET",
+		URL:    "/api/v1/tasks",
+	}
+
+	resp, err := client.Do(ctx, req)
+	require.NoError(t, err)
+	// GET does not match the POST endpoint, so we get the default 200 OK
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "{}", string(resp.Body))
+}
+
+func TestDo_WildcardMethod(t *testing.T) {
+	mrf := &DryrunResponsesFile{
+		Responses: []DryrunEndpoint{
+			{
+				Match: DryrunMatch{
+					Method:     "*",
+					URLPattern: "/api/v1/anything",
+				},
+				Responses: []DryrunResponse{
+					{StatusCode: 204},
+				},
+			},
+		},
+	}
+
+	client, err := NewDryrunAPIClient(mrf)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name   string
+		method string
+	}{
+		{"GET matches wildcard", "GET"},
+		{"POST matches wildcard", "POST"},
+		{"DELETE matches wildcard", "DELETE"},
+		{"PATCH matches wildcard", "PATCH"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &hyperfleet_api.Request{
+				Method: tc.method,
+				URL:    "/api/v1/anything",
+			}
+			resp, err := client.Do(ctx, req)
+			require.NoError(t, err)
+			assert.Equal(t, 204, resp.StatusCode)
+		})
+	}
+}
+
+func TestDo_SequentialResponses(t *testing.T) {
+	mrf := &DryrunResponsesFile{
+		Responses: []DryrunEndpoint{
+			{
+				Match: DryrunMatch{
+					Method:     "GET",
+					URLPattern: "/api/v1/resource",
+				},
+				Responses: []DryrunResponse{
+					{StatusCode: 200, Body: map[string]interface{}{"call": "first"}},
+					{StatusCode: 201, Body: map[string]interface{}{"call": "second"}},
+					{StatusCode: 202, Body: map[string]interface{}{"call": "third"}},
+				},
+			},
+		},
+	}
+
+	client, err := NewDryrunAPIClient(mrf)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	req := &hyperfleet_api.Request{
+		Method: "GET",
+		URL:    "/api/v1/resource",
+	}
+
+	// First call → first response
+	resp, err := client.Do(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// Second call → second response
+	resp, err = client.Do(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, 201, resp.StatusCode)
+
+	// Third call → third response
+	resp, err = client.Do(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, 202, resp.StatusCode)
+
+	// Fourth call → repeats last response (third)
+	resp, err = client.Do(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, 202, resp.StatusCode)
+
+	// Fifth call → still repeats last response
+	resp, err = client.Do(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, 202, resp.StatusCode)
+}
+
+func TestDo_StatusCodeZeroDefaultsOK(t *testing.T) {
+	mrf := &DryrunResponsesFile{
+		Responses: []DryrunEndpoint{
+			{
+				Match: DryrunMatch{
+					Method:     "GET",
+					URLPattern: "/api/v1/zero",
+				},
+				Responses: []DryrunResponse{
+					{StatusCode: 0, Body: map[string]interface{}{"ok": true}},
+				},
+			},
+		},
+	}
+
+	client, err := NewDryrunAPIClient(mrf)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	req := &hyperfleet_api.Request{
+		Method: "GET",
+		URL:    "/api/v1/zero",
+	}
+
+	resp, err := client.Do(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "200 OK", resp.Status)
+}
+
+func TestConvenienceMethods(t *testing.T) {
+	tests := []struct {
+		name           string
+		call           func(ctx context.Context, client *DryrunAPIClient) (*hyperfleet_api.Response, error)
+		expectedMethod string
+	}{
+		{
+			name: "Get",
+			call: func(ctx context.Context, c *DryrunAPIClient) (*hyperfleet_api.Response, error) {
+				return c.Get(ctx, "/test")
+			},
+			expectedMethod: "GET",
+		},
+		{
+			name: "Post",
+			call: func(ctx context.Context, c *DryrunAPIClient) (*hyperfleet_api.Response, error) {
+				return c.Post(ctx, "/test", []byte(`{"data":"post"}`))
+			},
+			expectedMethod: "POST",
+		},
+		{
+			name: "Put",
+			call: func(ctx context.Context, c *DryrunAPIClient) (*hyperfleet_api.Response, error) {
+				return c.Put(ctx, "/test", []byte(`{"data":"put"}`))
+			},
+			expectedMethod: "PUT",
+		},
+		{
+			name: "Patch",
+			call: func(ctx context.Context, c *DryrunAPIClient) (*hyperfleet_api.Response, error) {
+				return c.Patch(ctx, "/test", []byte(`{"data":"patch"}`))
+			},
+			expectedMethod: "PATCH",
+		},
+		{
+			name: "Delete",
+			call: func(ctx context.Context, c *DryrunAPIClient) (*hyperfleet_api.Response, error) {
+				return c.Delete(ctx, "/test")
+			},
+			expectedMethod: "DELETE",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client, err := NewDryrunAPIClient(nil)
+			require.NoError(t, err)
+
+			ctx := context.Background()
+			resp, err := tc.call(ctx, client)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+			require.Len(t, client.Requests, 1)
+			assert.Equal(t, tc.expectedMethod, client.Requests[0].Method)
+			assert.Equal(t, "/test", client.Requests[0].URL)
+		})
+	}
+}
+
+func TestBaseURL(t *testing.T) {
+	client, err := NewDryrunAPIClient(nil)
+	require.NoError(t, err)
+	assert.Equal(t, "http://mock-api", client.BaseURL())
+}

--- a/internal/dryrun/dryrun_responses.go
+++ b/internal/dryrun/dryrun_responses.go
@@ -1,0 +1,56 @@
+package dryrun
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// DryrunResponsesFile represents the top-level structure of a dryrun API responses JSON file.
+type DryrunResponsesFile struct {
+	Responses []DryrunEndpoint `json:"responses"`
+}
+
+// DryrunEndpoint defines a URL pattern matcher and its sequential responses.
+type DryrunEndpoint struct {
+	Match     DryrunMatch      `json:"match"`
+	Responses []DryrunResponse `json:"responses"`
+}
+
+// DryrunMatch defines the HTTP method and URL pattern to match against.
+type DryrunMatch struct {
+	Method     string `json:"method"`     // HTTP method or "*" for any
+	URLPattern string `json:"urlPattern"` // Go regexp
+}
+
+// DryrunResponse defines a single dryrun HTTP response.
+type DryrunResponse struct {
+	StatusCode int               `json:"statusCode"`
+	Headers    map[string]string `json:"headers,omitempty"`
+	Body       interface{}       `json:"body,omitempty"`
+}
+
+// LoadDryrunResponses reads and parses a dryrun API responses JSON file.
+func LoadDryrunResponses(path string) (*DryrunResponsesFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read dryrun responses file %q: %w", path, err)
+	}
+
+	var mrf DryrunResponsesFile
+	if err := json.Unmarshal(data, &mrf); err != nil {
+		return nil, fmt.Errorf("failed to parse dryrun responses file %q: %w", path, err)
+	}
+
+	// Validate each endpoint has at least one response
+	for i, ep := range mrf.Responses {
+		if len(ep.Responses) == 0 {
+			return nil, fmt.Errorf("dryrun responses file %q: endpoint %d has no responses defined", path, i)
+		}
+		if ep.Match.URLPattern == "" {
+			return nil, fmt.Errorf("dryrun responses file %q: endpoint %d has empty urlPattern", path, i)
+		}
+	}
+
+	return &mrf, nil
+}

--- a/internal/dryrun/dryrun_responses_test.go
+++ b/internal/dryrun/dryrun_responses_test.go
@@ -1,0 +1,159 @@
+package dryrun
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadDryrunResponses_ValidFile(t *testing.T) {
+	t.Run("minimal valid file", func(t *testing.T) {
+		dir := t.TempDir()
+		filePath := filepath.Join(dir, "responses.json")
+
+		content := `{
+  "responses": [
+    {
+      "match": {
+        "method": "GET",
+        "urlPattern": "/api/v1/things/.*"
+      },
+      "responses": [
+        {
+          "statusCode": 200,
+          "headers": {"Content-Type": "application/json"},
+          "body": {"id": "thing-1", "name": "Thing One"}
+        }
+      ]
+    },
+    {
+      "match": {
+        "method": "POST",
+        "urlPattern": "/api/v1/actions"
+      },
+      "responses": [
+        {
+          "statusCode": 201,
+          "body": {"status": "created"}
+        },
+        {
+          "statusCode": 409,
+          "body": {"error": "conflict"}
+        }
+      ]
+    }
+  ]
+}`
+		err := os.WriteFile(filePath, []byte(content), 0644)
+		require.NoError(t, err)
+
+		result, err := LoadDryrunResponses(filePath)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		assert.Len(t, result.Responses, 2)
+
+		// First endpoint
+		assert.Equal(t, "GET", result.Responses[0].Match.Method)
+		assert.Equal(t, "/api/v1/things/.*", result.Responses[0].Match.URLPattern)
+		assert.Len(t, result.Responses[0].Responses, 1)
+		assert.Equal(t, 200, result.Responses[0].Responses[0].StatusCode)
+		assert.Equal(t, "application/json", result.Responses[0].Responses[0].Headers["Content-Type"])
+		require.NotNil(t, result.Responses[0].Responses[0].Body)
+
+		// Second endpoint
+		assert.Equal(t, "POST", result.Responses[1].Match.Method)
+		assert.Equal(t, "/api/v1/actions", result.Responses[1].Match.URLPattern)
+		assert.Len(t, result.Responses[1].Responses, 2)
+		assert.Equal(t, 201, result.Responses[1].Responses[0].StatusCode)
+		assert.Equal(t, 409, result.Responses[1].Responses[1].StatusCode)
+	})
+
+	t.Run("real testdata file", func(t *testing.T) {
+		testdataPath := filepath.Join("..", "..", "test", "testdata", "dryrun", "dryrun-api-responses.json")
+		if _, err := os.Stat(testdataPath); os.IsNotExist(err) {
+			t.Skipf("testdata file not found at %s", testdataPath)
+		}
+
+		result, err := LoadDryrunResponses(testdataPath)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Greater(t, len(result.Responses), 0, "expected at least one endpoint in testdata file")
+
+		for i, ep := range result.Responses {
+			assert.NotEmpty(t, ep.Match.URLPattern, "endpoint %d should have a urlPattern", i)
+			assert.NotEmpty(t, ep.Responses, "endpoint %d should have at least one response", i)
+		}
+	})
+}
+
+func TestLoadDryrunResponses_FileNotFound(t *testing.T) {
+	_, err := LoadDryrunResponses("/nonexistent/path/responses.json")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read")
+}
+
+func TestLoadDryrunResponses_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "bad.json")
+
+	err := os.WriteFile(filePath, []byte(`{not valid json}`), 0644)
+	require.NoError(t, err)
+
+	_, err = LoadDryrunResponses(filePath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse")
+}
+
+func TestLoadDryrunResponses_NoResponses(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "no-responses.json")
+
+	content := `{
+  "responses": [
+    {
+      "match": {
+        "method": "GET",
+        "urlPattern": "/api/v1/things"
+      },
+      "responses": []
+    }
+  ]
+}`
+	err := os.WriteFile(filePath, []byte(content), 0644)
+	require.NoError(t, err)
+
+	_, err = LoadDryrunResponses(filePath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no responses defined")
+}
+
+func TestLoadDryrunResponses_EmptyURLPattern(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "empty-pattern.json")
+
+	content := `{
+  "responses": [
+    {
+      "match": {
+        "method": "GET",
+        "urlPattern": ""
+      },
+      "responses": [
+        {
+          "statusCode": 200
+        }
+      ]
+    }
+  ]
+}`
+	err := os.WriteFile(filePath, []byte(content), 0644)
+	require.NoError(t, err)
+
+	_, err = LoadDryrunResponses(filePath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty urlPattern")
+}

--- a/internal/dryrun/event_loader.go
+++ b/internal/dryrun/event_loader.go
@@ -1,0 +1,30 @@
+package dryrun
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2/event"
+)
+
+// LoadCloudEvent reads a CloudEvent from a JSON file in standard CloudEvents
+// JSON format and returns the parsed event.
+func LoadCloudEvent(path string) (*cloudevents.Event, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read event file %q: %w", path, err)
+	}
+
+	var evt cloudevents.Event
+	if err := json.Unmarshal(data, &evt); err != nil {
+		return nil, fmt.Errorf("failed to parse CloudEvent from %q: %w", path, err)
+	}
+
+	// Basic validation
+	if err := evt.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid CloudEvent in %q: %w", path, err)
+	}
+
+	return &evt, nil
+}

--- a/internal/dryrun/event_loader_test.go
+++ b/internal/dryrun/event_loader_test.go
@@ -1,0 +1,53 @@
+package dryrun
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeEventFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	err := os.WriteFile(p, []byte(content), 0644)
+	require.NoError(t, err)
+	return p
+}
+
+func TestLoadCloudEvent_ValidFile(t *testing.T) {
+	t.Run("loads a valid CloudEvent from file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := writeEventFile(t, dir, "event.json", `{"specversion":"1.0","id":"test-123","type":"com.example.test","source":"/test"}`)
+
+		evt, err := LoadCloudEvent(path)
+
+		require.NoError(t, err)
+		assert.Equal(t, "test-123", evt.ID())
+		assert.Equal(t, "com.example.test", evt.Type())
+		assert.Equal(t, "/test", evt.Source())
+	})
+}
+
+func TestLoadCloudEvent_FileNotFound(t *testing.T) {
+	t.Run("returns error when file does not exist", func(t *testing.T) {
+		_, err := LoadCloudEvent("/nonexistent/path/event.json")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read")
+	})
+}
+
+func TestLoadCloudEvent_InvalidJSON(t *testing.T) {
+	t.Run("returns error for invalid JSON", func(t *testing.T) {
+		dir := t.TempDir()
+		path := writeEventFile(t, dir, "bad.json", `{not json}`)
+
+		_, err := LoadCloudEvent(path)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse")
+	})
+}

--- a/internal/dryrun/recording_transport_client.go
+++ b/internal/dryrun/recording_transport_client.go
@@ -1,0 +1,180 @@
+package dryrun
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/manifest"
+	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/transport_client"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// TransportRecord stores details of a transport client operation.
+type TransportRecord struct {
+	Operation string // "apply", "get", "discover"
+	GVK       schema.GroupVersionKind
+	Namespace string
+	Name      string
+	Manifest  []byte
+	Result    *transport_client.ApplyResult
+	Error     error
+}
+
+// DryrunTransportClient implements transport_client.TransportClient by recording
+// all operations in-memory without executing real Kubernetes calls.
+// Applied resources are stored for subsequent discovery/get operations.
+type DryrunTransportClient struct {
+	mu                 sync.Mutex
+	resources          map[string]*unstructured.Unstructured // key: "namespace/name/gvk"
+	Records            []TransportRecord
+	discoveryOverrides DiscoveryOverrides
+}
+
+// NewDryrunTransportClient creates a new DryrunTransportClient.
+func NewDryrunTransportClient() *DryrunTransportClient {
+	return &DryrunTransportClient{
+		resources: make(map[string]*unstructured.Unstructured),
+		Records:   make([]TransportRecord, 0),
+	}
+}
+
+// NewDryrunTransportClientWithOverrides creates a DryrunTransportClient
+// with discovery overrides. When a resource is applied and its metadata.name
+// matches a key in the overrides map, the override object replaces the applied
+// manifest in the in-memory store.
+func NewDryrunTransportClientWithOverrides(overrides DiscoveryOverrides) *DryrunTransportClient {
+	return &DryrunTransportClient{
+		resources:          make(map[string]*unstructured.Unstructured),
+		Records:            make([]TransportRecord, 0),
+		discoveryOverrides: overrides,
+	}
+}
+
+func resourceKey(gvk schema.GroupVersionKind, namespace, name string) string {
+	return fmt.Sprintf("%s/%s/%s/%s/%s", gvk.Group, gvk.Version, gvk.Kind, namespace, name)
+}
+
+// ApplyResource parses the manifest JSON, stores it in-memory, and records the operation.
+func (c *DryrunTransportClient) ApplyResource(ctx context.Context, manifestBytes []byte, opts *transport_client.ApplyOptions, target transport_client.TransportContext) (*transport_client.ApplyResult, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Parse manifest
+	obj := &unstructured.Unstructured{}
+	if err := json.Unmarshal(manifestBytes, &obj.Object); err != nil {
+		record := TransportRecord{
+			Operation: "apply",
+			Manifest:  manifestBytes,
+			Error:     fmt.Errorf("failed to parse manifest: %w", err),
+		}
+		c.Records = append(c.Records, record)
+		return nil, record.Error
+	}
+
+	gvk := obj.GroupVersionKind()
+	namespace := obj.GetNamespace()
+	name := obj.GetName()
+	key := resourceKey(gvk, namespace, name)
+
+	// Determine operation: create or update
+	var operation manifest.Operation
+	if _, exists := c.resources[key]; exists {
+		operation = manifest.OperationUpdate
+	} else {
+		operation = manifest.OperationCreate
+	}
+
+	if opts != nil && opts.RecreateOnChange && operation == manifest.OperationUpdate {
+		operation = manifest.OperationRecreate
+	}
+
+	// Check for discovery override by resource name
+	if c.discoveryOverrides != nil {
+		if override, found := c.discoveryOverrides[name]; found {
+			overrideObj := &unstructured.Unstructured{Object: override}
+			c.resources[key] = overrideObj
+		} else {
+			c.resources[key] = obj
+		}
+	} else {
+		c.resources[key] = obj
+	}
+
+	result := &transport_client.ApplyResult{
+		Operation: operation,
+		Reason:    fmt.Sprintf("dry-run %s", operation),
+	}
+
+	c.Records = append(c.Records, TransportRecord{
+		Operation: "apply",
+		GVK:       gvk,
+		Namespace: namespace,
+		Name:      name,
+		Manifest:  manifestBytes,
+		Result:    result,
+	})
+
+	return result, nil
+}
+
+// GetResource returns a resource from the in-memory store or a NotFound error.
+func (c *DryrunTransportClient) GetResource(ctx context.Context, gvk schema.GroupVersionKind, namespace, name string, target transport_client.TransportContext) (*unstructured.Unstructured, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	key := resourceKey(gvk, namespace, name)
+	obj, exists := c.resources[key]
+
+	c.Records = append(c.Records, TransportRecord{
+		Operation: "get",
+		GVK:       gvk,
+		Namespace: namespace,
+		Name:      name,
+	})
+
+	if !exists {
+		return nil, fmt.Errorf("resource %s/%s %s/%s not found (dry-run)", gvk.Kind, gvk.Version, namespace, name)
+	}
+
+	return obj.DeepCopy(), nil
+}
+
+// DiscoverResources returns resources from the in-memory store filtered by discovery config.
+func (c *DryrunTransportClient) DiscoverResources(ctx context.Context, gvk schema.GroupVersionKind, discovery manifest.Discovery, target transport_client.TransportContext) (*unstructured.UnstructuredList, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.Records = append(c.Records, TransportRecord{
+		Operation: "discover",
+		GVK:       gvk,
+		Namespace: discovery.GetNamespace(),
+		Name:      discovery.GetName(),
+	})
+
+	list := &unstructured.UnstructuredList{}
+
+	for _, obj := range c.resources {
+		objGVK := obj.GroupVersionKind()
+		if objGVK.Group != gvk.Group || objGVK.Version != gvk.Version || objGVK.Kind != gvk.Kind {
+			continue
+		}
+
+		// Filter by namespace
+		ns := discovery.GetNamespace()
+		if ns != "" && ns != "*" && obj.GetNamespace() != ns {
+			continue
+		}
+
+		// Filter by name if single-resource discovery
+		if discovery.IsSingleResource() && obj.GetName() != discovery.GetName() {
+			continue
+		}
+
+		list.Items = append(list.Items, *obj.DeepCopy())
+	}
+
+	return list, nil
+}

--- a/internal/dryrun/recording_transport_client_test.go
+++ b/internal/dryrun/recording_transport_client_test.go
@@ -1,0 +1,405 @@
+package dryrun
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/manifest"
+	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/transport_client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// testDiscovery implements manifest.Discovery for use in tests.
+type testDiscovery struct {
+	namespace      string
+	name           string
+	labelSelector  string
+	singleResource bool
+}
+
+func (d *testDiscovery) GetNamespace() string { return d.namespace }
+func (d *testDiscovery) GetName() string      { return d.name }
+func (d *testDiscovery) GetLabelSelector() string {
+	return d.labelSelector
+}
+func (d *testDiscovery) IsSingleResource() bool { return d.singleResource }
+
+// makeManifest builds a valid JSON manifest for testing.
+func makeManifest(apiVersion, kind, namespace, name string) []byte {
+	obj := map[string]interface{}{
+		"apiVersion": apiVersion,
+		"kind":       kind,
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": namespace,
+		},
+	}
+	data, _ := json.Marshal(obj)
+	return data
+}
+
+func TestApplyResource_CreateNew(t *testing.T) {
+	ctx := context.Background()
+	client := NewDryrunTransportClient()
+	manifestBytes := makeManifest("v1", "ConfigMap", "default", "my-cm")
+
+	result, err := client.ApplyResource(ctx, manifestBytes, nil, nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, manifest.OperationCreate, result.Operation)
+	assert.Contains(t, result.Reason, "dry-run")
+
+	// Verify record was appended.
+	require.Len(t, client.Records, 1)
+	assert.Equal(t, "apply", client.Records[0].Operation)
+	assert.Equal(t, "my-cm", client.Records[0].Name)
+	assert.Equal(t, "default", client.Records[0].Namespace)
+	assert.Nil(t, client.Records[0].Error)
+
+	// Verify resource is retrievable via Get.
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+	obj, err := client.GetResource(ctx, gvk, "default", "my-cm", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "my-cm", obj.GetName())
+}
+
+func TestApplyResource_UpdateExisting(t *testing.T) {
+	ctx := context.Background()
+	client := NewDryrunTransportClient()
+	manifestBytes := makeManifest("v1", "ConfigMap", "default", "my-cm")
+
+	// First apply: create.
+	result1, err := client.ApplyResource(ctx, manifestBytes, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, manifest.OperationCreate, result1.Operation)
+
+	// Second apply: update.
+	result2, err := client.ApplyResource(ctx, manifestBytes, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, manifest.OperationUpdate, result2.Operation)
+
+	require.Len(t, client.Records, 2)
+}
+
+func TestApplyResource_RecreateOnChange(t *testing.T) {
+	ctx := context.Background()
+	client := NewDryrunTransportClient()
+	manifestBytes := makeManifest("v1", "ConfigMap", "default", "my-cm")
+
+	// First apply to create the resource.
+	_, err := client.ApplyResource(ctx, manifestBytes, nil, nil)
+	require.NoError(t, err)
+
+	// Second apply with RecreateOnChange.
+	opts := &transport_client.ApplyOptions{RecreateOnChange: true}
+	result, err := client.ApplyResource(ctx, manifestBytes, opts, nil)
+	require.NoError(t, err)
+	assert.Equal(t, manifest.OperationRecreate, result.Operation)
+}
+
+func TestApplyResource_InvalidJSON(t *testing.T) {
+	ctx := context.Background()
+	client := NewDryrunTransportClient()
+
+	result, err := client.ApplyResource(ctx, []byte("{invalid-json"), nil, nil)
+
+	assert.Nil(t, result)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse manifest")
+
+	// Record should still be appended with the error.
+	require.Len(t, client.Records, 1)
+	assert.Equal(t, "apply", client.Records[0].Operation)
+	assert.NotNil(t, client.Records[0].Error)
+}
+
+func TestApplyResource_NilOptions(t *testing.T) {
+	ctx := context.Background()
+	client := NewDryrunTransportClient()
+	manifestBytes := makeManifest("v1", "ConfigMap", "default", "my-cm")
+
+	// First apply to create.
+	_, err := client.ApplyResource(ctx, manifestBytes, nil, nil)
+	require.NoError(t, err)
+
+	// Second apply with nil opts should not panic and should produce Update.
+	result, err := client.ApplyResource(ctx, manifestBytes, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, manifest.OperationUpdate, result.Operation)
+}
+
+func TestApplyResource_WithDiscoveryOverride(t *testing.T) {
+	ctx := context.Background()
+
+	overrides := DiscoveryOverrides{
+		"my-cm": {
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":            "my-cm",
+				"namespace":       "default",
+				"resourceVersion": "12345",
+				"uid":             "fake-uid",
+			},
+			"data": map[string]interface{}{
+				"overridden": "true",
+			},
+		},
+	}
+	client := NewDryrunTransportClientWithOverrides(overrides)
+	manifestBytes := makeManifest("v1", "ConfigMap", "default", "my-cm")
+
+	_, err := client.ApplyResource(ctx, manifestBytes, nil, nil)
+	require.NoError(t, err)
+
+	// Get should return the override, not the original manifest.
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+	obj, err := client.GetResource(ctx, gvk, "default", "my-cm", nil)
+	require.NoError(t, err)
+
+	data, found, err := unstructuredNestedString(obj.Object, "data", "overridden")
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, "true", data)
+}
+
+// unstructuredNestedString is a small helper to navigate nested maps.
+func unstructuredNestedString(obj map[string]interface{}, fields ...string) (string, bool, error) {
+	current := obj
+	for i, f := range fields {
+		val, ok := current[f]
+		if !ok {
+			return "", false, nil
+		}
+		if i == len(fields)-1 {
+			s, ok := val.(string)
+			return s, ok, nil
+		}
+		m, ok := val.(map[string]interface{})
+		if !ok {
+			return "", false, fmt.Errorf("field %q is not a map", f)
+		}
+		current = m
+	}
+	return "", false, nil
+}
+
+func TestApplyResource_OverrideNoMatch(t *testing.T) {
+	ctx := context.Background()
+
+	overrides := DiscoveryOverrides{
+		"other-resource": {
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":      "other-resource",
+				"namespace": "default",
+			},
+		},
+	}
+	client := NewDryrunTransportClientWithOverrides(overrides)
+	manifestBytes := makeManifest("v1", "ConfigMap", "default", "my-cm")
+
+	_, err := client.ApplyResource(ctx, manifestBytes, nil, nil)
+	require.NoError(t, err)
+
+	// Get should return the original manifest since no override matched.
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+	obj, err := client.GetResource(ctx, gvk, "default", "my-cm", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "my-cm", obj.GetName())
+
+	// The override's extra fields should not be present.
+	_, found, _ := unstructuredNestedString(obj.Object, "data", "overridden")
+	assert.False(t, found)
+}
+
+func TestGetResource_NotFound(t *testing.T) {
+	ctx := context.Background()
+	client := NewDryrunTransportClient()
+
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+	obj, err := client.GetResource(ctx, gvk, "default", "missing", nil)
+
+	assert.Nil(t, obj)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+
+	// Record should still be appended.
+	require.Len(t, client.Records, 1)
+	assert.Equal(t, "get", client.Records[0].Operation)
+	assert.Equal(t, "missing", client.Records[0].Name)
+}
+
+func TestGetResource_ReturnsDeepCopy(t *testing.T) {
+	ctx := context.Background()
+	client := NewDryrunTransportClient()
+	manifestBytes := makeManifest("v1", "ConfigMap", "default", "my-cm")
+
+	_, err := client.ApplyResource(ctx, manifestBytes, nil, nil)
+	require.NoError(t, err)
+
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+
+	// Get the resource and mutate it.
+	obj, err := client.GetResource(ctx, gvk, "default", "my-cm", nil)
+	require.NoError(t, err)
+	obj.SetName("mutated-name")
+
+	// Get again and verify the store was not affected.
+	obj2, err := client.GetResource(ctx, gvk, "default", "my-cm", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "my-cm", obj2.GetName())
+}
+
+func TestDiscoverResources_ByGVK(t *testing.T) {
+	ctx := context.Background()
+	client := NewDryrunTransportClient()
+
+	// Apply two ConfigMaps and one Secret.
+	_, err := client.ApplyResource(ctx, makeManifest("v1", "ConfigMap", "default", "cm-1"), nil, nil)
+	require.NoError(t, err)
+	_, err = client.ApplyResource(ctx, makeManifest("v1", "ConfigMap", "default", "cm-2"), nil, nil)
+	require.NoError(t, err)
+	_, err = client.ApplyResource(ctx, makeManifest("v1", "Secret", "default", "secret-1"), nil, nil)
+	require.NoError(t, err)
+
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+	disc := &testDiscovery{namespace: "", name: ""}
+
+	list, err := client.DiscoverResources(ctx, gvk, disc, nil)
+	require.NoError(t, err)
+	assert.Len(t, list.Items, 2)
+
+	// All returned items should be ConfigMaps.
+	for _, item := range list.Items {
+		assert.Equal(t, "ConfigMap", item.GetKind())
+	}
+}
+
+func TestDiscoverResources_FilterByNamespace(t *testing.T) {
+	ctx := context.Background()
+	client := NewDryrunTransportClient()
+
+	_, err := client.ApplyResource(ctx, makeManifest("v1", "ConfigMap", "ns-a", "cm-1"), nil, nil)
+	require.NoError(t, err)
+	_, err = client.ApplyResource(ctx, makeManifest("v1", "ConfigMap", "ns-b", "cm-2"), nil, nil)
+	require.NoError(t, err)
+
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+	disc := &testDiscovery{namespace: "ns-a"}
+
+	list, err := client.DiscoverResources(ctx, gvk, disc, nil)
+	require.NoError(t, err)
+	require.Len(t, list.Items, 1)
+	assert.Equal(t, "cm-1", list.Items[0].GetName())
+}
+
+func TestDiscoverResources_SingleResourceByName(t *testing.T) {
+	ctx := context.Background()
+	client := NewDryrunTransportClient()
+
+	_, err := client.ApplyResource(ctx, makeManifest("v1", "ConfigMap", "default", "cm-1"), nil, nil)
+	require.NoError(t, err)
+	_, err = client.ApplyResource(ctx, makeManifest("v1", "ConfigMap", "default", "cm-2"), nil, nil)
+	require.NoError(t, err)
+
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+	disc := &testDiscovery{
+		namespace:      "default",
+		name:           "cm-1",
+		singleResource: true,
+	}
+
+	list, err := client.DiscoverResources(ctx, gvk, disc, nil)
+	require.NoError(t, err)
+	require.Len(t, list.Items, 1)
+	assert.Equal(t, "cm-1", list.Items[0].GetName())
+}
+
+func TestDiscoverResources_EmptyStore(t *testing.T) {
+	ctx := context.Background()
+	client := NewDryrunTransportClient()
+
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+	disc := &testDiscovery{}
+
+	list, err := client.DiscoverResources(ctx, gvk, disc, nil)
+	require.NoError(t, err)
+	assert.Empty(t, list.Items)
+}
+
+func TestConcurrentApplyAndGet(t *testing.T) {
+	ctx := context.Background()
+	client := NewDryrunTransportClient()
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+
+	const n = 50
+	var wg sync.WaitGroup
+
+	// Concurrently apply n resources.
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			name := fmt.Sprintf("cm-%d", idx)
+			m := makeManifest("v1", "ConfigMap", "default", name)
+			_, err := client.ApplyResource(ctx, m, nil, nil)
+			assert.NoError(t, err)
+		}(i)
+	}
+	wg.Wait()
+
+	// Concurrently get those resources.
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			name := fmt.Sprintf("cm-%d", idx)
+			obj, err := client.GetResource(ctx, gvk, "default", name, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, name, obj.GetName())
+		}(i)
+	}
+	wg.Wait()
+
+	// Verify all apply records exist (n applies + n gets).
+	assert.Len(t, client.Records, 2*n)
+
+	// Count apply records specifically.
+	applyCount := 0
+	for _, r := range client.Records {
+		if r.Operation == "apply" {
+			applyCount++
+		}
+	}
+	assert.Equal(t, n, applyCount)
+
+	// Verify no errors in any record.
+	for _, r := range client.Records {
+		if r.Operation == "apply" {
+			assert.Nil(t, r.Error)
+		}
+	}
+
+	// Also verify discover works after concurrent writes.
+	disc := &testDiscovery{}
+	list, err := client.DiscoverResources(ctx, gvk, disc, nil)
+	require.NoError(t, err)
+	assert.Len(t, list.Items, n)
+
+	// Check no "not found" errors leaked into the results.
+	for _, r := range client.Records {
+		if r.Operation == "get" {
+			assert.False(t, strings.Contains(fmt.Sprintf("%v", r.Error), "not found"),
+				"unexpected not-found error for resource %s", r.Name)
+		}
+	}
+}

--- a/internal/dryrun/trace.go
+++ b/internal/dryrun/trace.go
@@ -1,0 +1,394 @@
+package dryrun
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/executor"
+)
+
+const (
+	statusSuccess = "SUCCESS"
+	statusFailed  = "FAILED"
+)
+
+// ExecutionTrace contains all data needed to produce the trace output.
+type ExecutionTrace struct {
+	EventID   string
+	EventType string
+	Result    *executor.ExecutionResult
+	APIClient *DryrunAPIClient
+	Transport *DryrunTransportClient
+	Verbose   bool
+}
+
+// TraceJSON is the JSON-serializable representation of the execution trace.
+type TraceJSON struct {
+	Event               TraceEvent             `json:"event"`
+	Status              string                 `json:"status"`
+	Params              map[string]interface{} `json:"params,omitempty"`
+	Preconditions       []TracePrecondition    `json:"preconditions,omitempty"`
+	Resources           []TraceResource        `json:"resources,omitempty"`
+	DiscoveredResources map[string]interface{} `json:"discoveredResources,omitempty"`
+	PostActions         []TracePostAction      `json:"postActions,omitempty"`
+	Errors              map[string]string      `json:"errors,omitempty"`
+	APIRequests         []TraceAPIRequest      `json:"apiRequests,omitempty"`
+	TransportOps        []TraceTransportOp     `json:"transportOperations,omitempty"`
+}
+
+// TraceEvent is the JSON representation of the event.
+type TraceEvent struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+}
+
+// TracePrecondition is the JSON representation of a precondition result.
+type TracePrecondition struct {
+	Name    string `json:"name"`
+	Status  string `json:"status"`
+	Matched bool   `json:"matched"`
+	Error   string `json:"error,omitempty"`
+}
+
+// TraceResource is the JSON representation of a resource result.
+type TraceResource struct {
+	Name      string `json:"name"`
+	Kind      string `json:"kind"`
+	Namespace string `json:"namespace,omitempty"`
+	ResName   string `json:"resourceName,omitempty"`
+	Status    string `json:"status"`
+	Operation string `json:"operation"`
+	Reason    string `json:"reason,omitempty"`
+	Error     string `json:"error,omitempty"`
+}
+
+// TracePostAction is the JSON representation of a post-action result.
+type TracePostAction struct {
+	Name    string `json:"name"`
+	Status  string `json:"status"`
+	Skipped bool   `json:"skipped,omitempty"`
+	Error   string `json:"error,omitempty"`
+}
+
+// TraceAPIRequest is the JSON representation of a recorded API request.
+type TraceAPIRequest struct {
+	Method     string `json:"method"`
+	URL        string `json:"url"`
+	StatusCode int    `json:"statusCode"`
+	Request    string `json:"requestBody,omitempty"`
+	Response   string `json:"responseBody,omitempty"`
+}
+
+// TraceTransportOp is the JSON representation of a recorded transport operation.
+type TraceTransportOp struct {
+	Operation string `json:"operation"`
+	Kind      string `json:"kind"`
+	Namespace string `json:"namespace,omitempty"`
+	Name      string `json:"name"`
+	Result    string `json:"result,omitempty"`
+}
+
+// FormatText formats the execution trace as human-readable text.
+func (t *ExecutionTrace) FormatText() string {
+	var b strings.Builder
+	result := t.Result
+
+	b.WriteString("Dry-Run Execution Trace\n")
+	b.WriteString("========================\n")
+	fmt.Fprintf(&b, "Event: id=%s type=%s\n\n", t.EventID, t.EventType)
+
+	// Phase 1: Parameter Extraction
+	paramStatus := statusSuccess
+	if _, ok := result.Errors[executor.PhaseParamExtraction]; ok {
+		paramStatus = statusFailed
+	}
+	fmt.Fprintf(&b, "Phase 1: Parameter Extraction .............. %s\n", paramStatus)
+	if paramStatus == statusSuccess {
+		for name, val := range result.Params {
+			fmt.Fprintf(&b, "  %-16s = %v\n", name, formatValue(val))
+		}
+	} else {
+		fmt.Fprintf(&b, "  Error: %v\n", result.Errors[executor.PhaseParamExtraction])
+	}
+	b.WriteString("\n")
+
+	// Phase 2: Preconditions
+	precondStatus := statusSuccess
+	precondDetail := ""
+	if _, ok := result.Errors[executor.PhasePreconditions]; ok {
+		precondStatus = statusFailed
+	} else if result.ResourcesSkipped && result.SkipReason != "" {
+		precondDetail = " (NOT MET)"
+	} else if len(result.PreconditionResults) > 0 {
+		precondDetail = " (MET)"
+	}
+	fmt.Fprintf(&b, "Phase 2: Preconditions ..................... %s%s\n", precondStatus, precondDetail)
+
+	apiReqIdx := 0
+	for i, pr := range result.PreconditionResults {
+		status := "PASS"
+		if pr.Status == executor.StatusFailed {
+			status = "FAIL"
+		} else if !pr.Matched {
+			status = "NOT MET"
+		}
+		fmt.Fprintf(&b, "  [%d/%d] %-30s %s\n", i+1, len(result.PreconditionResults), pr.Name, status)
+
+		if pr.APICallMade && apiReqIdx < len(t.APIClient.Requests) {
+			req := t.APIClient.Requests[apiReqIdx]
+			fmt.Fprintf(&b, "    API Call: %s %s -> %d\n", req.Method, req.URL, req.StatusCode)
+			if t.Verbose {
+				if len(req.Body) > 0 {
+					fmt.Fprintf(&b, "    [verbose] Request body:\n      %s\n", prettyJSON(req.Body))
+				}
+				if len(req.Response) > 0 {
+					fmt.Fprintf(&b, "    [verbose] Response body:\n      %s\n", prettyJSON(req.Response))
+				}
+			}
+			apiReqIdx++
+		}
+
+		if len(pr.CapturedFields) > 0 {
+			for name, val := range pr.CapturedFields {
+				fmt.Fprintf(&b, "    Captured: %s = %v\n", name, formatValue(val))
+			}
+		}
+
+		if pr.Error != nil {
+			fmt.Fprintf(&b, "    Error: %v\n", pr.Error)
+		}
+	}
+	b.WriteString("\n")
+
+	// Phase 3: Resources
+	resStatus := statusSuccess
+	if _, ok := result.Errors[executor.PhaseResources]; ok {
+		resStatus = statusFailed
+	} else if result.ResourcesSkipped {
+		resStatus = "SKIPPED"
+	}
+	fmt.Fprintf(&b, "Phase 3: Resources ........................ %s\n", resStatus)
+
+	if result.ResourcesSkipped {
+		fmt.Fprintf(&b, "  Reason: %s\n", result.SkipReason)
+	} else {
+		for i, rr := range result.ResourceResults {
+			opStr := strings.ToUpper(string(rr.Operation))
+			if opStr == "" {
+				opStr = "UNKNOWN"
+			}
+			status := opStr
+			if rr.Status == executor.StatusFailed {
+				status = statusFailed
+			}
+			fmt.Fprintf(&b, "  [%d/%d] %-30s %s\n", i+1, len(result.ResourceResults), rr.Name, status)
+			fmt.Fprintf(&b, "    Kind: %-12s Namespace: %-12s Name: %s\n", rr.Kind, rr.Namespace, rr.ResourceName)
+
+			if t.Verbose {
+				for _, tr := range t.Transport.Records {
+					if tr.Operation == "apply" && tr.Name == rr.ResourceName && tr.Namespace == rr.Namespace {
+						fmt.Fprintf(&b, "    [verbose] Rendered manifest:\n      %s\n", prettyJSON(tr.Manifest))
+						break
+					}
+				}
+			}
+
+			if rr.Error != nil {
+				fmt.Fprintf(&b, "    Error: %v\n", rr.Error)
+			}
+		}
+	}
+
+	// Discovery results (resources available for payload CEL: resources.<name>)
+	if result.ExecutionContext != nil && result.ExecutionContext.Resources != nil && len(result.ExecutionContext.Resources) > 0 {
+		b.WriteString("\nPhase 3.5: Discovery Results ................. (available as resources.* in payload)\n")
+		celVars := result.ExecutionContext.GetCELVariables()
+		if r, ok := celVars["resources"].(map[string]interface{}); ok {
+			for name, val := range r {
+				fmt.Fprintf(&b, "  %s:\n", name)
+				b.WriteString("    ")
+				b.WriteString(formatValue(val))
+				b.WriteString("\n")
+			}
+		}
+	}
+	b.WriteString("\n")
+
+	// Phase 4: Post Actions
+	postStatus := statusSuccess
+	if _, ok := result.Errors[executor.PhasePostActions]; ok {
+		postStatus = statusFailed
+	}
+	fmt.Fprintf(&b, "Phase 4: Post Actions ..................... %s\n", postStatus)
+
+	for i, pa := range result.PostActionResults {
+		status := "EXECUTED"
+		if pa.Skipped {
+			status = "SKIPPED"
+		} else if pa.Status == executor.StatusFailed {
+			status = statusFailed
+		}
+		fmt.Fprintf(&b, "  [%d/%d] %-30s %s\n", i+1, len(result.PostActionResults), pa.Name, status)
+
+		if pa.Skipped {
+			fmt.Fprintf(&b, "    Reason: %s\n", pa.SkipReason)
+		}
+
+		if pa.APICallMade && apiReqIdx < len(t.APIClient.Requests) {
+			req := t.APIClient.Requests[apiReqIdx]
+			fmt.Fprintf(&b, "    API Call: %s %s -> %d\n", req.Method, req.URL, req.StatusCode)
+			if t.Verbose {
+				if len(req.Body) > 0 {
+					fmt.Fprintf(&b, "    [verbose] Request body:\n      %s\n", prettyJSON(req.Body))
+				}
+				if len(req.Response) > 0 {
+					fmt.Fprintf(&b, "    [verbose] Response body:\n      %s\n", prettyJSON(req.Response))
+				}
+			}
+			apiReqIdx++
+		}
+
+		if pa.Error != nil {
+			fmt.Fprintf(&b, "    Error: %v\n", pa.Error)
+		}
+	}
+	b.WriteString("\n")
+
+	// Final result
+	resultStr := statusSuccess
+	if result.Status == executor.StatusFailed {
+		resultStr = statusFailed
+	}
+	fmt.Fprintf(&b, "Result: %s\n", resultStr)
+
+	return b.String()
+}
+
+// FormatJSON formats the execution trace as JSON.
+func (t *ExecutionTrace) FormatJSON() ([]byte, error) {
+	result := t.Result
+
+	trace := TraceJSON{
+		Event:  TraceEvent{ID: t.EventID, Type: t.EventType},
+		Status: string(result.Status),
+		Params: result.Params,
+	}
+
+	// Discovered resources (from discovery phase, used in payload CEL)
+	if result.ExecutionContext != nil {
+		celVars := result.ExecutionContext.GetCELVariables()
+		if r, ok := celVars["resources"].(map[string]interface{}); ok {
+			trace.DiscoveredResources = r
+		}
+	}
+
+	// Preconditions
+	for _, pr := range result.PreconditionResults {
+		tp := TracePrecondition{
+			Name:    pr.Name,
+			Status:  string(pr.Status),
+			Matched: pr.Matched,
+		}
+		if pr.Error != nil {
+			tp.Error = pr.Error.Error()
+		}
+		trace.Preconditions = append(trace.Preconditions, tp)
+	}
+
+	// Resources
+	for _, rr := range result.ResourceResults {
+		tr := TraceResource{
+			Name:      rr.Name,
+			Kind:      rr.Kind,
+			Namespace: rr.Namespace,
+			ResName:   rr.ResourceName,
+			Status:    string(rr.Status),
+			Operation: string(rr.Operation),
+			Reason:    rr.OperationReason,
+		}
+		if rr.Error != nil {
+			tr.Error = rr.Error.Error()
+		}
+		trace.Resources = append(trace.Resources, tr)
+	}
+
+	// Post Actions
+	for _, pa := range result.PostActionResults {
+		tp := TracePostAction{
+			Name:    pa.Name,
+			Status:  string(pa.Status),
+			Skipped: pa.Skipped,
+		}
+		if pa.Error != nil {
+			tp.Error = pa.Error.Error()
+		}
+		trace.PostActions = append(trace.PostActions, tp)
+	}
+
+	// Errors
+	if len(result.Errors) > 0 {
+		trace.Errors = make(map[string]string)
+		for phase, err := range result.Errors {
+			trace.Errors[string(phase)] = err.Error()
+		}
+	}
+
+	// API Requests
+	for _, req := range t.APIClient.Requests {
+		tr := TraceAPIRequest{
+			Method:     req.Method,
+			URL:        req.URL,
+			StatusCode: req.StatusCode,
+		}
+		if t.Verbose {
+			if len(req.Body) > 0 {
+				tr.Request = string(req.Body)
+			}
+			if len(req.Response) > 0 {
+				tr.Response = string(req.Response)
+			}
+		}
+		trace.APIRequests = append(trace.APIRequests, tr)
+	}
+
+	// Transport Operations
+	for _, rec := range t.Transport.Records {
+		op := TraceTransportOp{
+			Operation: rec.Operation,
+			Kind:      rec.GVK.Kind,
+			Namespace: rec.Namespace,
+			Name:      rec.Name,
+		}
+		if rec.Result != nil {
+			op.Result = string(rec.Result.Operation)
+		}
+		trace.TransportOps = append(trace.TransportOps, op)
+	}
+
+	return json.MarshalIndent(trace, "", "  ")
+}
+
+// prettyJSON attempts to indent raw JSON bytes for readable output.
+// If the input is not valid JSON, it is returned as-is.
+func prettyJSON(raw []byte) string {
+	var buf bytes.Buffer
+	if err := json.Indent(&buf, raw, "      ", "  "); err != nil {
+		return string(raw)
+	}
+	return buf.String()
+}
+
+func formatValue(v interface{}) string {
+	switch val := v.(type) {
+	case string:
+		return fmt.Sprintf("%q", val)
+	default:
+		b, err := json.Marshal(val)
+		if err != nil {
+			return fmt.Sprintf("%v", val)
+		}
+		return string(b)
+	}
+}

--- a/internal/dryrun/trace_test.go
+++ b/internal/dryrun/trace_test.go
@@ -1,0 +1,276 @@
+package dryrun
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/executor"
+	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/manifest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeTestTrace(status executor.ExecutionStatus, verbose bool) *ExecutionTrace {
+	apiClient, _ := NewDryrunAPIClient(nil)
+	transport := NewDryrunTransportClient()
+	return &ExecutionTrace{
+		EventID:   "test-event-id",
+		EventType: "test.event.type",
+		Result: &executor.ExecutionResult{
+			Status: status,
+			Params: map[string]interface{}{"key": "value"},
+			Errors: make(map[executor.ExecutionPhase]error),
+		},
+		APIClient: apiClient,
+		Transport: transport,
+		Verbose:   verbose,
+	}
+}
+
+func TestFormatText_Success(t *testing.T) {
+	t.Run("successful execution trace contains all phases and SUCCESS result", func(t *testing.T) {
+		trace := makeTestTrace(executor.StatusSuccess, false)
+		trace.Result.PreconditionResults = []executor.PreconditionResult{
+			{
+				Name:    "check-exists",
+				Status:  executor.StatusSuccess,
+				Matched: true,
+			},
+		}
+		trace.Result.ResourceResults = []executor.ResourceResult{
+			{
+				Name:         "my-resource",
+				Kind:         "ConfigMap",
+				Namespace:    "default",
+				ResourceName: "my-configmap",
+				Status:       executor.StatusSuccess,
+				Operation:    manifest.OperationCreate,
+			},
+		}
+
+		output := trace.FormatText()
+
+		assert.Contains(t, output, "Dry-Run Execution Trace")
+		assert.Contains(t, output, "Phase 1: Parameter Extraction")
+		assert.Contains(t, output, "Phase 2: Preconditions")
+		assert.Contains(t, output, "Phase 3: Resources")
+		assert.Contains(t, output, "Phase 4: Post Actions")
+		assert.Contains(t, output, "Result: SUCCESS")
+	})
+}
+
+func TestFormatText_Failed(t *testing.T) {
+	t.Run("failed execution trace shows FAILED result and error in resource result", func(t *testing.T) {
+		trace := makeTestTrace(executor.StatusFailed, false)
+		trace.Result.Errors[executor.PhaseResources] = fmt.Errorf("resource apply failed: connection refused")
+		trace.Result.ResourceResults = []executor.ResourceResult{
+			{
+				Name:         "failing-resource",
+				Kind:         "Deployment",
+				Namespace:    "default",
+				ResourceName: "my-deploy",
+				Status:       executor.StatusFailed,
+				Operation:    manifest.OperationCreate,
+				Error:        fmt.Errorf("resource apply failed: connection refused"),
+			},
+		}
+
+		output := trace.FormatText()
+
+		assert.Contains(t, output, "Result: FAILED")
+		assert.Contains(t, output, "resource apply failed: connection refused")
+	})
+}
+
+func TestFormatText_ResourcesSkipped(t *testing.T) {
+	t.Run("skipped resources phase shows SKIPPED", func(t *testing.T) {
+		trace := makeTestTrace(executor.StatusSuccess, false)
+		trace.Result.ResourcesSkipped = true
+		trace.Result.SkipReason = "preconditions not met"
+
+		output := trace.FormatText()
+
+		assert.Contains(t, output, "Phase 3: Resources")
+		assert.Contains(t, output, "SKIPPED")
+		assert.Contains(t, output, "preconditions not met")
+	})
+}
+
+func TestFormatText_VerboseShowsBodies(t *testing.T) {
+	t.Run("verbose mode includes request and response bodies", func(t *testing.T) {
+		trace := makeTestTrace(executor.StatusSuccess, true)
+
+		trace.APIClient.Requests = append(trace.APIClient.Requests, RequestRecord{
+			Method:     "GET",
+			URL:        "http://mock-api/test",
+			StatusCode: 200,
+			Body:       []byte(`{"request":"data"}`),
+			Response:   []byte(`{"response":"data"}`),
+		})
+		trace.Result.PreconditionResults = []executor.PreconditionResult{
+			{
+				Name:        "api-check",
+				Status:      executor.StatusSuccess,
+				Matched:     true,
+				APICallMade: true,
+			},
+		}
+
+		output := trace.FormatText()
+
+		assert.Contains(t, output, "[verbose]")
+	})
+}
+
+func TestFormatText_NonVerboseOmitsBodies(t *testing.T) {
+	t.Run("non-verbose mode omits request and response bodies", func(t *testing.T) {
+		trace := makeTestTrace(executor.StatusSuccess, false)
+
+		trace.APIClient.Requests = append(trace.APIClient.Requests, RequestRecord{
+			Method:     "GET",
+			URL:        "http://mock-api/test",
+			StatusCode: 200,
+			Body:       []byte(`{"request":"data"}`),
+			Response:   []byte(`{"response":"data"}`),
+		})
+		trace.Result.PreconditionResults = []executor.PreconditionResult{
+			{
+				Name:        "api-check",
+				Status:      executor.StatusSuccess,
+				Matched:     true,
+				APICallMade: true,
+			},
+		}
+
+		output := trace.FormatText()
+
+		assert.NotContains(t, output, "[verbose]")
+	})
+}
+
+func TestFormatJSON_Structure(t *testing.T) {
+	t.Run("JSON output has correct event and status fields", func(t *testing.T) {
+		trace := makeTestTrace(executor.StatusSuccess, false)
+		trace.Result.PreconditionResults = []executor.PreconditionResult{
+			{
+				Name:    "check-exists",
+				Status:  executor.StatusSuccess,
+				Matched: true,
+			},
+		}
+
+		data, err := trace.FormatJSON()
+		require.NoError(t, err)
+
+		var result TraceJSON
+		err = json.Unmarshal(data, &result)
+		require.NoError(t, err)
+
+		assert.Equal(t, "test-event-id", result.Event.ID)
+		assert.Equal(t, "test.event.type", result.Event.Type)
+		assert.Equal(t, string(executor.StatusSuccess), result.Status)
+		assert.Len(t, result.Preconditions, 1)
+		assert.Equal(t, "check-exists", result.Preconditions[0].Name)
+	})
+}
+
+func TestFormatJSON_VerboseIncludesBodies(t *testing.T) {
+	t.Run("verbose JSON includes request and response bodies", func(t *testing.T) {
+		trace := makeTestTrace(executor.StatusSuccess, true)
+
+		trace.APIClient.Requests = append(trace.APIClient.Requests, RequestRecord{
+			Method:     "POST",
+			URL:        "http://mock-api/resource",
+			StatusCode: 201,
+			Body:       []byte(`{"name":"test"}`),
+			Response:   []byte(`{"id":"123"}`),
+		})
+
+		data, err := trace.FormatJSON()
+		require.NoError(t, err)
+
+		var result TraceJSON
+		err = json.Unmarshal(data, &result)
+		require.NoError(t, err)
+
+		require.Len(t, result.APIRequests, 1)
+		assert.NotEmpty(t, result.APIRequests[0].Request)
+		assert.NotEmpty(t, result.APIRequests[0].Response)
+	})
+}
+
+func TestFormatJSON_NonVerboseOmitsBodies(t *testing.T) {
+	t.Run("non-verbose JSON omits request and response bodies", func(t *testing.T) {
+		trace := makeTestTrace(executor.StatusSuccess, false)
+
+		trace.APIClient.Requests = append(trace.APIClient.Requests, RequestRecord{
+			Method:     "POST",
+			URL:        "http://mock-api/resource",
+			StatusCode: 201,
+			Body:       []byte(`{"name":"test"}`),
+			Response:   []byte(`{"id":"123"}`),
+		})
+
+		data, err := trace.FormatJSON()
+		require.NoError(t, err)
+
+		var result TraceJSON
+		err = json.Unmarshal(data, &result)
+		require.NoError(t, err)
+
+		require.Len(t, result.APIRequests, 1)
+		assert.Empty(t, result.APIRequests[0].Request)
+		assert.Empty(t, result.APIRequests[0].Response)
+	})
+}
+
+func TestPrettyJSON(t *testing.T) {
+	t.Run("valid JSON is indented", func(t *testing.T) {
+		input := []byte(`{"key":"value","nested":{"a":1}}`)
+		result := prettyJSON(input)
+
+		assert.Contains(t, result, "\n")
+		assert.Contains(t, result, "  ")
+
+		// Verify it is valid JSON
+		var parsed interface{}
+		err := json.Unmarshal([]byte(result), &parsed)
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid JSON is returned as-is", func(t *testing.T) {
+		input := []byte(`not valid json {{{`)
+		result := prettyJSON(input)
+
+		assert.Equal(t, string(input), result)
+	})
+}
+
+func TestFormatValue(t *testing.T) {
+	t.Run("string value is quoted", func(t *testing.T) {
+		result := formatValue("hello")
+
+		assert.True(t, strings.HasPrefix(result, `"`))
+		assert.True(t, strings.HasSuffix(result, `"`))
+		assert.Contains(t, result, "hello")
+	})
+
+	t.Run("non-string value uses JSON representation", func(t *testing.T) {
+		input := map[string]interface{}{"a": 1, "b": "two"}
+		result := formatValue(input)
+
+		// Should be valid JSON
+		var parsed map[string]interface{}
+		err := json.Unmarshal([]byte(result), &parsed)
+		assert.NoError(t, err)
+		assert.Equal(t, float64(1), parsed["a"])
+		assert.Equal(t, "two", parsed["b"])
+	})
+
+	t.Run("integer value uses JSON representation", func(t *testing.T) {
+		result := formatValue(42)
+		assert.Equal(t, "42", result)
+	})
+}

--- a/test/testdata/dryrun/adapter-config.yaml
+++ b/test/testdata/dryrun/adapter-config.yaml
@@ -1,0 +1,24 @@
+# Adapter deployment configuration for dry-run testing
+apiVersion: hyperfleet.redhat.com/v1alpha1
+kind: AdapterConfig
+metadata:
+  name: dryrun-adapter
+  labels:
+    hyperfleet.io/component: adapter
+
+spec:
+  adapter:
+    version: "0.1.0"
+
+  clients:
+    hyperfleetApi:
+      timeout: 10s
+      retryAttempts: 3
+      retryBackoff: exponential
+
+    broker:
+      subscriptionId: "dryrun-sub"
+      topic: "cluster-events"
+
+    kubernetes:
+      apiVersion: "v1"

--- a/test/testdata/dryrun/dryrun-api-responses.json
+++ b/test/testdata/dryrun/dryrun-api-responses.json
@@ -1,0 +1,55 @@
+{
+  "responses": [
+    {
+      "match": {
+        "method": "GET",
+        "urlPattern": "/api/hyperfleet/v1/clusters/.*"
+      },
+      "responses": [
+        {
+          "statusCode": 200,
+          "headers": {
+            "Content-Type": "application/json"
+          },
+          "body": {
+            "id": "abc-123",
+            "name": "abc123",
+            "kind": "Cluster",
+            "href": "/api/hyperfleet/v1/clusters/abc123",
+            "generation": "77",
+            "nodes": {
+              "compute": 3
+            },
+            "spec": {
+              "region": "us-east-1",
+              "provider": "aws"
+            },
+            "status": {
+              "conditions": [
+                {
+                  "type": "Ready",
+                  "status": "False"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "match": {
+        "method": "PATCH",
+        "urlPattern": "/api/hyperfleet/v1/clusters/.*/status"
+      },
+      "responses": [
+        {
+          "statusCode": 200,
+          "headers": {
+            "Content-Type": "application/json"
+          },
+          "body": {}
+        }
+      ]
+    }
+  ]
+}

--- a/test/testdata/dryrun/dryrun-discovery.json
+++ b/test/testdata/dryrun/dryrun-discovery.json
@@ -1,0 +1,46 @@
+{
+  "manifestwork-symbol000": {
+    "apiVersion": "work.open-cluster-management.io/v1",
+    "kind": "ManifestWork",
+    "metadata": {
+      "name": "manifestwork000-this-name-not-used",
+      "namespace": "cluster1",
+      "labels": {
+        "hyperfleet.io/resource-type": "manifestwork"
+      }
+    },
+    "spec": {
+      "workload": {
+        "manifests": [
+          {
+            "apiVersion": "v1",
+            "kind": "Namespace",
+            "metadata": {
+              "name": "abc123",
+              "labels": {
+                "hyperfleet.io/resource-type": "namespace",
+                "hyperfleet.io/cluster-id": "abc123",
+                "hyperfleet.io/label-for-discovery": "namespace-symbol111"
+              }
+            }
+          },
+          {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {
+              "name": "abc123-symbol222",
+              "namespace": "abc123",
+              "labels": {
+                "hyperfleet.io/cluster-id": "abc123"
+              }
+            },
+            "data": {
+              "cluster_id": "abc123",
+              "cluster_name": "test-cluster"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/testdata/dryrun/event.json
+++ b/test/testdata/dryrun/event.json
@@ -1,0 +1,14 @@
+{
+  "specversion": "1.0",
+  "id": "abc123",
+  "type": "io.hyperfleet.cluster.updated",
+  "source": "/api/clusters_mgmt/v1/clusters/abc123",
+  "time": "2025-01-15T10:30:00Z",
+  "datacontenttype": "application/json",
+  "data": {
+    "id": "abc123",
+    "kind": "Cluster",
+    "href": "/api/clusters_mgmt/v1/clusters/abc123",
+    "generation": 5
+  }
+}

--- a/test/testdata/dryrun/task-config-invalid.yaml
+++ b/test/testdata/dryrun/task-config-invalid.yaml
@@ -1,0 +1,44 @@
+# Invalid task configuration for testing validate command error reporting
+apiVersion: hyperfleet.redhat.com/v1alpha1
+kind: AdapterTaskConfig
+metadata:
+  name: invalid-task
+
+spec:
+  params:
+    - name: "clusterId"
+      source: "event.id"
+      type: "string"
+      required: true
+
+  preconditions:
+    - name: "bad-cel"
+      expression: |
+        this is not valid CEL !!!
+
+  resources:
+    - name: "missingFields"
+      manifest:
+        apiVersion: v1
+        kind: ConfigMap
+        # missing metadata.name — validation should catch this
+        metadata:
+          labels:
+            app: test
+          annotations:
+            hyperfleet.io/generation: "1"
+      discovery:
+        namespace: "default"
+        byName: "test"
+
+    - name: "undefinedVar"
+      manifest:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: "{{ .nonExistentVariable }}"
+          annotations:
+            hyperfleet.io/generation: "1"
+      discovery:
+        namespace: "default"
+        byName: "test"

--- a/test/testdata/dryrun/task-config.yaml
+++ b/test/testdata/dryrun/task-config.yaml
@@ -1,0 +1,251 @@
+# Task configuration for dry-run testing
+apiVersion: hyperfleet.redhat.com/v1alpha1
+kind: AdapterTaskConfig
+metadata:
+  name: dryrun-task
+  labels:
+    hyperfleet.io/adapter-type: dryrun
+
+spec:
+  params:
+    - name: "clusterId"
+      source: "event.id"
+      type: "string"
+      required: true
+
+    - name: "clusterKind"
+      source: "event.kind"
+      type: "string"
+      default: "Cluster"
+
+    - name: "generationValue"
+      source: "event.generation"
+      type: "string"
+      required: true
+
+    - name: "region"
+      source: "env.REGION"
+      type: "string"
+      default: "us-east-1"
+
+    - name: "adapterName"
+      source: "env.ADAPTER_NAME"
+      type: "string"
+      default: "dry-run-adapter"
+
+  preconditions:
+    - name: "fetch-cluster"
+      apiCall:
+        method: "GET"
+        url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}"
+        timeout: 10s
+      capture:
+        - name: "clusterName"
+          field: "name"
+        - name: "clusterStatus"
+          expression: |
+            status.conditions.filter(c, c.type == "Ready").size() > 0
+              ? status.conditions.filter(c, c.type == "Ready")[0].status
+              : "False"
+        - name: "computeNodes"
+          field: "nodes.compute"
+        #TODO: research why we can not have {{ now }} as expression
+        - name: "timestamp"
+          expression:  "\"2006-01-02T15:04:05Z07:00\""
+
+      conditions:
+        - field: "clusterStatus"
+          operator: "notEquals"
+          value: "True"
+
+  resources:
+    - name: "resource0"
+      transport: 
+        client: maestro
+        maestro:
+          targetCluster: cluster1
+      manifest:
+        apiVersion: work.open-cluster-management.io/v1
+        kind: ManifestWork
+        metadata:
+          # ManifestWork name - must be unique within consumer namespace
+          #name: "manifestwork-{{ .clusterId }}"
+          name: "manifestwork-symbol000"
+
+          # Labels for identification, filtering, and management
+          labels:
+            # HyperFleet tracking labels
+            hyperfleet.io/cluster-id: "{{ .clusterId }}"
+            hyperfleet.io/adapter: "{{ .adapterName }}"
+            hyperfleet.io/component: "infrastructure"
+            hyperfleet.io/generation: "{{ .generationValue }}"
+            hyperfleet.io/resource-group: "cluster-setup"
+
+            # Maestro-specific labels
+            maestro.io/source-id: "{{ .adapterName }}"
+            maestro.io/resource-type: "manifestwork"
+            maestro.io/priority: "normal"
+
+            # Standard Kubernetes application labels
+            app.kubernetes.io/name: "aro-hcp-cluster"
+            app.kubernetes.io/instance: "{{ .clusterId }}"
+            app.kubernetes.io/version: "v1.0.0"
+            app.kubernetes.io/component: "infrastructure"
+            app.kubernetes.io/part-of: "hyperfleet"
+            app.kubernetes.io/managed-by: "hyperfleet-adapter"
+            app.kubernetes.io/created-by: "{{ .adapterName }}"
+
+          # Annotations for metadata and operational information
+          annotations:
+            # Tracking and lifecycle
+            hyperfleet.io/created-by: "hyperfleet-adapter-framework"
+            hyperfleet.io/managed-by: "{{ .adapterName }}"
+            hyperfleet.io/generation: "{{ .generationValue }}"
+            hyperfleet.io/cluster-name: "{{ .clusterId }}"
+            hyperfleet.io/deployment-time: "{{ .timestamp }}"
+
+            # Maestro-specific annotations
+            maestro.io/applied-time: "{{ .timestamp }}"
+            maestro.io/source-adapter: "{{ .adapterName }}"
+
+            # Operational annotations
+            deployment.hyperfleet.io/strategy: "rolling"
+            deployment.hyperfleet.io/timeout: "300s"
+            monitoring.hyperfleet.io/enabled: "true"
+
+            # Documentation
+            description: "Complete cluster setup including namespace, configuration, and RBAC"
+            documentation: "https://docs.hyperfleet.io/adapters/aro-hcp"
+
+        # ManifestWork specification
+        spec:
+          # ============================================================================
+          # Workload - Contains the Kubernetes manifests to deploy
+          # ============================================================================
+          workload:
+            # Kubernetes manifests array - injected by framework from business logic config
+            manifests:
+            - apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: "{{ .clusterId | lower }}"
+                labels:
+                  hyperfleet.io/cluster-id: "{{ .clusterId }}"
+                  hyperfleet.io/managed-by: "{{ .metadata.name }}"
+                  hyperfleet.io/resource-type: "namespace"
+                  hyperfleet.io/label-for-discovery: "namespace-symbol111"
+                annotations:
+                  hyperfleet.io/created-by: "hyperfleet-adapter"
+                  hyperfleet.io/generation: "{{ .generationValue }}"
+            - apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: "cluster-config"
+                namespace: "{{ .clusterId }}-symbol222"
+                labels:
+                  hyperfleet.io/cluster-id: "{{ .clusterId }}"
+                annotations:
+                  hyperfleet.io/generation: "{{ .generationValue }}"
+              data:
+                cluster_id: "{{ .clusterId }}"
+                cluster_name: "{{ .clusterName }}"
+
+          # ============================================================================
+          # Delete Options - How resources should be removed
+          # ============================================================================
+          deleteOption:
+            # Propagation policy for resource deletion
+            # - "Foreground": Wait for dependent resources to be deleted first
+            # - "Background": Delete immediately, let cluster handle dependents
+            # - "Orphan": Leave resources on cluster when ManifestWork is deleted
+            propagationPolicy: "Foreground"
+
+            # Grace period for graceful deletion (seconds)
+            gracePeriodSeconds: 30
+
+          # ============================================================================
+          # Manifest Configurations - Per-resource settings for update and feedback
+          # ============================================================================
+          manifestConfigs:
+            # ========================================================================
+            # Configuration for Namespace resources
+            # ========================================================================
+            - resourceIdentifier:
+                group: ""                           # Core API group (empty for v1 resources)
+                resource: "namespaces"              # Resource type
+                name: "{{ .clusterId | lower }}"    # Specific resource name
+              updateStrategy:
+                type: "ServerSideApply"             # Use server-side apply for namespaces
+                serverSideApply:
+                  fieldManager: "hyperfleet-adapter" # Field manager name for conflict resolution
+                  force: false                      # Don't force conflicts (fail on conflicts)
+              feedbackRules:
+                - type: "JSONPaths"                 # Use JSON path expressions for status feedback
+                  jsonPaths:
+                    - name: "phase"                 # Namespace phase (Active, Terminating)
+                      path: ".status.phase"
+                    - name: "conditions"            # Namespace conditions array
+                      path: ".status.conditions"
+                    - name: "creationTimestamp"     # When namespace was created
+                      path: ".metadata.creationTimestamp"
+
+      discovery:
+        namespace: "*"
+        #byName: "cluster-{{ .clusterId }}-config"
+        #byName: "manifestwork0"
+        bySelectors:
+          labelSelector:
+            hyperfleet.io/resource-type: manifestwork
+
+      # Discover sub-resources within the manifestWork
+      # This approach can be used to use the discovery name to parameter level
+      # This can support jsonPath to dig into the resource status. like discoveryNamespace.status.conditions[?(@.type=="Ready")].status
+      nestedDiscoveries:
+        - name: "discoveryNamespace"
+          discovery:
+            bySelectors:
+              labelSelector:
+                hyperfleet.io/label-for-discovery: "namespace-symbol111"
+        - name: "discoveryConfigMap"
+          discovery:
+            byName: "{{ .clusterId }}-symbol222"
+
+  post:
+    payloads:
+      - name: "statusPayload"
+        build:
+          conditions:
+            - type: "Applied"
+              status:
+                expression: |
+                  has(resources.resource0) && has(resources.resource0.discoveryNamespace) ? "True" : "False"
+              reason:
+                expression: |
+                  resources.resource0.discoveryNamespace.metadata.name 
+                  + ' / ' +
+                  metadata.name
+
+                  + ' / ' +
+                  resources.resource0.discoveryConfigMap.metadata.name
+              message:
+                expression: |
+                  has(resources.resource0) && has(resources.resource0.discoveryNamespace)
+                    ? "Resources discovered successfully"
+                    : "Discovery pending"
+            - type: "Health"
+              status:
+                expression: |
+                  adapter.?executionStatus.orValue("") == "success" ? "True" : "False"
+              reason:
+                expression: |
+                  adapter.?errorReason.orValue("") != "" ? adapter.?errorReason.orValue("") : "Healthy"
+              message:
+                expression: |
+                  adapter.?errorMessage.orValue("") != "" ? adapter.?errorMessage.orValue("") : "Adapter healthy"
+
+    postActions:
+      - name: "update-status"
+        apiCall:
+          method: "PATCH"
+          url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}/statuses"
+          body: "{{ .statusPayload }}"


### PR DESCRIPTION
https://issues.redhat.com/browse/HYPERFLEET-652

- Adds a dry-run mode that simulates the full adapter execution pipeline (params → preconditions → resources → post-actions) locally, without connecting to any real infrastructure (broker, Kubernetes, Maestro, or HyperFleet API)
  - Introduces mock clients (DryrunAPIClient, DryrunTransportClient) that record all operations in-memory and support configurable responses via JSON files
  - Produces a detailed execution trace (text or JSON) showing what the adapter would do for a given CloudEvent, including extracted params, precondition results, resource operations, and post-action calls
  - Refactors cmd/adapter/main.go to extract shared logic (config loading, client creation, executor building) into reusable functions used by both serve and dry-run modes
  - Fixes resource identity (Kind, Namespace, Name) to be populated from the rendered manifest before transport apply, so the trace can report accurate resource details

It can be tested with the test files at `test/testdata/dryrun`

```
go run ./cmd/adapter/ serve \
    --config ./test/testdata/dryrun/adapter-config.yaml \
    --task-config ./test/testdata/dryrun/task-config.yaml \
    --dry-run-event ./test/testdata/dryrun/event.json \
    --dry-run-api-responses ./test/testdata/dryrun/dryrun-api-responses.json \
    --dry-run-discovery ./test/testdata/dryrun/dryrun-discovery.json \
    --dry-run-verbose
```

  Test plan

  - Verify dry-run with minimal flags: --dry-run-event event.json produces a text trace
  - Verify --dry-run-api-responses correctly matches requests by method and URL regex
  - Verify --dry-run-discovery overrides replace applied resources for discovery phase
  - Verify --dry-run-verbose includes rendered manifests and API request/response bodies
  - Verify --dry-run-output json produces valid structured JSON output
  - Verify normal serve mode is not affected by the refactoring
  - Run existing unit and integration tests: make test && make test-integration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local dry-run mode for running adapter workflows with mock API and transport clients
  * CLI flags to control dry-run event, API responses, discovery overrides, verbosity, and output format
  * Execution trace output (text or JSON) with optional verbose API/transport details
  * Dry-run input testdata for events, API responses, discovery, and configs

* **Documentation**
  * Expanded README with dry-run usage, flags table, input/output examples, and testdata references
  * Minor formatting and config-path clarifications

* **Bug Fixes / Improvements**
  * Resource identity now reported in execution results; serve/run flows unified for consistency

* **Tests**
  * Extensive unit tests for dry-run loaders, mock clients, transport, trace formatting, and concurrency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->