### PR TITLE
HYPERFLEET-596 - doc: unknown value

### DIFF
--- a/docs/adapter-authoring-guide.md
+++ b/docs/adapter-authoring-guide.md
@@ -576,7 +576,12 @@ The adapter reads status from the standard Kubernetes status subresource. The th
 
 The possible values for these conditions statuses are: `True`, `False` and `Unknown`.
 
-The `Unknown` value is used when there the condition value is still pending and there is no valid answer yet. Since adapters report always to the API, the status payload should account for this case.
+The `Unknown` value is used when there the condition value is still pending and there is no valid answer yet. Since adapters report always to the API, the status payload should account for this case:
+
+- If there are errors applying the resources
+- If conditions from resources are not conclusive
+
+When the HyperFleet API receives an status update with any of the mandatory condition's status to `Unknown` value, the API will not update the internal state. Therefore, Sentinel will keep emitting reconciliation events for status updates.
 
 **Applied** and **Available** are derived from your K8s object's status. **Health** reflects the adapter framework's own execution and uses the standard boilerplate (see section 8).
 


### PR DESCRIPTION
https://issues.redhat.com/browse/HYPERFLEET-596

- small updates to the authoring guide doc
- charts/examples/README.md rewritten as it was completely outdated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured Examples docs with a centralized section and a comparison table (kubernetes, maestro, maestro-kubernetes).
  * Shifted to a feature-focused listing with standardized headings (Common Configuration, Broker, Image, Usage).
  * Updated usage guidance to use example-specific values.yaml paths and revised Helm install commands.
  * Replaced detailed “How It Works” flow with a concise overview.
  * Clarified adapter status contract: expanded Unknown status criteria and noted API behavior when Unknown is reported (state not updated; reconciliation continues).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->