### PR TITLE
HYPERFLEET-672 - fix: rabbitmq exchange type

### DIFF
--- a/charts/templates/configmap-broker.yaml
+++ b/charts/templates/configmap-broker.yaml
@@ -47,7 +47,8 @@ data:
         url: {{ .Values.broker.rabbitmq.url | quote }}
         queue: {{ .Values.broker.rabbitmq.queue | quote }}
         exchange: {{ .Values.broker.rabbitmq.exchange | quote }}
-        routingKey: {{ .Values.broker.rabbitmq.routingKey | quote }}
+        routing_key: {{ .Values.broker.rabbitmq.routingKey | quote }}
+        exchange_type: {{ .Values.broker.rabbitmq.exchangeType | default "topic" | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -80,6 +80,7 @@ broker:
   # url: ""
   # queue: ""
   # exchange: ""
+  # exchangeType: "topic"
   # routingKey: ""
 
 


### PR DESCRIPTION
https://issues.redhat.com/browse/HYPERFLEET-672

If we don't set the exchange_type to align with sentinel creating the topic, the adapter will fail saying that is receiving "topic" instead of "fanout"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable RabbitMQ exchange_type setting with default "topic" for broker configuration.

* **Bug Fixes**
  * Normalized broker routing field name to routing_key in generated configuration to ensure consistent config output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->