### PR TITLE
HYPERFLEET-586 - feat: add ServiceMonitor and Service for Prometheus discovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,34 @@ test-helm: ## Test Helm charts (lint, template, validate)
 		--set readinessProbe.enabled=true \
 		--set startupProbe.enabled=true > /dev/null
 	@echo "Probes config template OK"
+	@echo ""
+	@echo "Testing template with ServiceMonitor enabled..."
+	@helm template test-release charts/ \
+		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
+		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
+		--set serviceMonitor.enabled=true \
+		--api-versions monitoring.coreos.com/v1/ServiceMonitor | grep -q 'kind: ServiceMonitor' \
+		|| { echo "ERROR: ServiceMonitor not rendered"; exit 1; }
+	@echo "ServiceMonitor enabled template OK"
+	@echo ""
+	@echo "Testing template with ServiceMonitor enabled but CRD unavailable..."
+	@output=$$(helm template test-release charts/ \
+		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
+		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
+		--set serviceMonitor.enabled=true) \
+		&& ! echo "$$output" | grep -q 'kind: ServiceMonitor' \
+		|| { echo "ERROR: ServiceMonitor rendered without CRD"; exit 1; }
+	@echo "ServiceMonitor CRD-missing template OK"
+	@echo ""
+	@echo "Testing template with ServiceMonitor disabled..."
+	@output=$$(helm template test-release charts/ \
+		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
+		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
+		--set serviceMonitor.enabled=false \
+		--api-versions monitoring.coreos.com/v1/ServiceMonitor) \
+		&& ! echo "$$output" | grep -q 'kind: ServiceMonitor' \
+		|| { echo "ERROR: ServiceMonitor rendered while disabled"; exit 1; }
+	@echo "ServiceMonitor disabled template OK"
 
 ##@ Code Quality
 

