### PR TITLE
HYPERFLEET-450 - feat: add Prometheus metrics for event processing

### DIFF
--- a/cmd/adapter/main.go
+++ b/cmd/adapter/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/transport_client"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/health"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/logger"
+	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/metrics"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/otel"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/version"
 	"github.com/openshift-hyperfleet/hyperfleet-broker/broker"
@@ -334,12 +335,13 @@ func createMaestroClient(ctx context.Context, maestroConfig *config_loader.Maest
 }
 
 // buildExecutor creates the executor with the given clients.
-func buildExecutor(config *config_loader.Config, apiClient hyperfleet_api.Client, tc transport_client.TransportClient, log logger.Logger) (*executor.Executor, error) {
+func buildExecutor(config *config_loader.Config, apiClient hyperfleet_api.Client, tc transport_client.TransportClient, log logger.Logger, recorder *metrics.Recorder) (*executor.Executor, error) {
 	return executor.NewBuilder().
 		WithConfig(config).
 		WithAPIClient(apiClient).
 		WithTransportClient(tc).
 		WithLogger(log).
+		WithMetricsRecorder(recorder).
 		Build()
 }
 
@@ -442,6 +444,9 @@ func runServe() error {
 		}
 	}()
 
+	// Create adapter metrics recorder
+	metricsRecorder := metrics.NewRecorder(config.Metadata.Name, version.Version, nil)
+
 	// Create real clients
 	log.Info(ctx, "Creating HyperFleet API client...")
 	apiClient, err := createAPIClient(config.Spec.Clients.HyperfleetAPI, log)
