### PR TITLE
HYPERFLEET-660 - fix: discovery byName example

### DIFF
--- a/charts/examples/maestro-kubernetes/adapter-task-config.yaml
+++ b/charts/examples/maestro-kubernetes/adapter-task-config.yaml
@@ -87,7 +87,7 @@ spec:
       # With this approach, the manifestWork object can be used to get the resources inside the manifestWork.
       # When try to dig  Manifest
       discovery:
-        byName: "{{ .clusterId }}"
+        byName: "mw-{{ .clusterId }}"
 
       # Discover sub-resources within the manifestWork
       # This approach can be used to use the discovery name to parameter level

--- a/charts/examples/maestro-kubernetes/adapter-task-resource-manifestwork.yaml
+++ b/charts/examples/maestro-kubernetes/adapter-task-resource-manifestwork.yaml
@@ -17,7 +17,7 @@ apiVersion: work.open-cluster-management.io/v1
 kind: ManifestWork
 metadata:
   # ManifestWork name - must be unique within consumer namespace
-  name: "hyperfleet-cluster-setup-{{ .clusterId }}"
+  name: "mw-{{ .clusterId }}"
 
   # Labels for identification, filtering, and management
   labels:

--- a/charts/examples/maestro/adapter-task-config.yaml
+++ b/charts/examples/maestro/adapter-task-config.yaml
@@ -86,7 +86,7 @@ spec:
       # With this approach, the manifestWork object can be used to get the resources inside the manifestWork.
       # When try to dig  Manifest
       discovery:
-        byName: "{{ .clusterId }}"
+        byName: "mw-{{ .clusterId }}"
 
       # Discover sub-resources within the manifestWork
       # This approach can be used to use the discovery name to parameter level

--- a/charts/examples/maestro/adapter-task-resource-manifestwork.yaml
+++ b/charts/examples/maestro/adapter-task-resource-manifestwork.yaml
@@ -17,7 +17,7 @@ apiVersion: work.open-cluster-management.io/v1
 kind: ManifestWork
 metadata:
   # ManifestWork name - must be unique within consumer namespace
-  name: "hyperfleet-cluster-setup-{{ .clusterId }}"
+  name: "mw-{{ .clusterId }}"
 
   # Labels for identification, filtering, and management
   labels:


### PR DESCRIPTION
https://issues.redhat.com/browse/HYPERFLEET-660

- Fixes a mismatch between the discovery.byName value and the actual ManifestWork resource name in the maestro and maestro-kubernetes examples.
  - Renames the ManifestWork name from `hyperfleet-cluster-setup-{{ .clusterId }}` to `mw-{{ .clusterId }} `for consistency.
  - Updates discovery.byName to use `mw-{{ .clusterId }}` so it correctlyresolves to the actual resource name.

  Context

  The byName field in the adapter task config must match the name of the
  ManifestWork resource it targets. The examples had a stale name
  (hyperfleet-cluster-setup-{{ .clusterId }}), causing the discovery lookup
  to fail or point to a non-existent resource.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ManifestWork resource naming conventions across configuration examples, changing from longer descriptive names to a standardized "mw-" prefix pattern for improved consistency and resource identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->