--- a/charts/templates/service.yaml
+++ b/charts/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "hyperfleet-adapter.fullname" . }}
+  labels:
+    {{- include "hyperfleet-adapter.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    {{- range .Values.containerPorts }}
+    - port: {{ .containerPort }}
+      targetPort: {{ .name }}
+      protocol: {{ .protocol | default "TCP" }}
+      name: {{ .name }}
+    {{- end }}
+  selector:
+    {{- include "hyperfleet-adapter.selectorLabels" . | nindent 4 }}

--- a/charts/templates/servicemonitor.yaml
+++ b/charts/templates/servicemonitor.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor") }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "hyperfleet-adapter.fullname" . }}
+  {{- if .Values.serviceMonitor.namespace | trim }}
+  namespace: {{ .Values.serviceMonitor.namespace | trim }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    {{- include "hyperfleet-adapter.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "hyperfleet-adapter.selectorLabels" . | nindent 6 }}
+  {{- if not (empty .Values.serviceMonitor.namespaceSelector) }}
+  namespaceSelector:
+    {{- toYaml .Values.serviceMonitor.namespaceSelector | nindent 4 }}
+  {{- else if .Values.serviceMonitor.namespace | trim }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  {{- end }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      honorLabels: {{ .Values.serviceMonitor.honorLabels }}
+      {{- with .Values.serviceMonitor.metricRelabeling }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -254,3 +254,32 @@ strategy:
 # Termination grace period in seconds
 terminationGracePeriodSeconds: 30
 tolerations: []
+
+# ServiceMonitor for Prometheus Operator discovery
+# Enables automatic scraping of the adapter's /metrics endpoint.
+# Requires the Prometheus Operator CRDs (monitoring.coreos.com/v1/ServiceMonitor) to be installed.
+# NOTE: Defaults to true. On clusters with Prometheus Operator CRDs, upgrading to this
+# chart version will automatically create a ServiceMonitor. On clusters without the CRDs
+# the resource is silently skipped. Set to false to opt out.
+serviceMonitor:
+  enabled: true
+  # Scrape interval
+  interval: 30s
+  # Scrape timeout (must be less than interval)
+  scrapeTimeout: 10s
+  # Additional labels for ServiceMonitor to match Prometheus selector
+  # Example: release: prometheus
+  labels: {}
+  # Honor labels from the target to avoid overwriting
+  honorLabels: true
+  # Metric relabel configs to apply to samples before ingestion
+  metricRelabeling: []
+  # Namespace selector for cross-namespace monitoring
+  # Example:
+  #   matchNames:
+  #     - hyperfleet-system
+  namespaceSelector: {}
+  # Override the namespace where ServiceMonitor is created (defaults to release namespace).
+  # When set, a namespaceSelector.matchNames is automatically added pointing to the
+  # release namespace so Prometheus can discover the Service across namespaces.
+  namespace: ""

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -2,6 +2,8 @@
 
 All metrics are exposed on the `/metrics` endpoint (port 9090) in Prometheus format. No additional configuration is needed.
 
+The Helm chart includes a **ServiceMonitor** template for automatic discovery by the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator). It is enabled by default (`serviceMonitor.enabled: true`) and scrapes the `/metrics` endpoint every 30s with `honorLabels: true` to preserve the adapter's `component` and `version` labels. The template is only rendered when the Prometheus Operator CRDs (`monitoring.coreos.com/v1/ServiceMonitor`) are available on the cluster; otherwise it is silently skipped. See the Helm `values.yaml` for configuration options (interval, scrapeTimeout, labels, namespaceSelector).
+
 ## Adapter Metrics
 
 The adapter exposes Prometheus metrics following the [HyperFleet Metrics Standard](https://github.com/openshift-hyperfleet/architecture/blob/main/hyperfleet/standards/metrics.md) with the `hyperfleet_adapter_` prefix.


### PR DESCRIPTION
## Summary

- Add `charts/templates/service.yaml`: ClusterIP Service exposing health (8080) and metrics (9090) ports for the adapter
- Add `charts/templates/servicemonitor.yaml`: ServiceMonitor for automatic Prometheus Operator discovery with configurable interval, timeout, labels, and cross-namespace support
- Update `charts/values.yaml`: add `serviceMonitor` configuration block (enabled by default)
- Update `docs/observability.md`: document ServiceMonitor availability and CRD auto-detection behavior
- Update `Makefile`: add Helm tests for both ServiceMonitor enabled and disabled paths

### Key design decisions

- **CRD capability check**: ServiceMonitor template uses `.Capabilities.APIVersions.Has "monitoring.coreos.com/v1"` — silently skipped on clusters without Prometheus Operator instead of failing
- **`honorLabels: true`**: preserves the adapter's `component` and `version` constant labels, which are required by all PromQL alert expressions in `docs/metrics.md`
- **Service is unconditional**: useful for `kubectl port-forward`, internal health checks, and future integrations beyond just ServiceMonitor
- **Namespace trimming**: guards against whitespace in `serviceMonitor.namespace` values
- **Empty `namespaceSelector`**: uses `not (empty ...)` check to avoid rendering `namespaceSelector: {}` when unset

## Test plan

- [ ] `make test-helm` passes all 8 template tests (including ServiceMonitor enabled with `--api-versions` and disabled)
- [ ] Deploy to GKE cluster with Prometheus Operator CRDs installed — verify Service, ServiceMonitor, and metrics endpoint
- [ ] Deploy to cluster without Prometheus Operator CRDs — verify chart installs without error (ServiceMonitor silently skipped)
- [ ] Verify `honorLabels: true` preserves `component`/`version` labels in scraped metrics

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prometheus Operator ServiceMonitor support with configurable enable toggle, scrape interval, timeout, labels, namespace selector, and metric relabeling
  * Kubernetes Service added with ClusterIP and customizable container ports

* **Documentation**
  * Expanded Observability docs: metrics overview, baseline & event metrics, broker metrics, histogram buckets, labels, and example PromQL queries

* **Chores**
  * Helm template tests validating ServiceMonitor rendering when enabled, disabled, or monitoring support is unavailable
<!-- end of auto-generated comment: release notes by coderabbit.ai -->