### PR TITLE
HYPERFLEET-653 - fix: rename generation variable

### DIFF
--- a/charts/examples/kubernetes/adapter-task-config.yaml
+++ b/charts/examples/kubernetes/adapter-task-config.yaml
@@ -56,7 +56,7 @@ spec:
       capture:
         - name: "clusterName"
           field: "name"
-        - name: "generationSpec"
+        - name: "generation"
           field: "generation"
         - name: "readyConditionStatus"
           expression: |
@@ -88,7 +88,7 @@ spec:
             hyperfleet.io/cluster-id: "{{ .clusterId }}"
             hyperfleet.io/cluster-name: "{{ .clusterName }}"
           annotations:
-            hyperfleet.io/generation: "{{ .generationSpec }}"
+            hyperfleet.io/generation: "{{ .generation }}"
       discovery:
         namespace: "*"  # Cluster-scoped resource (Namespace)
         bySelectors:
@@ -218,7 +218,7 @@ spec:
                   adapter.?errorMessage.orValue("") != "" ? adapter.?errorMessage.orValue("") : "All adapter operations in progress or completed successfully"
           # Event generation ID metadata field needs to use expression to avoid interpolation issues
           observed_generation:
-            expression: "generationSpec"
+            expression: "generation"
           observed_time: "{{ now | date \"2006-01-02T15:04:05Z07:00\" }}"
 
     postActions:

--- a/charts/examples/kubernetes/adapter-task-resource-deployment.yaml
+++ b/charts/examples/kubernetes/adapter-task-resource-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     hyperfleet.io/cluster-id: "{{ .clusterId }}"
     hyperfleet.io/resource-type: "deployment"
   annotations:
-    hyperfleet.io/generation: "{{ .generationSpec }}"
+    hyperfleet.io/generation: "{{ .generation }}"
 spec:
   replicas: 1
   selector:

--- a/charts/examples/kubernetes/adapter-task-resource-job-role.yaml
+++ b/charts/examples/kubernetes/adapter-task-resource-job-role.yaml
@@ -7,7 +7,7 @@ metadata:
     hyperfleet.io/cluster-id: "{{ .clusterId }}"
     hyperfleet.io/resource-type: "role"
   annotations:
-    hyperfleet.io/generation: "{{ .generationSpec }}"
+    hyperfleet.io/generation: "{{ .generation }}"
 rules:
   # Permission to get and update job status
   - apiGroups: [ "batch" ]

--- a/charts/examples/kubernetes/adapter-task-resource-job-serviceaccount.yaml
+++ b/charts/examples/kubernetes/adapter-task-resource-job-serviceaccount.yaml
@@ -7,4 +7,4 @@ metadata:
     hyperfleet.io/cluster-id: "{{ .clusterId }}"
     hyperfleet.io/resource-type: "service-account"
   annotations:
-    hyperfleet.io/generation: "{{ .generationSpec }}"
+    hyperfleet.io/generation: "{{ .generation }}"

--- a/charts/examples/kubernetes/adapter-task-resource-job.yaml
+++ b/charts/examples/kubernetes/adapter-task-resource-job.yaml
@@ -17,7 +17,7 @@ metadata:
     hyperfleet.io/cluster-id: "{{ .clusterId }}"
     hyperfleet.io/resource-type: "job"
   annotations:
-    hyperfleet.io/generation: "{{ .generationSpec }}"  # <- this gets resolved from adapterconfig params
+    hyperfleet.io/generation: "{{ .generation }}"  # <- this gets resolved from adapterconfig params
 spec:
   backoffLimit: 0
   activeDeadlineSeconds: 310  # 300 + 10 second buffer

--- a/configs/templates/cluster-status-payload.yaml
+++ b/configs/templates/cluster-status-payload.yaml
@@ -2,7 +2,7 @@
 # Used for reporting cluster status back to HyperFleet API
 status: "{{ .status }}"
 message: "{{ .message }}"
-observedGeneration: "{{ .generationSpec }}"
+observedGeneration: "{{ .generation }}"
 lastUpdated: "{{ now | date \"2006-01-02T15:04:05Z07:00\" }}"
 conditions:
   - type: "Ready"

--- a/configs/templates/job.yaml
+++ b/configs/templates/job.yaml
@@ -25,5 +25,5 @@ spec:
             - name: CLUSTER_ID
               value: "{{ .clusterId }}"
             - name: GENERATION_ID
-              value: "{{ .generationSpec }}"
+              value: "{{ .generation }}"
 

--- a/test/testdata/dryrun/dryrun-cel-showcase-task-config.yaml
+++ b/test/testdata/dryrun/dryrun-cel-showcase-task-config.yaml
@@ -40,7 +40,7 @@ spec:
       type: "string"
       default: "Cluster"
 
-    - name: "generationValue"
+    - name: "generation"
       source: "event.generation"
       type: "string"
       required: true
