### PR TITLE
HYPERFLEET-663 - fix: Change owned_reference to owner_references

### DIFF
--- a/docs/adapter-authoring-guide.md
+++ b/docs/adapter-authoring-guide.md
@@ -1009,12 +1009,12 @@ NodePool adapters follow the same pattern as cluster adapters with a few differe
 
 ### Event structure
 
-NodePool events include an `owned_reference` pointing to the parent cluster:
+NodePool events include an `owner_references` pointing to the parent cluster:
 
 ```yaml
 params:
   - name: "clusterId"
-    source: "event.owned_reference.id"    # Parent cluster
+    source: "event.owner_references.id"    # Parent cluster
     type: "string"
     required: true
 

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -76,14 +76,14 @@ func (e *Executor) Execute(ctx context.Context, data interface{}) *ExecutionResu
 		}
 	}
 
-	// This is intended to set OwnerReference and ResourceID for the event when it exist
+	// This is intended to set OwnerReferences and ResourceID for the event when it exists
 	// For example, when a NodePool event arrived
 	// the logger will set the cluster_id=owner_id, nodepool_id=resource_id, resource_type=nodepool
 	// but when a resource is cluster type, it will just record cluster_id=resource_id
-	if eventData.OwnedReference != nil {
+	if eventData.OwnerReferences != nil {
 		ctx = logger.WithResourceType(ctx, eventData.Kind)
 		ctx = logger.WithDynamicResourceID(ctx, eventData.Kind, eventData.ID)
-		ctx = logger.WithDynamicResourceID(ctx, eventData.OwnedReference.Kind, eventData.OwnedReference.ID)
+		ctx = logger.WithDynamicResourceID(ctx, eventData.OwnerReferences.Kind, eventData.OwnerReferences.ID)
 	} else {
 		ctx = logger.WithDynamicResourceID(ctx, eventData.Kind, eventData.ID)
 	}

--- a/internal/executor/types.go
+++ b/internal/executor/types.go
@@ -47,11 +47,11 @@ type ResourceRef struct {
 
 // EventData represents the data payload of a HyperFleet CloudEvent
 type EventData struct {
-	ID             string       `json:"id,omitempty"`
-	Kind           string       `json:"kind,omitempty"`
-	Href           string       `json:"href,omitempty"`
-	Generation     int64        `json:"generation,omitempty"`
-	OwnedReference *ResourceRef `json:"owned_reference,omitempty"`
+	ID              string       `json:"id,omitempty"`
+	Kind            string       `json:"kind,omitempty"`
+	Href            string       `json:"href,omitempty"`
+	Generation      int64        `json:"generation,omitempty"`
+	OwnerReferences *ResourceRef `json:"owner_references,omitempty"`
 }
 
 // ExecutorConfig holds configuration for the executor


### PR DESCRIPTION
https://issues.redhat.com/browse/HYPERFLEET-663

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected ownership reference field naming to properly reflect parent cluster identification across configuration and documentation.

* **Documentation**
  * Updated adapter authoring guide with corrected ownership reference field naming in code examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->