### PR TITLE
HYPERFLEET-723 - fix: standardize version handling to avoid go-toolset base image collision

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
 ARG GIT_SHA=unknown
 ARG GIT_DIRTY=""
 ARG BUILD_DATE=""
-ARG VERSION=""
+ARG APP_VERSION="0.0.0-dev"
 
 # Install make as root (UBI9 go-toolset doesn't include it), then switch back to non-root.
 USER root
@@ -29,7 +29,7 @@ COPY --chown=1001:0 . .
 RUN --mount=type=cache,target=/opt/app-root/src/go/pkg/mod,uid=1001 \
     --mount=type=cache,target=/opt/app-root/src/.cache/go-build,uid=1001 \
     CGO_ENABLED=0 GOOS=linux \
-    GIT_SHA=${GIT_SHA} GIT_DIRTY=${GIT_DIRTY} BUILD_DATE=${BUILD_DATE} VERSION=${VERSION} \
+    GIT_SHA=${GIT_SHA} GIT_DIRTY=${GIT_DIRTY} BUILD_DATE=${BUILD_DATE} \
     make build
 
 # Runtime stage
@@ -46,9 +46,9 @@ EXPOSE 8080
 ENTRYPOINT ["/app/adapter"]
 CMD ["serve"]
 
-ARG VERSION=""
+ARG APP_VERSION="0.0.0-dev"
 LABEL name="hyperfleet-adapter" \
       vendor="Red Hat" \
-      version="${VERSION}" \
+      version="${APP_VERSION}" \
       summary="HyperFleet Adapter - Event-driven adapter services for HyperFleet cluster provisioning" \
       description="Handles CloudEvents consumption, AdapterConfig CRD integration, precondition evaluation, Kubernetes Job creation/monitoring, and status reporting via API"

--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,13 @@ BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 GIT_SHA ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 GIT_DIRTY ?= $(shell [ -z "$$(git status --porcelain 2>/dev/null)" ] || echo "-modified")
 GIT_TAG ?= $(shell git describe --tags --exact-match 2>/dev/null || echo "")
-VERSION ?= $(GIT_SHA)$(GIT_DIRTY)
+APP_VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "0.0.0-dev")
 
 # Go build flags
 GOFLAGS ?= -trimpath
 VERSION_PKG := github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/version
 LDFLAGS := -s -w \
-           -X $(VERSION_PKG).Version=$(VERSION) \
+           -X $(VERSION_PKG).Version=$(APP_VERSION) \
            -X $(VERSION_PKG).Commit=$(GIT_SHA) \
            -X $(VERSION_PKG).BuildDate=$(BUILD_DATE)
 ifneq ($(GIT_TAG),)
@@ -39,7 +39,7 @@ DEV_BASE_IMAGE ?= registry.access.redhat.com/ubi9/ubi-minimal:latest
 # =============================================================================
 IMAGE_REGISTRY ?= quay.io/openshift-hyperfleet
 IMAGE_NAME ?= hyperfleet-adapter
-IMAGE_TAG ?= $(VERSION)
+IMAGE_TAG ?= $(APP_VERSION)
 
 # Dev image configuration - set QUAY_USER to push to personal registry
 # Usage: QUAY_USER=myuser make image-dev
@@ -210,7 +210,7 @@ image: check-container-tool ## Build container image
 		--build-arg GIT_SHA=$(GIT_SHA) \
 		--build-arg GIT_DIRTY=$(GIT_DIRTY) \
 		--build-arg BUILD_DATE=$(BUILD_DATE) \
-		--build-arg VERSION=$(VERSION) \
+		--build-arg APP_VERSION=$(APP_VERSION) \
 		-t $(IMAGE_REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG) .
 	@echo "Image built: $(IMAGE_REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)"
 
@@ -237,7 +237,7 @@ endif
 		--build-arg GIT_SHA=$(GIT_SHA) \
 		--build-arg GIT_DIRTY=$(GIT_DIRTY) \
 		--build-arg BUILD_DATE=$(BUILD_DATE) \
-		--build-arg VERSION=$(VERSION) \
+		--build-arg APP_VERSION=$(APP_VERSION) \
 		-t quay.io/$(QUAY_USER)/$(IMAGE_NAME):$(DEV_TAG) .
 	@echo "Pushing dev image..."
 	$(CONTAINER_TOOL) push quay.io/$(QUAY_USER)/$(IMAGE_NAME):$(DEV_TAG)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,7 +11,7 @@ const EnvUserAgent = "HYPERFLEET_USER_AGENT"
 // Example: go build -ldflags "-X github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/version.Version=1.0.0"
 var (
 	// Version is the semantic version of the adapter
-	Version = "0.1.0"
+	Version = "0.0.0-dev"
 
 	// Commit is the git commit SHA
 	Commit = "none"


### PR DESCRIPTION
## Summary

- Rename `VERSION` to `APP_VERSION` in Makefile to avoid collision with ubi9/go-toolset base image `ENV VERSION=<go-version>`
- Add `ENV VERSION=${APP_VERSION}` in Dockerfile to override the base image's env
- Set default version to `0.0.0-dev` for builds without ldflags
- Simplify Dockerfile RUN command (no conditional shell logic needed)

## Problem

The `ubi9/go-toolset:1.25` base image sets `ENV VERSION=1.25.7`. When the Makefile uses `VERSION ?=`, the base image's env takes precedence inside the container, causing the binary to report the Go toolchain version instead of the app version. This broke the adapter's config version validation (`config "0.1.0" != adapter "1.25.7"`).

## Version behavior after this change

| Build method | Version result |
|-------------|----------------|
| `go build ./cmd/...` (no ldflags) | `0.0.0-dev` |
| `make build` (local dev) | `v0.1.0-N-gabcdef` (git describe) |
| `make image-dev` (dev container) | `v0.1.0-N-gabcdef` (git describe) |
| `make image-push APP_VERSION=v0.1.1` (release) | `v0.1.1` |

## Test plan

- [x] `make image-dev` — version from git describe, not `1.25.7`
- [x] `make image APP_VERSION=v0.1.1` — version is `v0.1.1`
- [x] `podman build` with no args — version is `0.0.0-dev`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated version handling across build and image tooling, standardizing on a single APP_VERSION variable.
  * Default application version string changed to "0.0.0-dev".
  * Built images and runtime metadata now report the unified APP_VERSION value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->