@@ -174,7 +174,7 @@ spec:
             hyperfleet.io/resource-type: "namespace"
           annotations:
             hyperfleet.io/created-by: "hyperfleet-adapter"
-            hyperfleet.io/generation: "{{ .generationValue }}"
+            hyperfleet.io/generation: "{{ .generation }}"
       discovery:
         byName: "{{ .clusterId | lower }}"
 
@@ -191,7 +191,7 @@ spec:
           labels:
             hyperfleet.io/cluster-id: "{{ .clusterId }}"
           annotations:
-            hyperfleet.io/generation: "{{ .generationValue }}"
+            hyperfleet.io/generation: "{{ .generation }}"
         data:
           cluster_id: "{{ .clusterId }}"
           cluster_name: "{{ .clusterName }}"
@@ -212,7 +212,7 @@ spec:
           labels:
             hyperfleet.io/cluster-id: "{{ .clusterId }}"
           annotations:
-            hyperfleet.io/generation: "{{ .generationValue }}"
+            hyperfleet.io/generation: "{{ .generation }}"
         data:
           feature_flags: "ha-enabled,auto-scaling,monitoring"
           max_replicas: "10"
@@ -306,7 +306,7 @@ spec:
 
           # Pattern 15: Go template rendering in payload values
           observed_generation:
-            expression: "generationSpec"
+            expression: "generation"
           observed_time: "{{ now | date \"2006-01-02T15:04:05Z07:00\" }}"
 
           data:

--- a/test/testdata/dryrun/dryrun-kubernetes-task-config.yaml
+++ b/test/testdata/dryrun/dryrun-kubernetes-task-config.yaml
@@ -20,7 +20,7 @@ spec:
       type: "string"
       default: "Cluster"
 
-    - name: "generationValue"
+    - name: "generation"
       source: "event.generation"
       type: "string"
       required: true
@@ -75,7 +75,7 @@ spec:
             hyperfleet.io/resource-type: "namespace"
           annotations:
             hyperfleet.io/created-by: "hyperfleet-adapter"
-            hyperfleet.io/generation: "{{ .generationValue }}"
+            hyperfleet.io/generation: "{{ .generation }}"
 
       discovery:
         byName: "{{ .clusterId | lower }}"
@@ -93,7 +93,7 @@ spec:
           labels:
             hyperfleet.io/cluster-id: "{{ .clusterId }}"
           annotations:
-            hyperfleet.io/generation: "{{ .generationValue }}"
+            hyperfleet.io/generation: "{{ .generation }}"
         data:
           cluster_id: "{{ .clusterId }}"
           cluster_name: "{{ .clusterName }}"
@@ -182,7 +182,7 @@ spec:
                     : "Adapter execution completed successfully"
 
           observed_generation:
-            expression: "generationSpec"
+            expression: "generation"
           observed_time: "{{ now | date \"2006-01-02T15:04:05Z07:00\" }}"
 
           data:

--- a/test/testdata/task-config.yaml
+++ b/test/testdata/task-config.yaml
@@ -41,7 +41,7 @@ spec:
             status.conditions.filter(c, c.type == "Ready").size() > 0
               ? status.conditions.filter(c, c.type == "Ready")[0].status
               : "False"
-        - name: "generationSpec"
+        - name: "generation"
           field: "generation"
       # Structured conditions with valid operators
       conditions:
@@ -61,7 +61,7 @@ spec:
             hyperfleet.io/cluster-id: "{{ .clusterId }}"
             hyperfleet.io/managed-by: "hyperfleet-adapter"
           annotations:
-            hyperfleet.io/generation: "{{ .generationSpec }}"
+            hyperfleet.io/generation: "{{ .generation }}"
       discovery:
         namespace: "*"
         byName: "{{ .clusterId | lower }}"
@@ -74,7 +74,7 @@ spec:
           name: "cluster-{{ .clusterId }}-config"
           namespace: "{{ .clusterId | lower }}"
           annotations:
-            hyperfleet.io/generation: "{{ .generationSpec }}"
+            hyperfleet.io/generation: "{{ .generation }}"
         data:
           cluster_id: "{{ .clusterId }}"
       discovery:
@@ -129,7 +129,7 @@ spec:
                   adapter.?errorMessage.orValue("") != "" ? adapter.?errorMessage.orValue("") : "All adapter operations in progress or completed successfully"
           # Event generation ID metadata field needs to use expression to avoid interpolation issues
           observed_generation:
-            expression: "generationSpec"
+            expression: "generation"
           observed_time: "{{ now | date \"2006-01-02T15:04:05Z07:00\" }}"
 
     postActions:


### PR DESCRIPTION
Small PR to rename the generation variable in the config-task files, since we had different names such as `generation`, `generationSpec` and `generationValue` which were confusing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized field naming conventions across configuration and deployment templates for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->