### PR TITLE
HYPERFLEET-763 - feat: Add  `now()` Custom CEL Function for Time-Based ditions

### DIFF
--- a/internal/criteria/cel_evaluator.go
+++ b/internal/criteria/cel_evaluator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
@@ -122,6 +123,16 @@ func customCELFunctions() []cel.EnvOption {
 						return types.NullValue
 					}
 					return types.DefaultTypeAdapter.NativeToValue(found)
+				}),
+			),
+		),
+		cel.Function("now",
+			cel.Overload(
+				"now_string",
+				[]*cel.Type{},
+				cel.StringType,
+				cel.FunctionBinding(func(args ...ref.Val) ref.Val {
+					return types.String(time.Now().Format(time.RFC3339))
 				}),
 			),
 		),

--- a/internal/criteria/cel_evaluator_test.go
+++ b/internal/criteria/cel_evaluator_test.go
@@ -3,6 +3,7 @@ package criteria
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/logger"
 	"github.com/stretchr/testify/assert"
@@ -337,6 +338,29 @@ func TestCELEvaluatorCustomFunctions(t *testing.T) {
 
 	t.Run("dig returns null for missing path", func(t *testing.T) {
 		result, err := evaluator.EvaluateSafe(`dig(resources, "managedCluster.status.missing") == null`)
+		require.NoError(t, err)
+		require.False(t, result.HasError())
+		assert.Equal(t, true, result.Value)
+		assert.True(t, result.Matched)
+	})
+
+	t.Run("now returns RFC3339 timestamp", func(t *testing.T) {
+		result, err := evaluator.EvaluateSafe(`now()`)
+		require.NoError(t, err)
+		require.False(t, result.HasError())
+
+		timestamp, ok := result.Value.(string)
+		require.True(t, ok, "now() should return a string")
+		assert.NotEmpty(t, timestamp)
+
+		// Verify it's a valid RFC3339 timestamp by parsing it
+		_, parseErr := time.Parse(time.RFC3339, timestamp)
+		assert.NoError(t, parseErr, "now() should return a valid RFC3339 timestamp")
+	})
+
+	t.Run("now can be used with timestamp() for time calculations", func(t *testing.T) {
+		// Test that now() can be converted to timestamp type and used in calculations
+		result, err := evaluator.EvaluateSafe(`timestamp(now()).getFullYear() >= 2024`)
 		require.NoError(t, err)
 		require.False(t, result.HasError())
 		assert.Equal(t, true, result.Value)

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -580,6 +580,65 @@ func TestSequentialExecution_Preconditions(t *testing.T) {
 	}
 }
 
+// TestPrecondition_CustomCELFunctions tests that custom CEL functions (like now()) are available in precondition expressions
+func TestPrecondition_CustomCELFunctions(t *testing.T) {
+	tests := []struct {
+		name        string
+		expression  string
+		shouldMatch bool
+	}{
+		{
+			name:        "now() returns valid timestamp",
+			expression:  `timestamp(now()).getFullYear() >= 2024`,
+			shouldMatch: true,
+		},
+		{
+			name:        "now() can be used in time comparisons",
+			expression:  `(timestamp(now()) - timestamp("2020-01-01T00:00:00Z")).getSeconds() > 0`,
+			shouldMatch: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &config_loader.Config{
+				Adapter: config_loader.AdapterInfo{
+					Name:    "test-adapter",
+					Version: "1.0.0",
+				},
+				Preconditions: []config_loader.Precondition{
+					{ActionBase: config_loader.ActionBase{Name: "test-custom-function"}, Expression: tt.expression},
+				},
+			}
+
+			exec, err := NewBuilder().
+				WithConfig(config).
+				WithAPIClient(newMockAPIClient()).
+				WithTransportClient(k8s_client.NewMockK8sClient()).
+				WithLogger(logger.NewTestLogger()).
+				Build()
+			require.NoError(t, err, "failed to create executor")
+
+			ctx := logger.WithEventID(context.Background(), "test-custom-cel")
+			result := exec.Execute(ctx, map[string]interface{}{})
+
+			// Verify precondition executed
+			require.Len(t, result.PreconditionResults, 1, "expected one precondition result")
+			precondResult := result.PreconditionResults[0]
+
+			// Verify the expression evaluated correctly
+			assert.Equal(t, tt.shouldMatch, precondResult.Matched, "unexpected match result")
+			assert.Equal(t, StatusSuccess, precondResult.Status, "expected precondition status to be success")
+
+			if tt.shouldMatch {
+				// If precondition matched, resources should have been attempted
+				assert.Equal(t, StatusSuccess, result.Status, "expected overall status success")
+				assert.False(t, result.ResourcesSkipped, "resources should not be skipped")
+			}
+		})
+	}
+}
+
 // TestSequentialExecution_Resources tests that resources stop on first failure
 func TestSequentialExecution_Resources(t *testing.T) {
 	// Note: This test uses dry-run mode and focuses on the sequential logic


### PR DESCRIPTION
# Summary
- Add  `now()` Custom CEL Function for Time-Based ditions

# Testing
- `make test-all` passed
- The new built dev image can work well with the passed log.
```
time=2026-03-13T08:36:24.667Z level=DEBUG msg="Evaluating CEL expression: readyCondition == null || readyCondition.status != \"True\" ||\n(timestamp(currentTime) - timestamp(readyCondition.last_transition_time)).getSeconds() >= TTL_EXPIRY_THRESHOLD" component=cl-job version=v0.1.1-dirty hostname=adapter-clusters-cl-job-6868645549-ld7m9 event_id=a12e79ca-484c-44f8-83b5-d5b6b09f9429 trace_id=b6c8ae918a46a05342b1db86fee559a5 span_id=da43d4265d2e7988 cluster_id=2p0lte3ga0gefgnl66pb1em99hoe1jv2
time=2026-03-13T08:36:24.667Z level=DEBUG msg="CEL result: matched=true value=true" component=cl-job version=v0.1.1-dirty hostname=adapter-clusters-cl-job-6868645549-ld7m9 cluster_id=2p0lte3ga0gefgnl66pb1em99hoe1jv2 event_id=a12e79ca-484c-44f8-83b5-d5b6b09f9429 trace_id=b6c8ae918a46a05342b1db86fee559a5 span_id=da43d4265d2e7988
time=2026-03-13T08:36:24.667Z level=INFO msg="Precondition[validationCheck] evaluated: MET" component=cl-job version=v0.1.1-dirty hostname=adapter-clusters-cl-job-6868645549-ld7m9 event_id=a12e79ca-484c-44f8-83b5-d5b6b09f9429 trace_id=b6c8ae918a46a05342b1db86fee559a5 span_id=da43d4265d2e7988 cluster_id=2p0lte3ga0gefgnl66pb1em99hoe1jv2
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `now()` CEL function that returns the current timestamp in RFC3339 format, enabling time-based expressions and calculations within preconditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->