@@ -460,7 +465,7 @@ func runServe() error {
 
 	// Build executor
 	log.Info(ctx, "Creating event executor...")
-	exec, err := buildExecutor(config, apiClient, tc, log)
+	exec, err := buildExecutor(config, apiClient, tc, log, metricsRecorder)
 	if err != nil {
 		errCtx := logger.WithErrorField(ctx, err)
 		log.Errorf(errCtx, "Failed to create executor")
@@ -643,8 +648,8 @@ func runDryRun() error {
 		dryrunClient = dryrun.NewDryrunTransportClient()
 	}
 
-	// Build executor with mock clients (same builder as serve)
-	exec, err := buildExecutor(config, dryrunAPI, dryrunClient, log)
+	// Build executor with mock clients (same builder as serve, no metrics in dry-run)
+	exec, err := buildExecutor(config, dryrunAPI, dryrunClient, log, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create executor: %w", err)
 	}

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,8 +1,84 @@
 # Observability
 
+All metrics are exposed on the `/metrics` endpoint (port 9090) in Prometheus format. No additional configuration is needed.
+
+## Adapter Metrics
+
+The adapter exposes Prometheus metrics following the [HyperFleet Metrics Standard](https://github.com/openshift-hyperfleet/architecture/blob/main/hyperfleet/standards/metrics.md) with the `hyperfleet_adapter_` prefix.
+
+All adapter metrics include `component` and `version` as constant labels.
+
+### Baseline Metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `hyperfleet_adapter_build_info` | Gauge | `component`, `version`, `commit` | Build information (always 1) |
+| `hyperfleet_adapter_up` | Gauge | `component`, `version` | Whether the adapter is up and running (1=up, 0=shutting down) |
+
+### Event Processing Metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `hyperfleet_adapter_events_processed_total` | Counter | `component`, `version`, `status` | Total CloudEvents processed. Status: `success`, `failed`, `skipped` |
+| `hyperfleet_adapter_event_processing_duration_seconds` | Histogram | `component`, `version` | End-to-end event processing duration |
+| `hyperfleet_adapter_errors_total` | Counter | `component`, `version`, `error_type` | Total errors by execution phase |
+
+#### Status Values
+
+| Status | Description |
+|--------|-------------|
+| `success` | Event processed successfully with resources applied |
+| `skipped` | Event processed successfully but resources skipped (preconditions not met) |
+| `failed` | Event processing failed due to an error |
+
+#### Error Types
+
+The `error_type` label on `hyperfleet_adapter_errors_total` corresponds to the execution phase where the error occurred:
+
+| Error Type | Description |
+|------------|-------------|
+| `param_extraction` | Failed to extract parameters from the event |
+| `preconditions` | Precondition evaluation error (not the same as precondition not met) |
+| `resources` | Failed to apply Kubernetes resources |
+| `post_actions` | Failed to execute post-actions (e.g., status reporting) |
+
+#### Histogram Buckets
+
+The `event_processing_duration_seconds` histogram uses the following buckets (in seconds), as recommended by the [adapter metrics standard](https://github.com/openshift-hyperfleet/architecture/blob/main/hyperfleet/components/adapter/framework/adapter-metrics.md):
+
+```text
+0.1, 0.5, 1, 2, 5, 10, 30, 60, 120
+```
+
+### Example PromQL Queries
+
+Event processing success rate:
+
+```promql
+(
+  sum(rate(hyperfleet_adapter_events_processed_total{status="success"}[5m]))
+  /
+  sum(rate(hyperfleet_adapter_events_processed_total[5m]))
+) * 100
+```
+
+p95 event processing duration:
+
+```promql
+histogram_quantile(0.95,
+  rate(hyperfleet_adapter_event_processing_duration_seconds_bucket[5m])
+)
+```
+
+Error rate by phase:
+
+```promql
+sum by (error_type) (rate(hyperfleet_adapter_errors_total[5m]))
+```
+
 ## Broker Metrics
 
-The adapter automatically registers Prometheus metrics from the broker library on the `/metrics` endpoint (port 9090). No additional configuration is needed.
+The adapter automatically registers Prometheus metrics from the [hyperfleet-broker](https://github.com/openshift-hyperfleet/hyperfleet-broker) library.
 
 ### Available Metrics
 

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -7,11 +7,14 @@ import (
 	"reflect"
 	"strings"
 
+	"time"
+
 	"github.com/cloudevents/sdk-go/v2/event"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/config_loader"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/hyperfleet_api"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/transport_client"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/logger"
+	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/metrics"
 	pkgotel "github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/otel"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
@@ -256,12 +259,38 @@ func (e *Executor) CreateHandler() func(ctx context.Context, evt *event.Event) e
 		e.log.Infof(ctx, "Event received: id=%s type=%s source=%s time=%s",
 			evt.ID(), evt.Type(), evt.Source(), evt.Time())
 
-		_ = e.Execute(ctx, evt.Data())
+		start := time.Now()
+		result := e.Execute(ctx, evt.Data())
+		duration := time.Since(start)
+
+		e.recordMetrics(result, duration)
 
 		e.log.Infof(ctx, "Event processed: type=%s source=%s time=%s",
 			evt.Type(), evt.Source(), evt.Time())
 
 		return nil
+	}
+}
+
+// recordMetrics records Prometheus metrics based on the execution result.
+func (e *Executor) recordMetrics(result *ExecutionResult, duration time.Duration) {
+	recorder := e.config.MetricsRecorder
+	if recorder == nil {
+		return
+	}
+
+	recorder.ObserveProcessingDuration(duration)
+
+	switch {
+	case result.Status == StatusFailed:
+		recorder.RecordEventProcessed("failed")
+		for phase := range result.Errors {
+			recorder.RecordError(string(phase))
+		}
+	case result.ResourcesSkipped:
+		recorder.RecordEventProcessed("skipped")
+	default:
+		recorder.RecordEventProcessed("success")
 	}
 }
 
@@ -344,6 +373,12 @@ func (b *ExecutorBuilder) WithTransportClient(client transport_client.TransportC
 // WithLogger sets the logger
 func (b *ExecutorBuilder) WithLogger(log logger.Logger) *ExecutorBuilder {
 	b.config.Logger = log
+	return b
+}
+
+// WithMetricsRecorder sets the Prometheus metrics recorder
+func (b *ExecutorBuilder) WithMetricsRecorder(recorder *metrics.Recorder) *ExecutorBuilder {
+	b.config.MetricsRecorder = recorder
 	return b
 }
 

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/cloudevents/sdk-go/v2/event"
@@ -10,6 +11,9 @@ import (
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/hyperfleet_api"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/k8s_client"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/logger"
+	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -778,4 +782,176 @@ func TestSequentialExecution_SkipReasonCapture(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestCreateHandler_MetricsRecording verifies that CreateHandler records Prometheus metrics
+func TestCreateHandler_MetricsRecording(t *testing.T) {
+	tests := []struct {
+		name           string
+		preconditions  []config_loader.Precondition
+		expectedStatus string // "success", "skipped", or "failed"
+		expectedErrors []string
+	}{
+		{
+			name:           "success records success metric",
+			preconditions:  []config_loader.Precondition{},
+			expectedStatus: "success",
+		},
+		{
+			name: "skipped records skipped metric",
+			preconditions: []config_loader.Precondition{
+				{ActionBase: config_loader.ActionBase{Name: "check"}, Expression: "false"},
+			},
+			expectedStatus: "skipped",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := prometheus.NewRegistry()
+			recorder := metrics.NewRecorder("test-adapter", "v0.1.0", registry)
+
+			config := &config_loader.Config{
+				Metadata: config_loader.Metadata{Name: "test-adapter"},
+				Spec:     config_loader.ConfigSpec{Preconditions: tt.preconditions},
+			}
+
+			exec, err := NewBuilder().
+				WithConfig(config).
+				WithAPIClient(newMockAPIClient()).
+				WithTransportClient(k8s_client.NewMockK8sClient()).
+				WithLogger(logger.NewTestLogger()).
+				WithMetricsRecorder(recorder).
+				Build()
+			require.NoError(t, err)
+
+			handler := exec.CreateHandler()
+
+			evt := event.New()
+			evt.SetID("test-event-1")
+			evt.SetType("com.hyperfleet.test")
+			evt.SetSource("test")
+			eventData := map[string]interface{}{"id": "cluster-1"}
+			eventBytes, _ := json.Marshal(eventData)
+			_ = evt.SetData(event.ApplicationJSON, eventBytes)
+
+			err = handler(context.Background(), &evt)
+			require.NoError(t, err, "handler should always return nil")
+
+			// Verify events_processed_total
+			families, err := registry.Gather()
+			require.NoError(t, err)
+
+			eventsCount := getCounterValue(t, families, "hyperfleet_adapter_events_processed_total", "status", tt.expectedStatus)
+			assert.Equal(t, float64(1), eventsCount, "expected 1 event with status %s", tt.expectedStatus)
+
+			// Verify duration was recorded
+			durationFamily := findFamily(families, "hyperfleet_adapter_event_processing_duration_seconds")
+			require.NotNil(t, durationFamily, "duration metric should exist")
+			histogram := durationFamily.GetMetric()[0].GetHistogram()
+			assert.Equal(t, uint64(1), histogram.GetSampleCount(), "expected 1 duration sample")
+		})
+	}
+}
+
+// TestCreateHandler_MetricsRecording_Failed verifies error metrics are recorded on failure
+func TestCreateHandler_MetricsRecording_Failed(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	recorder := metrics.NewRecorder("test-adapter", "v0.1.0", registry)
+
+	config := &config_loader.Config{
+		Metadata: config_loader.Metadata{Name: "test-adapter"},
+		Spec: config_loader.ConfigSpec{
+			Params: []config_loader.Parameter{
+				{Name: "required", Source: "env.MISSING_VAR", Required: true},
+			},
+		},
+	}
+
+	exec, err := NewBuilder().
+		WithConfig(config).
+		WithAPIClient(newMockAPIClient()).
+		WithTransportClient(k8s_client.NewMockK8sClient()).
+		WithLogger(logger.NewTestLogger()).
+		WithMetricsRecorder(recorder).
+		Build()
+	require.NoError(t, err)
+
+	handler := exec.CreateHandler()
+
+	evt := event.New()
+	evt.SetID("test-event-fail")
+	evt.SetType("com.hyperfleet.test")
+	evt.SetSource("test")
+	eventData := map[string]interface{}{"id": "cluster-1"}
+	eventBytes, _ := json.Marshal(eventData)
+	_ = evt.SetData(event.ApplicationJSON, eventBytes)
+
+	err = handler(context.Background(), &evt)
+	require.NoError(t, err, "handler should always return nil even on failure")
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+
+	// Verify failed event was recorded
+	failedCount := getCounterValue(t, families, "hyperfleet_adapter_events_processed_total", "status", "failed")
+	assert.Equal(t, float64(1), failedCount, "expected 1 failed event")
+
+	// Verify error was recorded with phase label
+	errorCount := getCounterValue(t, families, "hyperfleet_adapter_errors_total", "error_type", "param_extraction")
+	assert.Equal(t, float64(1), errorCount, "expected 1 param_extraction error")
+}
+
+// TestCreateHandler_NilMetricsRecorder verifies handler works without a metrics recorder
+func TestCreateHandler_NilMetricsRecorder(t *testing.T) {
+	config := &config_loader.Config{
+		Metadata: config_loader.Metadata{Name: "test-adapter"},
+	}
+
+	exec, err := NewBuilder().
+		WithConfig(config).
+		WithAPIClient(newMockAPIClient()).
+		WithTransportClient(k8s_client.NewMockK8sClient()).
+		WithLogger(logger.NewTestLogger()).
+		Build()
+	require.NoError(t, err)
+
+	handler := exec.CreateHandler()
+
+	evt := event.New()
+	evt.SetID("test-event-nil")
+	evt.SetType("com.hyperfleet.test")
+	evt.SetSource("test")
+	_ = evt.SetData(event.ApplicationJSON, []byte(`{"id":"cluster-1"}`))
+
+	assert.NotPanics(t, func() {
+		_ = handler(context.Background(), &evt)
+	}, "handler with nil MetricsRecorder should not panic")
+}
+
+// helper functions for metrics assertions
+
+func findFamily(families []*dto.MetricFamily, name string) *dto.MetricFamily {
+	for _, f := range families {
+		if f.GetName() == name {
+			return f
+		}
+	}
+	return nil
+}
+
+func getCounterValue(t *testing.T, families []*dto.MetricFamily, metricName, labelName, labelValue string) float64 {
+	t.Helper()
+	family := findFamily(families, metricName)
+	if family == nil {
+		t.Fatalf("metric %s not found", metricName)
+	}
+	for _, m := range family.GetMetric() {
+		for _, l := range m.GetLabel() {
+			if l.GetName() == labelName && l.GetValue() == labelValue {
+				return m.GetCounter().GetValue()
+			}
+		}
+	}
+	return 0
 }

--- a/internal/executor/types.go
+++ b/internal/executor/types.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/manifest"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/transport_client"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/logger"
+	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/metrics"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -64,6 +65,8 @@ type ExecutorConfig struct {
 	TransportClient transport_client.TransportClient
 	// Logger is the logger instance
 	Logger logger.Logger
+	// MetricsRecorder records adapter-level Prometheus metrics (nil disables recording)
+	MetricsRecorder *metrics.Recorder
 }
 
 // Executor processes CloudEvents according to the adapter configuration

--- a/pkg/health/metrics_test.go
+++ b/pkg/health/metrics_test.go
@@ -5,7 +5,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/metrics"
 	"github.com/openshift-hyperfleet/hyperfleet-broker/broker"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -74,4 +76,86 @@ func TestBrokerMetricsExposedOnMetricsEndpoint(t *testing.T) {
 		"errors_total metric should be exposed on /metrics")
 	assert.Contains(t, metricsOutput, "hyperfleet_broker_message_duration_seconds",
 		"message_duration_seconds metric should be exposed on /metrics")
+}
+
+func TestAdapterMetricsExposedOnMetricsEndpoint(t *testing.T) {
+	registry := prometheus.NewRegistry()
+
+	// Register baseline adapter metrics (same as NewMetricsServer)
+	buildInfo := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "hyperfleet_adapter_build_info",
+			Help: "Build information for the adapter",
+		},
+		[]string{"component", "version", "commit"},
+	)
+	upGauge := prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "hyperfleet_adapter_up",
+			Help: "Whether the adapter is up and running",
+			ConstLabels: prometheus.Labels{
+				"component": "test-adapter",
+				"version":   "v0.1.0-test",
+			},
+		},
+	)
+	registry.MustRegister(buildInfo)
+	registry.MustRegister(upGauge)
+	buildInfo.WithLabelValues("test-adapter", "v0.1.0-test", "abc123").Set(1)
+	upGauge.Set(1)
+
+	// Register adapter event metrics using the same registry
+	recorder := metrics.NewRecorder("test-adapter", "v0.1.0-test", registry)
+
+	// Simulate adapter activity
+	recorder.RecordEventProcessed("success")
+	recorder.RecordEventProcessed("failed")
+	recorder.RecordEventProcessed("skipped")
+	recorder.ObserveProcessingDuration(500 * time.Millisecond)
+	recorder.RecordError("preconditions")
+
+	// Serve metrics from the shared registry
+	handler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	resp := w.Result()
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	metricsOutput := string(body)
+
+	// Verify baseline metrics
+	assert.Contains(t, metricsOutput, "hyperfleet_adapter_build_info")
+	assert.Contains(t, metricsOutput, "hyperfleet_adapter_up")
+
+	// Verify new adapter metrics
+	assert.Contains(t, metricsOutput, "hyperfleet_adapter_events_processed_total",
+		"events_processed_total metric should be exposed on /metrics")
+	assert.Contains(t, metricsOutput, "hyperfleet_adapter_event_processing_duration_seconds",
+		"event_processing_duration_seconds metric should be exposed on /metrics")
+	assert.Contains(t, metricsOutput, "hyperfleet_adapter_errors_total",
+		"errors_total metric should be exposed on /metrics")
+
+	// Verify status label values are present
+	assert.Contains(t, metricsOutput, `status="success"`,
+		"success status should be in output")
+	assert.Contains(t, metricsOutput, `status="failed"`,
+		"failed status should be in output")
+	assert.Contains(t, metricsOutput, `status="skipped"`,
+		"skipped status should be in output")
+
+	// Verify error_type label
+	assert.Contains(t, metricsOutput, `error_type="preconditions"`,
+		"preconditions error_type should be in output")
+
+	// Verify component and version labels are present on new metrics
+	assert.Contains(t, metricsOutput, `component="test-adapter"`,
+		"component label should be in output")
+	assert.Contains(t, metricsOutput, `version="v0.1.0-test"`,
+		"version label should be in output")
 }

