### PR TITLE
HYPERFLEET-662 - fix: helm warning duplicated volume projection

### DIFF
--- a/charts/examples/kubernetes/adapter-config.yaml
+++ b/charts/examples/kubernetes/adapter-config.yaml
@@ -2,9 +2,9 @@
 apiVersion: hyperfleet.redhat.com/v1alpha1
 kind: AdapterConfig
 metadata:
-  name: example1-namespace
+  name: kubernetes-example
   labels:
-    hyperfleet.io/adapter-type: example1-namespace
+    hyperfleet.io/adapter-type: kubernetes-example
     hyperfleet.io/component: adapter
 spec:
   adapter:

--- a/charts/examples/kubernetes/adapter-task-config.yaml
+++ b/charts/examples/kubernetes/adapter-task-config.yaml
@@ -2,9 +2,9 @@
 apiVersion: hyperfleet.redhat.com/v1alpha1
 kind: AdapterTaskConfig
 metadata:
-  name: example1-namespace
+  name: kubernetes-example
   labels:
-    hyperfleet.io/adapter-type: example1-namespace
+    hyperfleet.io/adapter-type: kubernetes-example
     hyperfleet.io/component: adapter
 spec:
   # Parameters with all required variables

--- a/charts/examples/maestro-kubernetes/adapter-config.yaml
+++ b/charts/examples/maestro-kubernetes/adapter-config.yaml
@@ -2,9 +2,9 @@
 apiVersion: hyperfleet.redhat.com/v1alpha1
 kind: AdapterConfig
 metadata:
-  name: example1-namespace
+  name: maestro-kubernetes-example
   labels:
-    hyperfleet.io/adapter-type: example1-namespace
+    hyperfleet.io/adapter-type: maestro-kubernetes-example
     hyperfleet.io/component: adapter
 spec:
   adapter:

--- a/charts/examples/maestro-kubernetes/adapter-task-config.yaml
+++ b/charts/examples/maestro-kubernetes/adapter-task-config.yaml
@@ -2,9 +2,9 @@
 apiVersion: hyperfleet.redhat.com/v1alpha1
 kind: AdapterTaskConfig
 metadata:
-  name: example1-namespace
+  name: maestro-kubernetes-example
   labels:
-    hyperfleet.io/adapter-type: example1-namespace
+    hyperfleet.io/adapter-type: maestro-kubernetes-example
     hyperfleet.io/component: adapter
 spec:
   # Parameters with all required variables

--- a/charts/examples/maestro/adapter-config.yaml
+++ b/charts/examples/maestro/adapter-config.yaml
@@ -2,9 +2,9 @@
 apiVersion: hyperfleet.redhat.com/v1alpha1
 kind: AdapterConfig
 metadata:
-  name: example1-namespace
+  name: maestro-example
   labels:
-    hyperfleet.io/adapter-type: example1-namespace
+    hyperfleet.io/adapter-type: maestro-example
     hyperfleet.io/component: adapter
 spec:
   adapter:

--- a/charts/examples/maestro/adapter-task-config.yaml
+++ b/charts/examples/maestro/adapter-task-config.yaml
@@ -2,9 +2,9 @@
 apiVersion: hyperfleet.redhat.com/v1alpha1
 kind: AdapterTaskConfig
 metadata:
-  name: example1-namespace
+  name: maestro-example
   labels:
-    hyperfleet.io/adapter-type: example1-namespace
+    hyperfleet.io/adapter-type: maestro-example
     hyperfleet.io/component: adapter
 spec:
   # Parameters with all required variables

--- a/charts/examples/maestro/adapter-task-resource-manifestwork.yaml
+++ b/charts/examples/maestro/adapter-task-resource-manifestwork.yaml
@@ -39,7 +39,7 @@ metadata:
     app.kubernetes.io/version: "v1.0.0"
     app.kubernetes.io/component: "infrastructure"
     app.kubernetes.io/part-of: "hyperfleet"
-    app.kubernetes.io/managed-by: "hyperfleet-adapter"
+    app.kubernetes.io/managed-by: "{{ .adapterName }}"
     app.kubernetes.io/created-by: "{{ .adapterName }}"
 
   # Annotations for metadata and operational information

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -147,9 +147,6 @@ spec:
             sources:
               - configMap:
                   name: {{ include "hyperfleet-adapter.adapterConfigMapName" . }}
-                  items:
-                    - key: adapter-config.yaml
-                      path: adapter-config.yaml
               - configMap:
                   name: {{ include "hyperfleet-adapter.adapterTaskConfigMapName" . }}
               - configMap:


### PR DESCRIPTION
https://issues.redhat.com/browse/HYPERFLEET-662

Every `helm install` or `helm upgrade` of the adapter chart produces a Kubernetes warning about overlapping paths in the projected volume configuration. The `adapter-config.yaml` key from the same ConfigMap is listed twice in the projected volume sources.

File to check `charts/templates/deployment.yaml`


Note: all other changes are just for changing the adapter names in the example YAMLs
I just reused this PR to reduce review fatigue



