### PR TITLE
HYPERFLEET-583 - feat: add dead man's switch metrics for silent failure detection

### DIFF
--- a/pkg/health/metrics.go
+++ b/pkg/health/metrics.go
@@ -7,16 +7,20 @@ import (
 
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/logger"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // MetricsServer provides HTTP metrics endpoint for Prometheus.
 type MetricsServer struct {
-	server    *http.Server
-	log       logger.Logger
-	port      string
-	upGauge   prometheus.Gauge
-	buildInfo *prometheus.GaugeVec
+	server             *http.Server
+	log                logger.Logger
+	port               string
+	upGauge            prometheus.Gauge
+	buildInfo          *prometheus.GaugeVec
+	lastProcessedGauge prometheus.Gauge
+	lastSuccessGauge   prometheus.Gauge
+	lastFailureGauge   prometheus.Gauge
 }
 
 // MetricsConfig holds configuration for metrics registration.
@@ -27,7 +31,12 @@ type MetricsConfig struct {
 }
 
 // NewMetricsServer creates a new metrics server with required HyperFleet metrics.
+// Each server uses its own Prometheus registry to avoid conflicts.
 func NewMetricsServer(log logger.Logger, port string, cfg MetricsConfig) *MetricsServer {
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(collectors.NewGoCollector())
+	registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
+
 	// Create build_info metric per HyperFleet metrics standard
 	buildInfo := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -49,9 +58,43 @@ func NewMetricsServer(log logger.Logger, port string, cfg MetricsConfig) *Metric
 		},
 	)
 
+	// Dead man's switch: timestamp of last processed CloudEvent (regardless of outcome)
+	lastProcessedGauge := prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "hyperfleet_adapter_last_message_processed_timestamp",
+			Help: "Unix timestamp of the last processed CloudEvent (dead man's switch)",
+			ConstLabels: prometheus.Labels{
+				"component": cfg.Component,
+			},
+		},
+	)
+
+	lastSuccessGauge := prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "hyperfleet_adapter_last_message_success_timestamp",
+			Help: "Unix timestamp of the last CloudEvent that was processed successfully",
+			ConstLabels: prometheus.Labels{
+				"component": cfg.Component,
+			},
+		},
+	)
+
+	lastFailureGauge := prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "hyperfleet_adapter_last_message_failure_timestamp",
+			Help: "Unix timestamp of the last CloudEvent that failed processing",
+			ConstLabels: prometheus.Labels{
+				"component": cfg.Component,
+			},
+		},
+	)
+
 	// Register metrics
-	prometheus.MustRegister(buildInfo)
-	prometheus.MustRegister(upGauge)
+	registry.MustRegister(buildInfo)
+	registry.MustRegister(upGauge)
+	registry.MustRegister(lastProcessedGauge)
+	registry.MustRegister(lastSuccessGauge)
+	registry.MustRegister(lastFailureGauge)
 
 	// Set build_info to 1 (this is an info metric)
 	buildInfo.WithLabelValues(cfg.Component, cfg.Version, cfg.Commit).Set(1)
@@ -60,13 +103,16 @@ func NewMetricsServer(log logger.Logger, port string, cfg MetricsConfig) *Metric
 	upGauge.Set(1)
 
 	mux := http.NewServeMux()