--- a/pkg/metrics/recorder.go
+++ b/pkg/metrics/recorder.go
@@ -1,0 +1,99 @@
+// Package metrics provides Prometheus metrics recording for the HyperFleet adapter.
+// It follows the HyperFleet Metrics Standard with the hyperfleet_adapter_ prefix.
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Recorder registers and records adapter-level Prometheus metrics.
+// All methods are nil-safe: calling methods on a nil *Recorder is a no-op,
+// which allows dry-run mode to skip metrics without nil checks at every call site.
+type Recorder struct {
+	eventsProcessed    *prometheus.CounterVec
+	processingDuration prometheus.Observer
+	errorsTotal        *prometheus.CounterVec
+}
+
+// NewRecorder creates a new Recorder and registers metrics with the given registerer.
+// If reg is nil, prometheus.DefaultRegisterer is used.
+func NewRecorder(component, version string, reg prometheus.Registerer) *Recorder {
+	if reg == nil {
+		reg = prometheus.DefaultRegisterer
+	}
+
+	eventsProcessed := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "hyperfleet_adapter_events_processed_total",
+			Help: "Total number of CloudEvents processed by the adapter",
+			ConstLabels: prometheus.Labels{
+				"component": component,
+				"version":   version,
+			},
+		},
+		[]string{"status"},
+	)
+
+	processingDuration := prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "hyperfleet_adapter_event_processing_duration_seconds",
+			Help:    "Duration of event processing in seconds",
+			Buckets: []float64{0.1, 0.5, 1, 2, 5, 10, 30, 60, 120},
+			ConstLabels: prometheus.Labels{
+				"component": component,
+				"version":   version,
+			},
+		},
+	)
+
+	errorsTotal := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "hyperfleet_adapter_errors_total",
+			Help: "Total number of errors encountered by the adapter",
+			ConstLabels: prometheus.Labels{
+				"component": component,
+				"version":   version,
+			},
+		},
+		[]string{"error_type"},
+	)
+
+	reg.MustRegister(eventsProcessed)
+	reg.MustRegister(processingDuration)
+	reg.MustRegister(errorsTotal)
+
+	return &Recorder{
+		eventsProcessed:    eventsProcessed,
+		processingDuration: processingDuration,
+		errorsTotal:        errorsTotal,
+	}
+}
+
+// RecordEventProcessed increments the events_processed_total counter for the given status.
+// Valid status values: "success", "failed", "skipped".
+func (r *Recorder) RecordEventProcessed(status string) {
+	if r == nil {
+		return
+	}
+	r.eventsProcessed.WithLabelValues(status).Inc()
+}
+
+// ObserveProcessingDuration records the event processing duration in seconds.
+func (r *Recorder) ObserveProcessingDuration(d time.Duration) {
+	if r == nil {
+		return
+	}
+	r.processingDuration.Observe(d.Seconds())
+}
+
+// RecordError increments the errors_total counter for the given error type.
+// Error types correspond to execution phases: "param_extraction", "preconditions",
+// "resources", "post_actions".
+func (r *Recorder) RecordError(errorType string) {
+	if r == nil {
+		return
+	}
+	r.errorsTotal.WithLabelValues(errorType).Inc()
+}

