### PR TITLE
HYPERFLEET-679 - fix: examples use of namespace in discovery

### DIFF
--- a/charts/examples/kubernetes/adapter-task-config.yaml
+++ b/charts/examples/kubernetes/adapter-task-config.yaml
@@ -90,7 +90,6 @@ spec:
           annotations:
             hyperfleet.io/generation: "{{ .generation }}"
       discovery:
-        namespace: "*"  # Cluster-scoped resource (Namespace)
         bySelectors:
           labelSelector:
             hyperfleet.io/cluster-id: "{{ .clusterId }}"
@@ -116,7 +115,6 @@ spec:
       manifest:
         ref: "/etc/adapter/job-role.yaml"
       discovery:
-        namespace: "*"
         bySelectors:
           labelSelector:
             hyperfleet.io/cluster-id: "{{ .clusterId }}"
@@ -128,7 +126,6 @@ spec:
       manifest:
         ref: "/etc/adapter/job-rolebinding.yaml"
       discovery:
-        namespace: "*"
         bySelectors:
           labelSelector:
             hyperfleet.io/cluster-id: "{{ .clusterId }}"
@@ -140,7 +137,6 @@ spec:
       manifest:
         ref: "/etc/adapter/job.yaml"
       discovery:
-        namespace: "*"
         bySelectors:
           labelSelector:
             hyperfleet.io/cluster-id: "{{ .clusterId }}"
@@ -156,7 +152,6 @@ spec:
       manifest:
         ref: "/etc/adapter/deployment.yaml"
       discovery:
-        namespace: "*"
         bySelectors:
           labelSelector:
             hyperfleet.io/resource-type: "deployment"

--- a/docs/adapter-authoring-guide.md
+++ b/docs/adapter-authoring-guide.md
@@ -416,7 +416,7 @@ discovery:
 
 # By label selector
 discovery:
-  namespace: "{{ .clusterId }}"       # omit or "*" for cluster-scoped
+  namespace: "{{ .clusterId }}"       # omit for all namespaces / cluster-scoped
   bySelectors:
     labelSelector:
       hyperfleet.io/cluster-id: "{{ .clusterId }}"

--- a/test/testdata/dryrun/dryrun-maestro-adapter-task-config.yaml
+++ b/test/testdata/dryrun/dryrun-maestro-adapter-task-config.yaml
@@ -190,9 +190,8 @@ spec:
                 type: "ServerSideApply"
 
       discovery:
-        namespace: "*"
         #byName: "cluster-{{ .clusterId }}-config"
-        #byName: "manifestwork0"
+        #byName: "manifestwork-symbol000"
         bySelectors:
           labelSelector:
             maestro.io/resource-type: manifestwork
@@ -340,6 +339,6 @@ spec:
     postActions:
       - name: "update-status"
         apiCall:
-          method: "PATCH"
+          method: "POST"
           url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}/statuses"
           body: "{{ .statusPayload }}"


### PR DESCRIPTION
https://issues.redhat.com/browse/HYPERFLEET-572

- Small changes to make the examples in adapter repository functional.
Using `namespace: "*"` has no special meaning and looks for a literal namespace name of `*`
- `apiCall` was using `PATCH` for reporting to API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified namespace scoping behavior in discovery by label selector documentation.

* **Chores**
  * Refined discovery configuration to use selector-based filtering instead of wildcard namespace matching.
  * Updated adapter status endpoint method for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->