-	mux.Handle("/metrics", promhttp.Handler())
+	mux.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
 
 	return &MetricsServer{
-		log:       log,
-		port:      port,
-		upGauge:   upGauge,
-		buildInfo: buildInfo,
+		log:                log,
+		port:               port,
+		upGauge:            upGauge,
+		buildInfo:          buildInfo,
+		lastProcessedGauge: lastProcessedGauge,
+		lastSuccessGauge:   lastSuccessGauge,
+		lastFailureGauge:   lastFailureGauge,
 		server: &http.Server{
 			Addr:              ":" + port,
 			Handler:           mux,
@@ -87,6 +133,22 @@ func (s *MetricsServer) Start(ctx context.Context) error {
 	}()
 
 	return nil
+}
+
+// RecordMessageProcessed updates the dead man's switch metric to the current time.
+// Call this after every CloudEvent is processed, regardless of outcome.
+func (s *MetricsServer) RecordMessageProcessed() {
+	s.lastProcessedGauge.SetToCurrentTime()
+}
+
+// RecordMessageSuccess updates the last success timestamp to the current time.
+func (s *MetricsServer) RecordMessageSuccess() {
+	s.lastSuccessGauge.SetToCurrentTime()
+}
+
+// RecordMessageFailure updates the last failure timestamp to the current time.
+func (s *MetricsServer) RecordMessageFailure() {
+	s.lastFailureGauge.SetToCurrentTime()
 }
 
 // Shutdown gracefully shuts down the metrics server.

--- a/pkg/health/metrics_test.go
+++ b/pkg/health/metrics_test.go
@@ -1,0 +1,183 @@
+package health
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestMetricsServer(t *testing.T) *MetricsServer {
+	t.Helper()
+	return NewMetricsServer(&mockLogger{}, "0", MetricsConfig{
+		Component: "test-adapter",
+		Version:   "v0.0.1-test",
+		Commit:    "abc123",
+	})
+}
+
+func getGaugeValue(t *testing.T, g prometheus.Gauge) float64 {
+	t.Helper()
+	ch := make(chan prometheus.Metric, 1)
+	g.Collect(ch)
+	m := <-ch
+	metric := &dto.Metric{}
+	require.NoError(t, m.Write(metric))
+	return metric.GetGauge().GetValue()
+}
+
+func TestMetricsServer_RecordMessageProcessed_UpdatesTimestamp(t *testing.T) {
+	ms := newTestMetricsServer(t)
+
+	before := float64(time.Now().Unix())
+	ms.RecordMessageProcessed()
+	after := float64(time.Now().Unix())
+
+	val := getGaugeValue(t, ms.lastProcessedGauge)
+	assert.GreaterOrEqual(t, val, before, "timestamp should be >= time before call")
+	assert.LessOrEqual(t, val, after+1, "timestamp should be <= time after call")
+}
+
+func TestMetricsServer_RecordMessageProcessed_AdvancesTimestamp(t *testing.T) {
+	ms := newTestMetricsServer(t)
+
+	ms.RecordMessageProcessed()
+	first := getGaugeValue(t, ms.lastProcessedGauge)
+
+	time.Sleep(10 * time.Millisecond)
+
+	ms.RecordMessageProcessed()
+	second := getGaugeValue(t, ms.lastProcessedGauge)
+
+	assert.GreaterOrEqual(t, second, first, "second call should produce >= timestamp")
+}
+
+func TestMetricsServer_LastProcessedGauge_ZeroBeforeFirstCall(t *testing.T) {
+	ms := newTestMetricsServer(t)
+	val := getGaugeValue(t, ms.lastProcessedGauge)
+	assert.Equal(t, float64(0), val, "gauge should be 0 before any message is processed")
+}
+
+func TestMetricsServer_RecordMessageSuccess_UpdatesTimestamp(t *testing.T) {
+	ms := newTestMetricsServer(t)
+
+	before := float64(time.Now().Unix())
+	ms.RecordMessageSuccess()
+	after := float64(time.Now().Unix())
+
+	val := getGaugeValue(t, ms.lastSuccessGauge)
+	assert.GreaterOrEqual(t, val, before)
+	assert.LessOrEqual(t, val, after+1)
+}
+
+func TestMetricsServer_RecordMessageFailure_UpdatesTimestamp(t *testing.T) {
+	ms := newTestMetricsServer(t)
+
+	before := float64(time.Now().Unix())
+	ms.RecordMessageFailure()
+	after := float64(time.Now().Unix())
+
+	val := getGaugeValue(t, ms.lastFailureGauge)
+	assert.GreaterOrEqual(t, val, before)
+	assert.LessOrEqual(t, val, after+1)
+}
+
+func TestMetricsServer_SuccessAndFailure_Independent(t *testing.T) {
+	ms := newTestMetricsServer(t)
+
+	ms.RecordMessageSuccess()
+	successVal := getGaugeValue(t, ms.lastSuccessGauge)
+	failureVal := getGaugeValue(t, ms.lastFailureGauge)
+
+	assert.Greater(t, successVal, float64(0), "success gauge should be updated")
+	assert.Equal(t, float64(0), failureVal, "failure gauge should remain 0")
+
+	ms.RecordMessageFailure()
+	failureVal = getGaugeValue(t, ms.lastFailureGauge)
+	assert.Greater(t, failureVal, float64(0), "failure gauge should now be updated")
+}
+
+func TestMetricsServer_MetricsEndpoint_ExposesAllMetrics(t *testing.T) {
+	ms := newTestMetricsServer(t)
+
+	ms.RecordMessageProcessed()
+	ms.RecordMessageSuccess()
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	w := httptest.NewRecorder()
+	ms.server.Handler.ServeHTTP(w, req)
+
+	resp := w.Result()
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body := w.Body.String()
+	assert.True(t, strings.Contains(body, "hyperfleet_adapter_up"), "should expose up metric")
+	assert.True(t, strings.Contains(body, "hyperfleet_adapter_build_info"), "should expose build_info metric")
+	assert.True(t, strings.Contains(body, "hyperfleet_adapter_last_message_processed_timestamp"),
+		"should expose last_message_processed_timestamp metric")
+	assert.True(t, strings.Contains(body, "hyperfleet_adapter_last_message_success_timestamp"),
+		"should expose last_message_success_timestamp metric")
+	assert.True(t, strings.Contains(body, `component="test-adapter"`),
+		"metric should include component label")
+}
+
+func TestMetricsServer_MetricsEndpoint_ExposesDefaultCollectors(t *testing.T) {
+	ms := newTestMetricsServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	w := httptest.NewRecorder()
+	ms.server.Handler.ServeHTTP(w, req)
+
+	body := w.Body.String()
+	assert.True(t, strings.Contains(body, "go_goroutines"), "should expose Go runtime metrics")
+	assert.True(t, strings.Contains(body, "process_cpu_seconds_total"), "should expose process metrics")
+}
+
+func TestMetricsServer_Shutdown_SetsUpToZero(t *testing.T) {
+	ms := newTestMetricsServer(t)
+
+	val := getGaugeValue(t, ms.upGauge)
+	assert.Equal(t, float64(1), val, "up gauge should be 1 before shutdown")
+
+	err := ms.Shutdown(context.Background())
+	require.NoError(t, err)
+
+	val = getGaugeValue(t, ms.upGauge)
+	assert.Equal(t, float64(0), val, "up gauge should be 0 after shutdown")
+}
+
+func TestMetricsServer_Lifecycle(t *testing.T) {
+	port := "19090"
+	ms := NewMetricsServer(&mockLogger{}, port, MetricsConfig{
+		Component: "lifecycle-test",
+		Version:   "v0.0.1",
+		Commit:    "def456",
+	})
+
+	ctx := context.Background()
+	err := ms.Start(ctx)
+	require.NoError(t, err)
+
+	time.Sleep(50 * time.Millisecond)
+
+	ms.RecordMessageProcessed()
+	ms.RecordMessageSuccess()
+
+	resp, err := http.Get("http://localhost:" + port + "/metrics")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err = ms.Shutdown(shutdownCtx)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary

- Add three Prometheus gauge metrics to detect silent failures where the adapter is running but not processing messages:
  - `hyperfleet_adapter_last_message_processed_timestamp` — dead man's switch, updated on every processed CloudEvent
  - `hyperfleet_adapter_last_message_success_timestamp` — updated only on successful execution
  - `hyperfleet_adapter_last_message_failure_timestamp` — updated only on failed execution
- Extend `CreateHandler` with an optional `onResult` callback so the caller can observe the `ExecutionResult` without coupling the executor to metrics
- Refactor `MetricsServer` to use a dedicated Prometheus registry with Go/process collectors

## Test plan

- [x] Unit tests for all three metrics (timestamp updates, independence, zero before first call)
- [x] Unit test verifying `/metrics` endpoint exposes all metrics including Go/process collectors
- [x] Unit test for `CreateHandler` callback: receives `StatusSuccess` on valid event, `StatusFailed` on invalid event, no-op when no callback provided
- [x] Existing health server and executor tests pass unchanged
- [x] `go build`, `go vet`, `golangci-lint` all clean

Jira: https://issues.redhat.com/browse/HYPERFLEET-583

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added timestamp metrics tracking when messages are last processed, successfully handled, and failed. These metrics enable better monitoring and alerting on message processing status.
  * Enhanced metrics collection with per-server registries and improved observability.

* **Tests**
  * Added comprehensive test coverage for message processing metrics and callback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->