### PR TITLE
HYPERFLEET-730 - fix: copy CA certificates from builder to ubi9-micro runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,8 @@ FROM ${BASE_IMAGE}
 
 WORKDIR /app
 
+# ubi9-micro doesn't include CA certificates; copy from builder for TLS (e.g. Google Pub/Sub)
+COPY --from=builder /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 COPY --from=builder /build/bin/hyperfleet-adapter /app/adapter
 
 USER 65532:65532


### PR DESCRIPTION
## Summary
- Copy CA trust bundle from builder stage to ubi9-micro runtime image
- Fixes TLS failures (`x509: certificate signed by unknown authority`) when connecting to external services (e.g. Google Pub/Sub)
- `ubi9-micro` is extremely minimal and doesn't include CA certificates; Go static binaries (`CGO_ENABLED=0`) need system CA certs for TLS verification

## Test plan
- [x] Verified adapter connects to Google Pub/Sub successfully with rebuilt image
- [ ] CI passes

Fixes: [HYPERFLEET-730](https://issues.redhat.com/browse/HYPERFLEET-730)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TLS certificate verification in production runtime environments. Secure connections to external services now function properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->