--- a/pkg/metrics/recorder_test.go
+++ b/pkg/metrics/recorder_test.go
@@ -1,0 +1,190 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRecorder(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	recorder := NewRecorder("test-adapter", "v0.1.0", registry)
+	require.NotNil(t, recorder)
+
+	// Trigger all metrics so they appear in Gather()
+	recorder.RecordEventProcessed("success")
+	recorder.ObserveProcessingDuration(1 * time.Millisecond)
+	recorder.RecordError("test")
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+
+	names := make(map[string]bool)
+	for _, f := range families {
+		names[f.GetName()] = true
+	}
+
+	assert.True(t, names["hyperfleet_adapter_events_processed_total"],
+		"events_processed_total should be registered")
+	assert.True(t, names["hyperfleet_adapter_event_processing_duration_seconds"],
+		"event_processing_duration_seconds should be registered")
+	assert.True(t, names["hyperfleet_adapter_errors_total"],
+		"errors_total should be registered")
+}
+
+func TestRecordEventProcessed(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	recorder := NewRecorder("test-adapter", "v0.1.0", registry)
+
+	recorder.RecordEventProcessed("success")
+	recorder.RecordEventProcessed("success")
+	recorder.RecordEventProcessed("failed")
+	recorder.RecordEventProcessed("skipped")
+	recorder.RecordEventProcessed("skipped")
+	recorder.RecordEventProcessed("skipped")
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+
+	var eventsFamily *dto.MetricFamily
+	for _, f := range families {
+		if f.GetName() == "hyperfleet_adapter_events_processed_total" {
+			eventsFamily = f
+			break
+		}
+	}
+	require.NotNil(t, eventsFamily, "events_processed_total metric family should exist")
+
+	counts := make(map[string]float64)
+	for _, m := range eventsFamily.GetMetric() {
+		for _, l := range m.GetLabel() {
+			if l.GetName() == "status" {
+				counts[l.GetValue()] = m.GetCounter().GetValue()
+			}
+		}
+	}
+
+	assert.Equal(t, float64(2), counts["success"], "success count")
+	assert.Equal(t, float64(1), counts["failed"], "failed count")
+	assert.Equal(t, float64(3), counts["skipped"], "skipped count")
+}
+
+func TestRecordEventProcessed_ConstLabels(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	recorder := NewRecorder("my-adapter", "v1.2.3", registry)
+
+	recorder.RecordEventProcessed("success")
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+
+	var eventsFamily *dto.MetricFamily
+	for _, f := range families {
+		if f.GetName() == "hyperfleet_adapter_events_processed_total" {
+			eventsFamily = f
+			break
+		}
+	}
+	require.NotNil(t, eventsFamily)
+
+	// Verify component and version ConstLabels are present
+	m := eventsFamily.GetMetric()[0]
+	labels := make(map[string]string)
+	for _, l := range m.GetLabel() {
+		labels[l.GetName()] = l.GetValue()
+	}
+
+	assert.Equal(t, "my-adapter", labels["component"], "component label")
+	assert.Equal(t, "v1.2.3", labels["version"], "version label")
+}
+
+func TestObserveProcessingDuration(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	recorder := NewRecorder("test-adapter", "v0.1.0", registry)
+
+	recorder.ObserveProcessingDuration(500 * time.Millisecond)
+	recorder.ObserveProcessingDuration(2 * time.Second)
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+
+	var durationFamily *dto.MetricFamily
+	for _, f := range families {
+		if f.GetName() == "hyperfleet_adapter_event_processing_duration_seconds" {
+			durationFamily = f
+			break
+		}
+	}
+	require.NotNil(t, durationFamily, "event_processing_duration_seconds metric family should exist")
+
+	m := durationFamily.GetMetric()[0]
+	histogram := m.GetHistogram()
+	require.NotNil(t, histogram)
+
+	assert.Equal(t, uint64(2), histogram.GetSampleCount(), "sample count")
+	assert.InDelta(t, 2.5, histogram.GetSampleSum(), 0.01, "sample sum")
+
+	// Verify bucket boundaries match expected values
+	expectedBuckets := []float64{0.1, 0.5, 1, 2, 5, 10, 30, 60, 120}
+	buckets := histogram.GetBucket()
+	require.Len(t, buckets, len(expectedBuckets), "number of buckets")
+	for i, b := range buckets {
+		assert.Equal(t, expectedBuckets[i], b.GetUpperBound(), "bucket %d upper bound", i)
+	}
+}
+
+func TestRecordError(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	recorder := NewRecorder("test-adapter", "v0.1.0", registry)
+
+	recorder.RecordError("param_extraction")
+	recorder.RecordError("preconditions")
+	recorder.RecordError("preconditions")
+	recorder.RecordError("resources")
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+
+	var errorsFamily *dto.MetricFamily
+	for _, f := range families {
+		if f.GetName() == "hyperfleet_adapter_errors_total" {
+			errorsFamily = f
+			break
+		}
+	}
+	require.NotNil(t, errorsFamily, "errors_total metric family should exist")
+
+	counts := make(map[string]float64)
+	for _, m := range errorsFamily.GetMetric() {
+		for _, l := range m.GetLabel() {
+			if l.GetName() == "error_type" {
+				counts[l.GetValue()] = m.GetCounter().GetValue()
+			}
+		}
+	}
+
+	assert.Equal(t, float64(1), counts["param_extraction"], "param_extraction error count")
+	assert.Equal(t, float64(2), counts["preconditions"], "preconditions error count")
+	assert.Equal(t, float64(1), counts["resources"], "resources error count")
+}
+
+func TestNilRecorderNoPanic(t *testing.T) {
+	var recorder *Recorder
+
+	// All methods should be no-ops and not panic
+	assert.NotPanics(t, func() {
+		recorder.RecordEventProcessed("success")
+	}, "RecordEventProcessed on nil recorder")
+
+	assert.NotPanics(t, func() {
+		recorder.ObserveProcessingDuration(1 * time.Second)
+	}, "ObserveProcessingDuration on nil recorder")
+
+	assert.NotPanics(t, func() {
+		recorder.RecordError("test_error")
+	}, "RecordError on nil recorder")
+}


