### PR TITLE
HYPERFLEET-734 - fix: use 0.0.0-dev version for dev image builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,7 @@ endif
 		--build-arg GIT_SHA=$(GIT_SHA) \
 		--build-arg GIT_DIRTY=$(GIT_DIRTY) \
 		--build-arg BUILD_DATE=$(BUILD_DATE) \
-		--build-arg APP_VERSION=$(APP_VERSION) \
+		--build-arg APP_VERSION=0.0.0-dev \
 		-t quay.io/$(QUAY_USER)/$(IMAGE_NAME):$(DEV_TAG) .
 	@echo "Pushing dev image..."
 	$(CONTAINER_TOOL) push quay.io/$(QUAY_USER)/$(IMAGE_NAME):$(DEV_TAG)


### PR DESCRIPTION
## Summary

- Override `APP_VERSION` to `0.0.0-dev` in the `image-dev` Makefile target instead of using `git describe --tags`
- Dev images should not carry release tag version strings

## Jira

https://issues.redhat.com/browse/HYPERFLEET-734

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->