### PR TITLE
HYPERFLEET-728: skip version validation for 0.0.0-dev dev builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,8 @@ test-helm: ## Test Helm charts (lint, template, validate)
 		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set podDisruptionBudget.enabled=true \
-		--set podDisruptionBudget.minAvailable=1 > /dev/null
+		--set podDisruptionBudget.minAvailable=1 \
+		--set podDisruptionBudget.maxUnavailable=null > /dev/null
 	@echo "PDB config template OK"
 	@echo ""
 	@echo "Testing template with autoscaling..."

--- a/internal/config_loader/loader_test.go
+++ b/internal/config_loader/loader_test.go
@@ -718,6 +718,16 @@ func TestValidateAdapterVersion(t *testing.T) {
 	err = ValidateAdapterVersion(config, "")
 	assert.NoError(t, err)
 
+	// Dev build versions (0.0.0-* skip validation)
+	err = ValidateAdapterVersion(config, "0.0.0-dev")
+	assert.NoError(t, err)
+
+	err = ValidateAdapterVersion(config, "0.0.0-master")
+	assert.NoError(t, err)
+
+	err = ValidateAdapterVersion(config, "v0.0.0-dev")
+	assert.NoError(t, err)
+
 	// Pre-release version with same major.minor - should pass
 	err = ValidateAdapterVersion(config, "1.0.1-rc.1")
 	assert.NoError(t, err)

--- a/internal/config_loader/validator.go
+++ b/internal/config_loader/validator.go
@@ -653,6 +653,11 @@ func ValidateAdapterVersion(config *AdapterConfig, expectedVersion string) error
 		return fmt.Errorf("invalid expected adapter version %q: %w", expectedVersion, err)
 	}
 
+	// Skip validation for dev builds (0.0.0-*) where major, minor, and patch are all zero
+	if expectedSemver.Major() == 0 && expectedSemver.Minor() == 0 && expectedSemver.Patch() == 0 {
+		return nil
+	}
+
 	if configSemver.Major() != expectedSemver.Major() || configSemver.Minor() != expectedSemver.Minor() {
 		return fmt.Errorf("adapter version mismatch: config %q (major.minor=%d.%d) != adapter %q (major.minor=%d.%d)",
 			configVersion, configSemver.Major(), configSemver.Minor(),


### PR DESCRIPTION
Local builds without git tags default to version 0.0.0-dev, which fails ValidateAdapterVersion against the config's adapter version. Skip validation when the binary version is 0.0.0-dev, matching the existing behavior for empty version strings.

Also fix test-helm PDB test that failed when setting minAvailable without clearing the default maxUnavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Adapter version validation now supports development and pre-release versions following 0.0.0-* patterns (e.g., 0.0.0-dev, 0.0.0-master).

* **Tests**
  * Added test coverage for development version validation patterns.

* **Chores**
  * Updated Helm test template configuration for pod disruption budget settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->