### PR DESCRIPTION
## Summary

- Add `hyperfleet_adapter_events_processed_total` counter with `status` label (success/failed/skipped)
- Add `hyperfleet_adapter_event_processing_duration_seconds` histogram with standard adapter buckets
- Add `hyperfleet_adapter_errors_total` counter with `error_type` label (by execution phase)
- Create `pkg/metrics` package with nil-safe `Recorder` (no-op in dry-run mode)
- Instrument `CreateHandler()` to record metrics after each event execution
- Update `docs/observability.md` with full metrics documentation and PromQL examples

## Test plan

- [x] Unit tests for `Recorder` registration and value recording (`pkg/metrics/recorder_test.go`)
- [x] Unit tests for `CreateHandler()` metrics integration - success, skipped, failed scenarios (`internal/executor/executor_test.go`)
- [x] Unit test verifying nil `MetricsRecorder` does not panic
- [x] Integration test verifying new metrics appear on `/metrics` endpoint (`pkg/health/metrics_test.go`)
- [x] `make test` passes
- [x] `make lint` passes (0 issues)

Ref: https://issues.redhat.com/browse/HYPERFLEET-450

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Prometheus-based metrics collection for event processing, including event counts, processing duration, and error tracking with detailed labels and status classifications.

* **Documentation**
  * Updated observability documentation with metrics endpoint details, baseline metrics, PromQL examples, and comprehensive metric reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->