### PR TITLE
HYPERFLEET-769 - fix: enable revive linter and resolve lint violations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,6 @@
-# HyperFleet Adapter golangci-lint v2 Configuration
-# Required linters (16):
-# - Code Quality (9): errcheck, govet, staticcheck, ineffassign, unused, unconvert, unparam, goconst, exhaustive
-# - Code Style (6): gofmt, goimports, misspell, lll, revive, gocritic
-# - Security (1): gosec
+# HyperFleet Adapter - golangci-lint configuration
+# Follows HyperFleet architecture linting standards
+# Aligned with: https://github.com/openshift-hyperfleet/architecture/blob/main/hyperfleet/standards/golangci.yml
 
 version: "2"
 
@@ -36,9 +34,12 @@ linters:
       check-type-assertions: true
       check-blank: true
 
+    govet:
+      enable-all: true
+
     goconst:
       min-len: 3
-      min-occurrences: 4
+      min-occurrences: 3
 
     misspell:
       locale: US
@@ -49,28 +50,22 @@ linters:
       line-length: 120
 
     revive:
-      confidence: 0.1
       rules:
         - name: exported
-          disabled: true
+          severity: warning
+          disabled: true  # Can be too noisy for internal packages
+        - name: unexported-return
+          severity: warning
+          disabled: false
         - name: var-naming
-          disabled: true
-        - name: package-comments
-          disabled: true
-        - name: unused-parameter
-          disabled: true
-        - name: indent-error-flow
-          disabled: true
-        - name: empty-block
-          disabled: true
-        - name: context-as-argument
-          disabled: true
-        - name: redefines-builtin-id
-          disabled: true
+          severity: warning
+          disabled: false
+
+    unparam:
+      check-exported: false
 
     exhaustive:
       default-signifies-exhaustive: true
-      default-case-required: false
 
     gocritic:
       disabled-checks:
@@ -80,7 +75,7 @@ linters:
         - exitAfterDefer
 
   exclusions:
-    generated: strict
+    generated: lax
     presets:
       - comments
       - common-false-positives
@@ -88,8 +83,7 @@ linters:
       - std-error-handling
     rules:
       # Relaxed rules for test files
-      - path: '(.+)_test\.go'
-        linters:
+      - linters:
           - gosec
           - errcheck
           - unparam
@@ -97,9 +91,9 @@ linters:
           - lll
           - gocritic
           - exhaustive
+        path: _test\.go
       # Relaxed rules for integration tests
-      - path: 'test/'
-        linters:
+      - linters:
           - gosec
           - errcheck
           - unparam
@@ -108,35 +102,71 @@ linters:
           - gocritic
           - revive
           - exhaustive
+        path: test/
       # Relaxed rules for cmd/
-      - path: 'cmd/'
-        linters:
+      - linters:
           - revive
           - lll
+        path: cmd/
       # Relaxed rules for internal packages
-      - path: 'internal/'
-        linters:
+      - linters:
           - lll
+        path: internal/
       # Relaxed rules for pkg/
-      - path: 'pkg/'
-        linters:
+      - linters:
           - lll
+        path: pkg/
       # G304: file inclusion via variable - acceptable for config loader
-      - path: 'internal/config_loader/'
+      - linters:
+          - gosec
+        path: internal/config_loader/
         text: 'G304'
-        linters:
-          - gosec
       # G404: weak random - acceptable for jitter in retry logic
-      - path: 'internal/hyperfleet_api/client\.go'
-        text: 'G404'
-        linters:
+      - linters:
           - gosec
+        path: internal/hyperfleet_api/client\.go
+        text: 'G404'
+      # Package naming: underscore packages are structural and renaming is out of scope
+      # Scoped to legacy underscore packages only
+      - linters:
+          - revive
+        path: internal/(config_loader|hyperfleet_api|maestro_client|k8s_client|transport_client)/
+        text: "don't use an underscore in package name"
+      # Package naming: allow existing package names (scoped to legacy packages)
+      - linters:
+          - revive
+        path: (internal/(config_loader|hyperfleet_api|maestro_client|k8s_client|transport_client)|pkg/utils)/
+        text: "avoid meaningless package names"
+      - linters:
+          - revive
+        path: (internal/(config_loader|hyperfleet_api|maestro_client|k8s_client|transport_client)|pkg/errors)/
+        text: "avoid package names that conflict with"
+    # Standard exclusion paths
+    paths:
+      - third_party(/|$)
+      - builtin(/|$)
+      - examples(/|$)
 
 formatters:
   enable:
     - gofmt
     - goimports
+  settings:
+    gofmt:
+      simplify: true
+  exclusions:
+    generated: lax
+    paths:
+      - third_party(/|$)
+      - builtin(/|$)
+      - examples(/|$)
 
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
+  new: false
+
+output:
+  formats:
+    text:
+      path: stdout

--- a/cmd/adapter/main.go
+++ b/cmd/adapter/main.go
@@ -408,7 +408,9 @@ func runServe(flags *pflag.FlagSet) error {
 		config.Clients.HyperfleetAPI.RetryAttempts)
 	var redactedConfigBytes []byte
 	if config.DebugConfig {
-		if data, err := yaml.Marshal(config.Redacted()); err != nil {
+		var data []byte
+		data, err = yaml.Marshal(config.Redacted())
+		if err != nil {
 			errCtx := logger.WithErrorField(ctx, err)
 			log.Warnf(errCtx, "Failed to marshal adapter configuration for logging")
 		} else {
@@ -428,15 +430,16 @@ func runServe(flags *pflag.FlagSet) error {
 	defer func() {
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), OTelShutdownTimeout)
 		defer shutdownCancel()
-		if err := tp.Shutdown(shutdownCtx); err != nil {
-			errCtx := logger.WithErrorField(shutdownCtx, err)
+		if shutdownErr := tp.Shutdown(shutdownCtx); shutdownErr != nil {
+			errCtx := logger.WithErrorField(shutdownCtx, shutdownErr)
 			log.Warnf(errCtx, "Failed to shutdown TracerProvider")
 		}
 	}()
 
 	// Start health server
 	healthServer := health.NewServer(log, HealthServerPort, config.Adapter.Name)
-	if err := healthServer.Start(ctx); err != nil {
+	err = healthServer.Start(ctx)
+	if err != nil {
 		errCtx := logger.WithErrorField(ctx, err)
 		log.Errorf(errCtx, "Failed to start health server")
 		return fmt.Errorf("failed to start health server: %w", err)
@@ -448,8 +451,8 @@ func runServe(flags *pflag.FlagSet) error {
 	defer func() {
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), HealthServerShutdownTimeout)
 		defer shutdownCancel()
-		if err := healthServer.Shutdown(shutdownCtx); err != nil {
-			errCtx := logger.WithErrorField(shutdownCtx, err)
+		if shutdownErr := healthServer.Shutdown(shutdownCtx); shutdownErr != nil {
+			errCtx := logger.WithErrorField(shutdownCtx, shutdownErr)
 			log.Warnf(errCtx, "Failed to shutdown health server")
 		}
 	}()
@@ -460,7 +463,8 @@ func runServe(flags *pflag.FlagSet) error {
 		Version:   version.Version,
 		Commit:    version.Commit,
 	})
-	if err := metricsServer.Start(ctx); err != nil {
+	err = metricsServer.Start(ctx)
+	if err != nil {
 		errCtx := logger.WithErrorField(ctx, err)
 		log.Errorf(errCtx, "Failed to start metrics server")
 		return fmt.Errorf("failed to start metrics server: %w", err)
@@ -468,8 +472,8 @@ func runServe(flags *pflag.FlagSet) error {
 	defer func() {
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), HealthServerShutdownTimeout)
 		defer shutdownCancel()
-		if err := metricsServer.Shutdown(shutdownCtx); err != nil {
-			errCtx := logger.WithErrorField(shutdownCtx, err)
+		if shutdownErr := metricsServer.Shutdown(shutdownCtx); shutdownErr != nil {
+			errCtx := logger.WithErrorField(shutdownCtx, shutdownErr)
 			log.Warnf(errCtx, "Failed to shutdown metrics server")
 		}
 	}()
@@ -524,7 +528,7 @@ func runServe(flags *pflag.FlagSet) error {
 	// Get broker config
 	subscriptionID := config.Clients.Broker.SubscriptionID
 	if subscriptionID == "" {
-		err := fmt.Errorf("clients.broker.subscription_id is required")
+		err = fmt.Errorf("clients.broker.subscription_id is required")
 		errCtx := logger.WithErrorField(ctx, err)
 		log.Errorf(errCtx, "Missing required broker configuration")
 		return err
@@ -532,7 +536,7 @@ func runServe(flags *pflag.FlagSet) error {
 
 	topic := config.Clients.Broker.Topic
 	if topic == "" {
-		err := fmt.Errorf("clients.broker.topic is required")
+		err = fmt.Errorf("clients.broker.topic is required")
 		errCtx := logger.WithErrorField(ctx, err)
 		log.Errorf(errCtx, "Missing required broker configuration")
 		return err
@@ -669,7 +673,8 @@ func runDryRun(flags *pflag.FlagSet) error {
 	// Create recording transport client
 	var dryrunClient *dryrun.DryrunTransportClient
 	if dryRunDiscovery != "" {
-		overrides, err := dryrun.LoadDiscoveryOverrides(dryRunDiscovery)
+		var overrides dryrun.DiscoveryOverrides
+		overrides, err = dryrun.LoadDiscoveryOverrides(dryRunDiscovery)
 		if err != nil {
 			return fmt.Errorf("failed to load discovery overrides: %w", err)
 		}

--- a/internal/config_loader/loader.go
+++ b/internal/config_loader/loader.go
@@ -99,13 +99,13 @@ func LoadConfig(opts ...LoadOption) (*Config, error) {
 
 	// Validate AdapterConfig structure
 	adapterValidator := NewAdapterConfigValidator(adapterCfg, adapterBaseDir)
-	if err := adapterValidator.ValidateStructure(); err != nil {
+	if err = adapterValidator.ValidateStructure(); err != nil {
 		return nil, fmt.Errorf("adapter config validation failed: %w", err)
 	}
 
 	// Validate adapter version if specified
 	if o.adapterVersion != "" {
-		if err := ValidateAdapterVersion(adapterCfg, o.adapterVersion); err != nil {
+		if err = ValidateAdapterVersion(adapterCfg, o.adapterVersion); err != nil {
 			return nil, fmt.Errorf("adapter version validation failed: %w", err)
 		}
 	}

--- a/internal/config_loader/loader_test.go
+++ b/internal/config_loader/loader_test.go
@@ -137,8 +137,8 @@ func TestAdapterConfigValidation(t *testing.T) {
 	tests := []struct {
 		name      string
 		yaml      string
-		wantError bool
 		errorMsg  string
+		wantError bool
 	}{
 		{
 			name: "valid minimal adapter config",
@@ -204,8 +204,8 @@ func TestTaskConfigValidation(t *testing.T) {
 	tests := []struct {
 		name      string
 		yaml      string
-		wantError bool
 		errorMsg  string
+		wantError bool
 	}{
 		{
 			name:      "valid minimal task config",
@@ -268,8 +268,8 @@ func TestValidatePreconditionsInTaskConfig(t *testing.T) {
 	tests := []struct {
 		name      string
 		yaml      string
-		wantError bool
 		errorMsg  string
+		wantError bool
 	}{
 		{
 			name: "valid precondition with API call",
@@ -352,8 +352,8 @@ func TestValidateResourcesInTaskConfig(t *testing.T) {
 	tests := []struct {
 		name      string
 		yaml      string
-		wantError bool
 		errorMsg  string
+		wantError bool
 	}{
 		{
 			name: "valid resource with manifest",
@@ -591,9 +591,9 @@ func TestValidateFileReferencesInTaskConfig(t *testing.T) {
 	tests := []struct {
 		name    string
 		config  *AdapterTaskConfig
+		errMsg  string
 		baseDir string
 		wantErr bool
-		errMsg  string
 	}{
 		{
 			name: "valid payload buildRef",
@@ -903,9 +903,9 @@ func TestValidateResourceDiscoveryInTaskConfig(t *testing.T) {
 
 	tests := []struct {
 		name      string
+		errMsg    string
 		resources []Resource
 		wantErr   bool
-		errMsg    string
 	}{
 		{
 			name: "valid - manifest.ref with discovery bySelectors",
@@ -1047,8 +1047,8 @@ func TestConditionValuesAlias(t *testing.T) {
 	// Test that both "value" and "values" YAML keys are supported
 	tests := []struct {
 		name     string
-		yaml     string
 		expected interface{}
+		yaml     string
 	}{
 		{
 			name: "value with single item",
@@ -1116,10 +1116,10 @@ func TestTransportConfigYAMLParsing(t *testing.T) {
 	tests := []struct {
 		name           string
 		yaml           string
-		wantError      bool
 		wantClient     string
 		wantTarget     string
 		wantMaestroNil bool
+		wantError      bool
 	}{
 		{
 			name: "resource with kubernetes transport",
@@ -1231,8 +1231,8 @@ resources:
 func TestGetTransportClient(t *testing.T) {
 	tests := []struct {
 		name     string
-		resource Resource
 		want     string
+		resource Resource
 	}{
 		{
 			name:     "nil transport defaults to kubernetes",

--- a/internal/config_loader/types.go
+++ b/internal/config_loader/types.go
@@ -11,14 +11,14 @@ import (
 // Config is the unified configuration passed throughout the application.
 // Created by merging AdapterConfig (deployment) and AdapterTaskConfig (task).
 type Config struct {
-	Adapter       AdapterInfo    `yaml:"adapter"`
-	Clients       ClientsConfig  `yaml:"clients"`
-	DebugConfig   bool           `yaml:"debug_config,omitempty"`
+	Post          *PostConfig    `yaml:"post,omitempty"`
 	Log           LogConfig      `yaml:"log,omitempty"`
+	Adapter       AdapterInfo    `yaml:"adapter"`
 	Params        []Parameter    `yaml:"params,omitempty"`
 	Preconditions []Precondition `yaml:"preconditions,omitempty"`
 	Resources     []Resource     `yaml:"resources,omitempty"`
-	Post          *PostConfig    `yaml:"post,omitempty"`
+	Clients       ClientsConfig  `yaml:"clients"`
+	DebugConfig   bool           `yaml:"debug_config,omitempty"`
 }
 
 // Merge combines AdapterConfig (deployment) and AdapterTaskConfig (task) into a unified Config.
@@ -104,8 +104,9 @@ type FieldExpressionDef struct {
 //	  expression: "adapter.?errorMessage.orValue(\"\")"
 //	  default: "success"
 type ValueDef struct {
+	// Default value if extraction fails or returns nil
+	Default            any `yaml:"default"`
 	FieldExpressionDef `yaml:",inline"`
-	Default            any `yaml:"default"` // Default value if extraction fails or returns nil
 }
 
 // ParseValueDef attempts to parse a value as a ValueDef.
@@ -174,12 +175,12 @@ type KubernetesConfig struct {
 // Parameter represents a parameter extraction configuration.
 // Parameters are extracted from external sources (event data, env vars) using Source.
 type Parameter struct {
+	Default     interface{} `yaml:"default,omitempty"`
 	Name        string      `yaml:"name" validate:"required"`
 	Source      string      `yaml:"source,omitempty" validate:"required"`
 	Type        string      `yaml:"type,omitempty"`
 	Description string      `yaml:"description,omitempty"`
 	Required    bool        `yaml:"required,omitempty"`
-	Default     interface{} `yaml:"default,omitempty"`
 }
 
 // Payload represents a dynamically built payload for post-processing.
@@ -190,16 +191,16 @@ type Parameter struct {
 // - Use Build for inline payload definitions directly in the config
 // - Use BuildRef to reference an external YAML file containing the build definition
 type Payload struct {
-	Name string `yaml:"name" validate:"required"`
 	// Build contains a structure that will be evaluated and converted to JSON at runtime.
 	// The structure is kept as raw interface{} to allow flexible schema definitions.
 	// Mutually exclusive with BuildRef.
 	Build interface{} `yaml:"build,omitempty" validate:"required_without=BuildRef,excluded_with=BuildRef"`
+	// BuildRefContent holds the loaded content from BuildRef file (populated by loader)
+	BuildRefContent map[string]interface{} `yaml:"-"`
+	Name            string                 `yaml:"name" validate:"required"`
 	// BuildRef references an external YAML file containing the build definition.
 	// Mutually exclusive with Build.
 	BuildRef string `yaml:"build_ref,omitempty" validate:"required_without=Build,excluded_with=Build"`
-	// BuildRefContent holds the loaded content from BuildRef file (populated by loader)
-	BuildRefContent map[string]interface{} `yaml:"-"`
 }
 
 // Validate checks that exactly one of Build or BuildRef is set.
@@ -219,18 +220,18 @@ func (p *Payload) Validate() error {
 // ActionBase contains common fields for action-like configurations.
 // Used by Precondition and PostAction to reduce duplication.
 type ActionBase struct {
-	Name    string     `yaml:"name" validate:"required"`
 	APICall *APICall   `yaml:"api_call,omitempty" validate:"omitempty"`
 	Log     *LogAction `yaml:"log,omitempty"`
+	Name    string     `yaml:"name" validate:"required"`
 }
 
 // Precondition represents a precondition check.
 // Must have at least one of: APICall (from ActionBase), Expression, or Conditions.
 type Precondition struct {
 	ActionBase `yaml:",inline"`
+	Expression string         `yaml:"expression,omitempty" validate:"required_without_all=ActionBase.APICall Conditions"`
 	Capture    []CaptureField `yaml:"capture,omitempty" validate:"dive"`
 	Conditions []Condition    `yaml:"conditions,omitempty" validate:"dive,required_without_all=ActionBase.APICall Expression"`
-	Expression string         `yaml:"expression,omitempty" validate:"required_without_all=ActionBase.APICall Conditions"`
 }
 
 // APICall represents an API call configuration
@@ -238,10 +239,10 @@ type APICall struct {
 	Method        string   `yaml:"method" validate:"required,oneof=GET POST PUT PATCH DELETE"`
 	URL           string   `yaml:"url" validate:"required"`
 	Timeout       string   `yaml:"timeout,omitempty"`
-	RetryAttempts int      `yaml:"retry_attempts,omitempty"`
 	RetryBackoff  string   `yaml:"retry_backoff,omitempty"`
-	Headers       []Header `yaml:"headers,omitempty"`
 	Body          string   `yaml:"body,omitempty"`
+	Headers       []Header `yaml:"headers,omitempty"`
+	RetryAttempts int      `yaml:"retry_attempts,omitempty"`
 }
 
 // Header represents an HTTP header
@@ -262,17 +263,19 @@ type CaptureField struct {
 
 // Condition represents a structured condition
 type Condition struct {
+	// Populated by UnmarshalYAML from "value" or "values"
+	Value    interface{} `yaml:"-"`
 	Field    string      `yaml:"field"`
 	Operator string      `yaml:"operator" validate:"required,validoperator"`
-	Value    interface{} `yaml:"-"` // Populated by UnmarshalYAML from "value" or "values"
 }
 
 // conditionRaw is used for custom unmarshaling to support both "value" and "values" keys
 type conditionRaw struct {
+	Value interface{} `yaml:"value"`
+	// Alias for Value
+	Values   interface{} `yaml:"values"`
 	Field    string      `yaml:"field"`
 	Operator string      `yaml:"operator"`
-	Value    interface{} `yaml:"value"`
-	Values   interface{} `yaml:"values"` // Alias for Value
 }
 
 // UnmarshalYAML implements custom unmarshaling to support both "value" and "values" keys
@@ -302,10 +305,10 @@ func (c *Condition) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // TransportConfig specifies which transport client to use for a resource
 type TransportConfig struct {
-	// Client is the transport client type: "kubernetes" or "maestro"
-	Client string `yaml:"client" validate:"required,oneof=kubernetes maestro"`
 	// Maestro contains maestro-specific transport settings (required when Client is "maestro")
 	Maestro *MaestroTransportConfig `yaml:"maestro,omitempty"`
+	// Client is the transport client type: "kubernetes" or "maestro"
+	Client string `yaml:"client" validate:"required,oneof=kubernetes maestro"`
 }
 
 // MaestroTransportConfig contains maestro-specific transport settings
@@ -319,27 +322,27 @@ type MaestroTransportConfig struct {
 // or a ManifestWork (for maestro transport). The transport client determines
 // how to parse and apply it.
 type Resource struct {
-	Name             string           `yaml:"name" validate:"required,resourcename"`
-	Transport        *TransportConfig `yaml:"transport,omitempty"`
-	Manifest         interface{}      `yaml:"manifest,omitempty"`
-	RecreateOnChange bool             `yaml:"recreate_on_change,omitempty"`
-	Discovery        *DiscoveryConfig `yaml:"discovery,omitempty" validate:"required"`
+	Name      string           `yaml:"name" validate:"required,resourcename"`
+	Transport *TransportConfig `yaml:"transport,omitempty"`
+	Manifest  interface{}      `yaml:"manifest,omitempty"`
+	Discovery *DiscoveryConfig `yaml:"discovery,omitempty" validate:"required"`
 	// NestedDiscoveries defines how to discover individual sub-resources within the applied manifest.
 	// For example, discovering resources inside a ManifestWork's workload.
 	NestedDiscoveries []NestedDiscovery `yaml:"nested_discoveries,omitempty" validate:"dive"`
+	RecreateOnChange  bool              `yaml:"recreate_on_change,omitempty"`
 }
 
 // NestedDiscovery defines a named discovery for a sub-resource within the parent manifest.
 type NestedDiscovery struct {
-	Name      string           `yaml:"name" validate:"required,resourcename"`
 	Discovery *DiscoveryConfig `yaml:"discovery" validate:"required"`
+	Name      string           `yaml:"name" validate:"required,resourcename"`
 }
 
 // DiscoveryConfig represents resource discovery configuration
 type DiscoveryConfig struct {
+	BySelectors *SelectorConfig `yaml:"by_selectors,omitempty" validate:"required_without=ByName,excluded_with=ByName,omitempty"`
 	Namespace   string          `yaml:"namespace,omitempty"`
-	ByName      string          `yaml:"by_name,omitempty" validate:"required_without=BySelectors"`
-	BySelectors *SelectorConfig `yaml:"by_selectors,omitempty" validate:"required_without=ByName,omitempty"`
+	ByName      string          `yaml:"by_name,omitempty" validate:"required_without=BySelectors,excluded_with=BySelectors"`
 }
 
 // SelectorConfig represents label selector configuration
@@ -432,17 +435,17 @@ func (ve *ValidationErrors) HasErrors() bool {
 // and CLI flags using Viper.
 type AdapterConfig struct {
 	Adapter     AdapterInfo   `yaml:"adapter" mapstructure:"adapter"`
+	Log         LogConfig     `yaml:"log,omitempty" mapstructure:"log"`
 	Clients     ClientsConfig `yaml:"clients" mapstructure:"clients"`
 	DebugConfig bool          `yaml:"debug_config,omitempty" mapstructure:"debug_config"`
-	Log         LogConfig     `yaml:"log,omitempty" mapstructure:"log"`
 }
 
 // ClientsConfig contains configuration for all external clients
 type ClientsConfig struct {
 	Maestro       *MaestroClientConfig `yaml:"maestro,omitempty" mapstructure:"maestro"`
-	HyperfleetAPI HyperfleetAPIConfig  `yaml:"hyperfleet_api" mapstructure:"hyperfleet_api"`
 	Broker        BrokerConfig         `yaml:"broker,omitempty" mapstructure:"broker"`
 	Kubernetes    KubernetesConfig     `yaml:"kubernetes" mapstructure:"kubernetes"`
+	HyperfleetAPI HyperfleetAPIConfig  `yaml:"hyperfleet_api" mapstructure:"hyperfleet_api"`
 }
 
 // MaestroClientConfig contains Maestro client configuration
@@ -451,18 +454,19 @@ type MaestroClientConfig struct {
 	HTTPServerAddress        string            `yaml:"http_server_address" mapstructure:"http_server_address"`
 	SourceID                 string            `yaml:"source_id" mapstructure:"source_id"`
 	ClientID                 string            `yaml:"client_id" mapstructure:"client_id"`
-	Auth                     MaestroAuthConfig `yaml:"auth" mapstructure:"auth"`
 	Timeout                  string            `yaml:"timeout" mapstructure:"timeout"`
 	ServerHealthinessTimeout string            `yaml:"server_healthiness_timeout,omitempty" mapstructure:"server_healthiness_timeout"`
-	RetryAttempts            int               `yaml:"retry_attempts" mapstructure:"retry_attempts"`
 	Keepalive                *KeepaliveConfig  `yaml:"keepalive,omitempty" mapstructure:"keepalive"`
+	Auth                     MaestroAuthConfig `yaml:"auth" mapstructure:"auth"`
+	RetryAttempts            int               `yaml:"retry_attempts" mapstructure:"retry_attempts"`
 	Insecure                 bool              `yaml:"insecure,omitempty" mapstructure:"insecure"`
 }
 
 // MaestroAuthConfig contains authentication configuration for Maestro
 type MaestroAuthConfig struct {
-	Type      string     `yaml:"type" mapstructure:"type"` // "tls" or "none"
 	TLSConfig *TLSConfig `yaml:"tls_config,omitempty" mapstructure:"tls_config"`
+	// "tls" or "none"
+	Type string `yaml:"type" mapstructure:"type"`
 }
 
 // TLSConfig contains TLS certificate configuration
@@ -483,8 +487,8 @@ type KeepaliveConfig struct {
 // Contains params, preconditions, resources, and post-processing actions.
 // This config is loaded from YAML without environment variable overrides.
 type AdapterTaskConfig struct {
+	Post          *PostConfig    `yaml:"post,omitempty" validate:"omitempty"`
 	Params        []Parameter    `yaml:"params,omitempty" validate:"dive"`
 	Preconditions []Precondition `yaml:"preconditions,omitempty" validate:"dive"`
 	Resources     []Resource     `yaml:"resources,omitempty" validate:"unique=Name,dive"`
-	Post          *PostConfig    `yaml:"post,omitempty" validate:"omitempty"`
 }

--- a/internal/config_loader/validator.go
+++ b/internal/config_loader/validator.go
@@ -23,8 +23,8 @@ var templateVarRegex = regexp.MustCompile(`\{\{\s*\.([a-zA-Z_][a-zA-Z0-9_\.]*)\s
 // AdapterConfigValidator validates AdapterConfig (deployment configuration)
 type AdapterConfigValidator struct {
 	config  *AdapterConfig
-	baseDir string
 	errors  *ValidationErrors
+	baseDir string
 }
 
 // NewAdapterConfigValidator creates a validator for AdapterConfig
@@ -53,10 +53,10 @@ func (v *AdapterConfigValidator) ValidateStructure() error {
 // TaskConfigValidator validates AdapterTaskConfig (task configuration)
 type TaskConfigValidator struct {
 	config      *AdapterTaskConfig
-	baseDir     string
 	errors      *ValidationErrors
 	definedVars map[string]bool
 	celEnv      *cel.Env
+	baseDir     string
 }
 
 // NewTaskConfigValidator creates a validator for AdapterTaskConfig

--- a/internal/config_loader/validator_test.go
+++ b/internal/config_loader/validator_test.go
@@ -404,9 +404,9 @@ func TestBuiltinVariables(t *testing.T) {
 func TestPayloadValidate(t *testing.T) {
 	tests := []struct {
 		name      string
+		errorMsg  string
 		payload   Payload
 		wantError bool
-		errorMsg  string
 	}{
 		{
 			name: "valid payload with Build only",
@@ -826,8 +826,8 @@ func TestValidateFileReferencesManifestRef(t *testing.T) {
 	tests := []struct {
 		name    string
 		config  *AdapterTaskConfig
-		wantErr bool
 		errMsg  string
+		wantErr bool
 	}{
 		{
 			name: "valid manifest ref for maestro transport",

--- a/internal/criteria/cel_evaluator.go
+++ b/internal/criteria/cel_evaluator.go
@@ -25,17 +25,17 @@ type CELEvaluator struct {
 type CELResult struct {
 	// Value is the result of the CEL expression evaluation (nil if error)
 	Value interface{}
-	// Matched indicates if the result is boolean true (for conditions)
-	// Always false when Error is set
-	Matched bool
+	// Error indicates if evaluation failed (nil if successful)
+	// Common causes: "field not found", "null value access", "type mismatch"
+	Error error
 	// ValueType is the CEL type of Value (e.g., "bool", "string", "int", "map", "list")
 	// Empty when evaluation failed
 	ValueType string
 	// Expression is the original expression that was evaluated
 	Expression string
-	// Error indicates if evaluation failed (nil if successful)
-	// Common causes: "field not found", "null value access", "type mismatch"
-	Error error
+	// Matched indicates if the result is boolean true (for conditions)
+	// Always false when Error is set
+	Matched bool
 }
 
 // HasError returns true if the evaluation resulted in an error

--- a/internal/criteria/cel_evaluator_test.go
+++ b/internal/criteria/cel_evaluator_test.go
@@ -31,10 +31,10 @@ func TestCELEvaluatorEvaluate(t *testing.T) {
 	require.NoError(t, err)
 
 	tests := []struct {
+		wantValue  interface{}
 		name       string
 		expression string
 		wantMatch  bool
-		wantValue  interface{}
 		wantErr    bool
 	}{
 		{
@@ -386,9 +386,9 @@ func TestEvaluateSafeErrorHandling(t *testing.T) {
 	tests := []struct {
 		name        string
 		expression  string
+		wantReason  string // substring to match in Error
 		wantSuccess bool
 		wantMatched bool
-		wantReason  string // substring to match in Error
 	}{
 		{
 			name:        "existing nested field",

--- a/internal/criteria/evaluator.go
+++ b/internal/criteria/evaluator.go
@@ -12,28 +12,28 @@ import (
 
 // EvaluationResult contains the result of evaluating a condition
 type EvaluationResult struct {
-	// Matched indicates if the condition was satisfied
-	Matched bool
 	// FieldValue is the actual value of the field that was evaluated
 	FieldValue interface{}
+	// ExpectedValue is the value the condition was compared against
+	ExpectedValue interface{}
 	// Field is the field path that was evaluated
 	Field string
 	// Operator is the operator used
 	Operator Operator
-	// ExpectedValue is the value the condition was compared against
-	ExpectedValue interface{}
+	// Matched indicates if the condition was satisfied
+	Matched bool
 }
 
 // ConditionsResult contains the result of evaluating multiple conditions
 type ConditionsResult struct {
-	// Matched indicates if all conditions were satisfied
-	Matched bool
+	// ExtractedFields maps field paths to their values
+	ExtractedFields map[string]interface{}
 	// Results contains individual results for each condition
 	Results []EvaluationResult
 	// FailedCondition is the index of the first failed condition (-1 if all passed)
 	FailedCondition int
-	// ExtractedFields maps field paths to their values
-	ExtractedFields map[string]interface{}
+	// Matched indicates if all conditions were satisfied
+	Matched bool
 }
 
 // Evaluator evaluates criteria against an evaluation context
@@ -171,8 +171,8 @@ func (e *Evaluator) EvaluateConditions(conditions []ConditionDef) (*ConditionsRe
 // ExtractValueResult contains the result of value extraction
 type ExtractValueResult struct {
 	Value  interface{} // Extracted value
-	Source string      // The field path or expression used
 	Error  error       // Error if extraction failed
+	Source string      // The field path or expression used
 }
 
 // ExtractValue extracts a value from the context using either field (JSONPath) or expression (CEL).
@@ -251,16 +251,16 @@ func (e *Evaluator) EvaluateCEL(expression string) (*CELResult, error) {
 
 // ConditionDef defines a condition to evaluate
 type ConditionDef struct {
+	Value    interface{}
 	Field    string
 	Operator Operator
-	Value    interface{}
 }
 
 // ConditionDefJSON is used for JSON/YAML unmarshaling with string operator
 type ConditionDefJSON struct {
+	Value    interface{} `json:"value" yaml:"value"`
 	Field    string      `json:"field" yaml:"field"`
 	Operator string      `json:"operator" yaml:"operator"`
-	Value    interface{} `json:"value" yaml:"value"`
 }
 
 // ToConditionDef converts ConditionDefJSON to ConditionDef with typed Operator

--- a/internal/criteria/evaluator_test.go
+++ b/internal/criteria/evaluator_test.go
@@ -51,8 +51,8 @@ func TestEvaluationContextGetField(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		path    string
 		want    interface{}
+		path    string
 		wantNil bool // field not found returns nil value
 	}{
 		{
@@ -160,11 +160,11 @@ func TestEvaluationContextMergeConcurrent(t *testing.T) {
 
 func TestEvaluateEquals(t *testing.T) {
 	tests := []struct {
-		name      string
 		field     interface{}
 		value     interface{}
-		want      bool
+		name      string
 		wantError bool
+		want      bool
 	}{
 		{
 			name:  "equal strings",
@@ -219,11 +219,11 @@ func TestEvaluateEquals(t *testing.T) {
 
 func TestEvaluateIn(t *testing.T) {
 	tests := []struct {
-		name      string
 		field     interface{}
 		list      interface{}
-		want      bool
+		name      string
 		wantError bool
+		want      bool
 	}{
 		{
 			name:  "value in string list",
@@ -266,11 +266,11 @@ func TestEvaluateIn(t *testing.T) {
 
 func TestEvaluateContains(t *testing.T) {
 	tests := []struct {
-		name      string
 		field     interface{}
 		needle    interface{}
-		want      bool
+		name      string
 		wantError bool
+		want      bool
 	}{
 		{
 			name:   "string contains substring",
@@ -319,11 +319,11 @@ func TestEvaluateContains(t *testing.T) {
 
 func TestEvaluateGreaterThan(t *testing.T) {
 	tests := []struct {
-		name      string
 		field     interface{}
 		threshold interface{}
-		want      bool
+		name      string
 		wantError bool
+		want      bool
 	}{
 		{
 			name:      "int greater than",
@@ -390,11 +390,11 @@ func TestEvaluateGreaterThan(t *testing.T) {
 
 func TestEvaluateLessThan(t *testing.T) {
 	tests := []struct {
-		name      string
 		field     interface{}
 		threshold interface{}
-		want      bool
+		name      string
 		wantError bool
+		want      bool
 	}{
 		{
 			name:      "int less than",
@@ -461,8 +461,8 @@ func TestEvaluateLessThan(t *testing.T) {
 
 func TestEvaluateExists(t *testing.T) {
 	tests := []struct {
-		name  string
 		field interface{}
+		name  string
 		want  bool
 	}{
 		{
@@ -530,10 +530,10 @@ func TestEvaluatorEvaluateCondition(t *testing.T) {
 	tests := []struct {
 		name      string
 		field     string
-		operator  Operator
 		value     interface{}
-		want      bool
+		operator  Operator
 		wantError bool
+		want      bool
 	}{
 		{
 			name:     "equals operator",
@@ -618,8 +618,8 @@ func TestEvaluatorEvaluateConditions(t *testing.T) {
 	tests := []struct {
 		name       string
 		conditions []ConditionDef
-		want       bool
 		wantError  bool
+		want       bool
 	}{
 		{
 			name: "all conditions pass",
@@ -671,8 +671,8 @@ func TestExtractField(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		path      string
 		want      interface{}
+		path      string
 		wantError bool
 	}{
 		{
@@ -759,8 +759,8 @@ func TestExtractFieldJSONPath(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		path      string
 		want      interface{}
+		path      string
 		wantError bool
 	}{
 		{
@@ -847,8 +847,8 @@ func TestExtractFieldFunction(t *testing.T) {
 
 func TestToFloat64(t *testing.T) {
 	tests := []struct {
-		name      string
 		value     interface{}
+		name      string
 		want      float64
 		wantError bool
 	}{

--- a/internal/criteria/types.go
+++ b/internal/criteria/types.go
@@ -197,9 +197,9 @@ func (c *EvaluationContext) Data() map[string]interface{} {
 
 // EvaluationError represents an error during criteria evaluation
 type EvaluationError struct {
+	Err     error
 	Field   string
 	Message string
-	Err     error
 }
 
 func (e *EvaluationError) Error() string {

--- a/internal/dryrun/dryrun_api_client.go
+++ b/internal/dryrun/dryrun_api_client.go
@@ -13,12 +13,12 @@ import (
 
 // RequestRecord stores details of an API request made through the dryrun client.
 type RequestRecord struct {
-	Method     string
-	URL        string
 	Headers    map[string]string
+	URL        string
+	Method     string
 	Body       []byte
-	StatusCode int
 	Response   []byte
+	StatusCode int
 }
 
 // DryrunAPIClient implements hyperfleet_api.Client backed by file-defined dryrun responses.
@@ -26,13 +26,13 @@ type RequestRecord struct {
 // sequentially from a configured array per endpoint. All requests are recorded.
 type DryrunAPIClient struct {
 	endpoints []compiledEndpoint
-	mu        sync.Mutex
 	Requests  []RequestRecord
+	mu        sync.Mutex
 }
 
 type compiledEndpoint struct {
-	method  string
 	pattern *regexp.Regexp
+	method  string
 	resps   []DryrunResponse
 	callIdx int
 }

--- a/internal/dryrun/dryrun_responses.go
+++ b/internal/dryrun/dryrun_responses.go
@@ -25,9 +25,9 @@ type DryrunMatch struct {
 
 // DryrunResponse defines a single dryrun HTTP response.
 type DryrunResponse struct {
-	StatusCode int               `json:"statusCode"`
 	Headers    map[string]string `json:"headers,omitempty"`
 	Body       interface{}       `json:"body,omitempty"`
+	StatusCode int               `json:"statusCode"`
 }
 
 // LoadDryrunResponses reads and parses a dryrun API responses JSON file.

--- a/internal/dryrun/recording_transport_client.go
+++ b/internal/dryrun/recording_transport_client.go
@@ -12,25 +12,31 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+const (
+	operationApply    = "apply"
+	operationGet      = "get"
+	operationDiscover = "discover"
+)
+
 // TransportRecord stores details of a transport client operation.
 type TransportRecord struct {
-	Operation string // "apply", "get", "discover"
-	GVK       schema.GroupVersionKind
+	Error     error
+	Result    *transport_client.ApplyResult
 	Namespace string
 	Name      string
+	GVK       schema.GroupVersionKind
+	Operation string // operationApply, operationGet, operationDiscover
 	Manifest  []byte
-	Result    *transport_client.ApplyResult
-	Error     error
 }
 
 // DryrunTransportClient implements transport_client.TransportClient by recording
 // all operations in-memory without executing real Kubernetes calls.
 // Applied resources are stored for subsequent discovery/get operations.
 type DryrunTransportClient struct {
-	mu                 sync.Mutex
 	resources          map[string]*unstructured.Unstructured // key: "namespace/name/gvk"
-	Records            []TransportRecord
 	discoveryOverrides DiscoveryOverrides
+	Records            []TransportRecord
+	mu                 sync.Mutex
 }
 
 // NewDryrunTransportClient creates a new DryrunTransportClient.
@@ -66,7 +72,7 @@ func (c *DryrunTransportClient) ApplyResource(ctx context.Context, manifestBytes
 	obj := &unstructured.Unstructured{}
 	if err := json.Unmarshal(manifestBytes, &obj.Object); err != nil {
 		record := TransportRecord{
-			Operation: "apply",
+			Operation: operationApply,
 			Manifest:  manifestBytes,
 			Error:     fmt.Errorf("failed to parse manifest: %w", err),
 		}
@@ -109,7 +115,7 @@ func (c *DryrunTransportClient) ApplyResource(ctx context.Context, manifestBytes
 	}
 
 	c.Records = append(c.Records, TransportRecord{
-		Operation: "apply",
+		Operation: operationApply,
 		GVK:       gvk,
 		Namespace: namespace,
 		Name:      name,
@@ -129,7 +135,7 @@ func (c *DryrunTransportClient) GetResource(ctx context.Context, gvk schema.Grou
 	obj, exists := c.resources[key]
 
 	c.Records = append(c.Records, TransportRecord{
-		Operation: "get",
+		Operation: operationGet,
 		GVK:       gvk,
 		Namespace: namespace,
 		Name:      name,
@@ -148,7 +154,7 @@ func (c *DryrunTransportClient) DiscoverResources(ctx context.Context, gvk schem
 	defer c.mu.Unlock()
 
 	c.Records = append(c.Records, TransportRecord{
-		Operation: "discover",
+		Operation: operationDiscover,
 		GVK:       gvk,
 		Namespace: discovery.GetNamespace(),
 		Name:      discovery.GetName(),

--- a/internal/dryrun/recording_transport_client_test.go
+++ b/internal/dryrun/recording_transport_client_test.go
@@ -179,8 +179,8 @@ func unstructuredNestedString(obj map[string]interface{}, fields ...string) (str
 			return "", false, nil
 		}
 		if i == len(fields)-1 {
-			s, ok := val.(string)
-			return s, ok, nil
+			s, strOk := val.(string)
+			return s, strOk, nil
 		}
 		m, ok := val.(map[string]interface{})
 		if !ok {

--- a/internal/dryrun/trace.go
+++ b/internal/dryrun/trace.go
@@ -16,11 +16,11 @@ const (
 
 // ExecutionTrace contains all data needed to produce the trace output.
 type ExecutionTrace struct {
-	EventID   string
-	EventType string
 	Result    *executor.ExecutionResult
 	APIClient *DryrunAPIClient
 	Transport *DryrunTransportClient
+	EventID   string
+	EventType string
 	Verbose   bool
 }
 
@@ -46,10 +46,10 @@ type TraceEvent struct {
 
 // TracePrecondition is the JSON representation of a precondition result.
 type TracePrecondition struct {
+	Error   string `json:"error,omitempty"`
 	Name    string `json:"name"`
 	Status  string `json:"status"`
 	Matched bool   `json:"matched"`
-	Error   string `json:"error,omitempty"`
 }
 
 // TraceResource is the JSON representation of a resource result.
@@ -66,19 +66,19 @@ type TraceResource struct {
 
 // TracePostAction is the JSON representation of a post-action result.
 type TracePostAction struct {
+	Error   string `json:"error,omitempty"`
 	Name    string `json:"name"`
 	Status  string `json:"status"`
 	Skipped bool   `json:"skipped,omitempty"`
-	Error   string `json:"error,omitempty"`
 }
 
 // TraceAPIRequest is the JSON representation of a recorded API request.
 type TraceAPIRequest struct {
+	Request    string `json:"requestBody,omitempty"`
+	Response   string `json:"responseBody,omitempty"`
 	Method     string `json:"method"`
 	URL        string `json:"url"`
 	StatusCode int    `json:"statusCode"`
-	Request    string `json:"requestBody,omitempty"`
-	Response   string `json:"responseBody,omitempty"`
 }
 
 // TraceTransportOp is the JSON representation of a recorded transport operation.
@@ -188,7 +188,7 @@ func (t *ExecutionTrace) FormatText() string {
 
 			if t.Verbose {
 				for _, tr := range t.Transport.Records {
-					if tr.Operation == "apply" && tr.Name == rr.ResourceName && tr.Namespace == rr.Namespace {
+					if tr.Operation == operationApply && tr.GVK.Kind == rr.Kind && tr.Name == rr.ResourceName && tr.Namespace == rr.Namespace {
 						fmt.Fprintf(&b, "    [verbose] Rendered manifest:\n      %s\n", prettyJSON(tr.Manifest))
 						break
 					}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -105,13 +105,15 @@ func (e *Executor) Execute(ctx context.Context, data interface{}) *ExecutionResu
 
 	// Phase 1: Parameter Extraction
 	e.log.Infof(ctx, "Phase %s: RUNNING", result.CurrentPhase)
-	if err := e.executeParamExtraction(execCtx); err != nil {
+	if paramErr := e.executeParamExtraction(execCtx); paramErr != nil {
 		result.Status = StatusFailed
-		result.Errors[PhaseParamExtraction] = err
-		execCtx.SetError("ParameterExtractionFailed", err.Error())
-		resErr := fmt.Errorf("resource execution failed: %w", err)
+		result.Errors[PhaseParamExtraction] = paramErr
+		execCtx.SetError("ParameterExtractionFailed", paramErr.Error())
+		resErr := fmt.Errorf("parameter extraction failed: %w", paramErr)
 		errCtx := logger.WithErrorField(ctx, resErr)
-		e.log.Errorf(errCtx, "Phase %s: FAILED", result.CurrentPhase)
+		e.log.Errorf(errCtx, "Phase %s: FAILED", PhaseParamExtraction)
+		result.ExecutionContext = execCtx
+		result.Params = execCtx.Params
 		return result
 	}
 	result.Params = execCtx.Params
@@ -152,15 +154,15 @@ func (e *Executor) Execute(ctx context.Context, data interface{}) *ExecutionResu
 	resources := e.config.Config.Resources
 	e.log.Infof(ctx, "Phase %s: RUNNING - %d configured", result.CurrentPhase, len(resources))
 	if !result.ResourcesSkipped {
-		resourceResults, err := e.resourceExecutor.ExecuteAll(ctx, resources, execCtx)
+		resourceResults, resourceErr := e.resourceExecutor.ExecuteAll(ctx, resources, execCtx)
 		result.ResourceResults = resourceResults
 
-		if err != nil {
+		if resourceErr != nil {
 			result.Status = StatusFailed
-			resErr := fmt.Errorf("resource execution failed: %w", err)
+			resErr := fmt.Errorf("resource execution failed: %w", resourceErr)
 			result.Errors[result.CurrentPhase] = resErr
-			execCtx.SetError("ResourceFailed", err.Error())
-			errCtx := logger.WithErrorField(ctx, err)
+			execCtx.SetError("ResourceFailed", resourceErr.Error())
+			errCtx := logger.WithErrorField(ctx, resourceErr)
 			e.log.Errorf(errCtx, "Phase %s: FAILED", result.CurrentPhase)
 			// Continue to post actions for error reporting
 		} else {

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -26,8 +26,8 @@ func newMockAPIClient() *hyperfleet_api.MockClient {
 // TestNewExecutor tests the NewExecutor function
 func TestNewExecutor(t *testing.T) {
 	tests := []struct {
-		name        string
 		config      *ExecutorConfig
+		name        string
 		expectError bool
 	}{
 		{
@@ -302,10 +302,10 @@ func TestParamExtractor(t *testing.T) {
 	_ = evt.SetData(event.ApplicationJSON, eventData)
 
 	tests := []struct {
-		name        string
-		params      []config_loader.Parameter
-		expectKey   string
 		expectValue interface{}
+		name        string
+		expectKey   string
+		params      []config_loader.Parameter
 		expectError bool
 	}{
 		{
@@ -473,11 +473,11 @@ func TestRenderTemplate(t *testing.T) {
 func TestSequentialExecution_Preconditions(t *testing.T) {
 	tests := []struct {
 		name             string
+		expectedLastName string
 		preconditions    []config_loader.Precondition
 		expectedResults  int // number of results before stopping
 		expectError      bool
 		expectNotMet     bool
-		expectedLastName string
 	}{
 		{
 			name: "all pass - all executed",
@@ -728,10 +728,10 @@ func TestSequentialExecution_Resources(t *testing.T) {
 // TestSequentialExecution_PostActions tests that post actions stop on first failure
 func TestSequentialExecution_PostActions(t *testing.T) {
 	tests := []struct {
+		mockError       error
+		mockResponse    *hyperfleet_api.Response
 		name            string
 		postActions     []config_loader.PostAction
-		mockResponse    *hyperfleet_api.Response
-		mockError       error
 		expectedResults int
 		expectError     bool
 	}{
@@ -799,8 +799,8 @@ func TestSequentialExecution_PostActions(t *testing.T) {
 func TestSequentialExecution_SkipReasonCapture(t *testing.T) {
 	tests := []struct {
 		name           string
-		preconditions  []config_loader.Precondition
 		expectedStatus ExecutionStatus
+		preconditions  []config_loader.Precondition
 		expectSkipped  bool
 	}{
 		{

--- a/internal/executor/param_extractor_test.go
+++ b/internal/executor/param_extractor_test.go
@@ -10,9 +10,9 @@ import (
 func TestConvertParamType(t *testing.T) {
 	tests := []struct {
 		name       string
+		want       interface{}
 		value      interface{}
 		targetType string
-		want       interface{}
 		wantErr    bool
 	}{
 		// String conversions
@@ -95,8 +95,8 @@ func TestConvertToString(t *testing.T) {
 
 func TestConvertToInt64(t *testing.T) {
 	tests := []struct {
-		name    string
 		value   interface{}
+		name    string
 		want    int64
 		wantErr bool
 	}{
@@ -127,8 +127,8 @@ func TestConvertToInt64(t *testing.T) {
 
 func TestConvertToFloat64(t *testing.T) {
 	tests := []struct {
-		name    string
 		value   interface{}
+		name    string
 		want    float64
 		wantErr bool
 	}{
@@ -159,10 +159,10 @@ func TestConvertToFloat64(t *testing.T) {
 
 func TestConvertToBool(t *testing.T) {
 	tests := []struct {
-		name    string
 		value   interface{}
-		want    bool
+		name    string
 		wantErr bool
+		want    bool
 	}{
 		{name: "bool true", value: true, want: true},
 		{name: "bool false", value: false, want: false},

--- a/internal/executor/post_action_executor_test.go
+++ b/internal/executor/post_action_executor_test.go
@@ -28,10 +28,10 @@ func TestBuildPayload(t *testing.T) {
 	pae := testPAE()
 
 	tests := []struct {
-		name        string
+		expected    interface{}
 		build       interface{}
 		params      map[string]interface{}
-		expected    interface{}
+		name        string
 		expectError bool
 	}{
 		{
@@ -117,10 +117,10 @@ func TestBuildMapPayload(t *testing.T) {
 	pae := testPAE()
 
 	tests := []struct {
-		name        string
+		expected    map[string]interface{}
 		input       map[string]interface{}
 		params      map[string]interface{}
-		expected    map[string]interface{}
+		name        string
 		expectError bool
 	}{
 		{
@@ -196,11 +196,11 @@ func TestProcessValue(t *testing.T) {
 	pae := testPAE()
 
 	tests := []struct {
-		name        string
+		expected    interface{}
 		value       interface{}
 		params      map[string]interface{}
 		evalCtxData map[string]interface{}
-		expected    interface{}
+		name        string
 		expectError bool
 	}{
 		{
@@ -304,9 +304,9 @@ func TestProcessValue(t *testing.T) {
 
 func TestPostActionExecutor_ExecuteAll(t *testing.T) {
 	tests := []struct {
-		name            string
 		postConfig      *config_loader.PostConfig
 		mockResponse    *hyperfleet_api.Response
+		name            string
 		expectedResults int
 		expectError     bool
 	}{
@@ -406,14 +406,14 @@ func TestPostActionExecutor_ExecuteAll(t *testing.T) {
 
 func TestExecuteAPICall(t *testing.T) {
 	tests := []struct {
-		name         string
+		mockError    error
 		apiCall      *config_loader.APICall
 		params       map[string]interface{}
 		mockResponse *hyperfleet_api.Response
-		mockError    error
-		expectError  bool
+		name         string
 		expectedURL  string
 		expectedBody string // optional: for POST/PUT/PATCH, assert last request body (rendered payload)
+		expectError  bool
 	}{
 		{
 			name:        "nil api call",

--- a/internal/executor/resource_executor.go
+++ b/internal/executor/resource_executor.go
@@ -78,7 +78,7 @@ func (re *ResourceExecutor) executeResource(ctx context.Context, resource config
 
 	// Step 2: Extract resource identity from rendered manifest for result reporting
 	var obj unstructured.Unstructured
-	if err := json.Unmarshal(renderedBytes, &obj.Object); err == nil {
+	if unmarshalErr := json.Unmarshal(renderedBytes, &obj.Object); unmarshalErr == nil {
 		result.Kind = obj.GetKind()
 		result.Namespace = obj.GetNamespace()
 		result.ResourceName = obj.GetName()
@@ -441,21 +441,21 @@ func deepCopyMap(ctx context.Context, m map[string]interface{}, log logger.Logge
 	if err != nil {
 		// Fallback to shallow copy if deep copy fails
 		log.Warnf(ctx, "Failed to deep copy map: %v. Falling back to shallow copy.", err)
-		result := make(map[string]interface{})
+		fallback := make(map[string]interface{})
 		for k, v := range m {
-			result[k] = v
+			fallback[k] = v
 		}
-		return result
+		return fallback
 	}
 
 	result, ok := copied.(map[string]interface{})
 	if !ok {
 		// Should not happen, but handle gracefully
-		result := make(map[string]interface{})
+		fallback := make(map[string]interface{})
 		for k, v := range m {
-			result[k] = v
+			fallback[k] = v
 		}
-		return result
+		return fallback
 	}
 
 	return result

--- a/internal/executor/types.go
+++ b/internal/executor/types.go
@@ -48,11 +48,11 @@ type ResourceRef struct {
 
 // EventData represents the data payload of a HyperFleet CloudEvent
 type EventData struct {
+	OwnerReferences *ResourceRef `json:"owner_references,omitempty"`
 	ID              string       `json:"id,omitempty"`
 	Kind            string       `json:"kind,omitempty"`
 	Href            string       `json:"href,omitempty"`
 	Generation      int64        `json:"generation,omitempty"`
-	OwnerReferences *ResourceRef `json:"owner_references,omitempty"`
 }
 
 // ExecutorConfig holds configuration for the executor
@@ -80,52 +80,54 @@ type Executor struct {
 
 // ExecutionResult contains the result of processing an event
 type ExecutionResult struct {
+	// ExecutionContext contains the full execution context (for testing and debugging)
+	ExecutionContext *ExecutionContext
+	// Params contains the extracted parameters
+	Params map[string]interface{}
+	// Errors contains errors keyed by the phase where they occurred
+	Errors map[ExecutionPhase]error
+	// SkipReason is why resources were skipped (e.g., "precondition not met")
+	SkipReason string
 	// Status is the overall execution status (runtime perspective)
 	Status ExecutionStatus
 	// CurrentPhase is the phase where execution ended (or is currently)
 	CurrentPhase ExecutionPhase
-	// Params contains the extracted parameters
-	Params map[string]interface{}
 	// PreconditionResults contains results of precondition evaluations
 	PreconditionResults []PreconditionResult
 	// ResourceResults contains results of resource operations
 	ResourceResults []ResourceResult
 	// PostActionResults contains results of post-action executions
 	PostActionResults []PostActionResult
-	// Errors contains errors keyed by the phase where they occurred
-	Errors map[ExecutionPhase]error
 	// ResourcesSkipped indicates if resources were skipped (business outcome)
 	ResourcesSkipped bool
-	// SkipReason is why resources were skipped (e.g., "precondition not met")
-	SkipReason string
-	// ExecutionContext contains the full execution context (for testing and debugging)
-	ExecutionContext *ExecutionContext
 }
 
 // PreconditionResult contains the result of a single precondition evaluation
 type PreconditionResult struct {
+	// Error is the error if Status is StatusFailed
+	Error error
+	// CapturedFields contains fields captured from the API response
+	CapturedFields map[string]interface{}
+	// CELResult contains CEL evaluation result (if expression was used)
+	CELResult *criteria.CELResult
 	// Name is the precondition name
 	Name string
 	// Status is the result status
 	Status ExecutionStatus
+	// APIResponse contains the raw API response (if APICallMade)
+	APIResponse []byte
+	// ConditionResults contains individual condition evaluation results
+	ConditionResults []criteria.EvaluationResult
 	// Matched indicates if conditions were satisfied
 	Matched bool
 	// APICallMade indicates if an API call was made
 	APICallMade bool
-	// APIResponse contains the raw API response (if APICallMade)
-	APIResponse []byte
-	// CapturedFields contains fields captured from the API response
-	CapturedFields map[string]interface{}
-	// ConditionResults contains individual condition evaluation results
-	ConditionResults []criteria.EvaluationResult
-	// CELResult contains CEL evaluation result (if expression was used)
-	CELResult *criteria.CELResult
-	// Error is the error if Status is StatusFailed
-	Error error
 }
 
 // ResourceResult contains the result of a single resource operation
 type ResourceResult struct {
+	// Error is the error if Status is StatusFailed
+	Error error
 	// Name is the resource name from config
 	Name string
 	// Kind is the Kubernetes resource kind
@@ -134,35 +136,33 @@ type ResourceResult struct {
 	Namespace string
 	// ResourceName is the actual K8s resource name
 	ResourceName string
+	// OperationReason explains why this operation was performed
+	// Examples: "resource not found", "generation changed from 1 to 2", "generation 1 unchanged", "recreate_on_change=true"
+	OperationReason string
 	// Status is the result status
 	Status ExecutionStatus
 	// Operation is the operation performed (create, update, recreate, skip)
 	Operation manifest.Operation
-	// OperationReason explains why this operation was performed
-	// Examples: "resource not found", "generation changed from 1 to 2", "generation 1 unchanged", "recreate_on_change=true"
-	OperationReason string
-	// Error is the error if Status is StatusFailed
-	Error error
 }
 
 // PostActionResult contains the result of a single post-action execution
 type PostActionResult struct {
+	// Error is the error if Status is StatusFailed
+	Error error
 	// Name is the post-action name
 	Name string
-	// Status is the result status
-	Status ExecutionStatus
-	// Skipped indicates if the action was skipped due to when condition
-	Skipped bool
 	// SkipReason is the reason for skipping
 	SkipReason string
-	// APICallMade indicates if an API call was made
-	APICallMade bool
+	// Status is the result status
+	Status ExecutionStatus
 	// APIResponse contains the raw API response (if APICallMade)
 	APIResponse []byte
 	// HTTPStatus is the HTTP status code of the API response
 	HTTPStatus int
-	// Error is the error if Status is StatusFailed
-	Error error
+	// Skipped indicates if the action was skipped due to when condition
+	Skipped bool
+	// APICallMade indicates if an API call was made
+	APICallMade bool
 }
 
 // ExecutionContext holds runtime context during execution
@@ -181,29 +181,29 @@ type ExecutionContext struct {
 	// Nested discoveries are also added as top-level entries keyed by nested discovery name.
 	// Values are expected to be *unstructured.Unstructured.
 	Resources map[string]interface{}
-	// Adapter holds adapter execution metadata
-	Adapter AdapterMetadata
 	// Evaluations tracks all condition evaluations for debugging/auditing
 	Evaluations []EvaluationRecord
+	// Adapter holds adapter execution metadata
+	Adapter AdapterMetadata
 }
 
 // EvaluationRecord tracks a single condition evaluation during execution
 type EvaluationRecord struct {
-	// Phase is the execution phase where this evaluation occurred
-	Phase ExecutionPhase
-	// Name is the name of the precondition/resource/action being evaluated
-	Name string
-	// EvaluationType indicates what kind of evaluation was performed
-	EvaluationType EvaluationType
-	// Expression is the CEL expression or condition description
-	Expression string
-	// Matched indicates whether the evaluation succeeded
-	Matched bool
 	// FieldResults contains individual field evaluation results keyed by field path (for structured conditions)
 	// Reuses criteria.EvaluationResult to avoid duplication
 	FieldResults map[string]criteria.EvaluationResult
 	// Timestamp is when the evaluation occurred
 	Timestamp time.Time
+	// Name is the name of the precondition/resource/action being evaluated
+	Name string
+	// Expression is the CEL expression or condition description
+	Expression string
+	// Phase is the execution phase where this evaluation occurred
+	Phase ExecutionPhase
+	// EvaluationType indicates what kind of evaluation was performed
+	EvaluationType EvaluationType
+	// Matched indicates whether the evaluation succeeded
+	Matched bool
 }
 
 // EvaluationType indicates the type of evaluation performed
@@ -218,18 +218,18 @@ const (
 
 // AdapterMetadata holds adapter execution metadata for CEL expressions
 type AdapterMetadata struct {
+	// ExecutionError contains detailed error information if execution failed
+	ExecutionError *ExecutionError `json:"executionError,omitempty"`
 	// ExecutionStatus is the overall execution status (runtime perspective: "success", "failed")
 	ExecutionStatus string
 	// ErrorReason is the error reason if failed (process execution errors only)
 	ErrorReason string
 	// ErrorMessage is the error message if failed (process execution errors only)
 	ErrorMessage string
-	// ExecutionError contains detailed error information if execution failed
-	ExecutionError *ExecutionError `json:"executionError,omitempty"`
-	// ResourcesSkipped indicates if resources were skipped (business outcome)
-	ResourcesSkipped bool `json:"resourcesSkipped,omitempty"`
 	// SkipReason is why resources were skipped (e.g., "precondition not met")
 	SkipReason string `json:"skipReason,omitempty"`
+	// ResourcesSkipped indicates if resources were skipped (business outcome)
+	ResourcesSkipped bool `json:"resourcesSkipped,omitempty"`
 }
 
 // ExecutionError represents a structured execution error
@@ -307,6 +307,10 @@ func (ec *ExecutionContext) SetError(reason, message string) {
 	ec.Adapter.ExecutionStatus = string(StatusFailed)
 	ec.Adapter.ErrorReason = reason
 	ec.Adapter.ErrorMessage = message
+	ec.Adapter.ExecutionError = &ExecutionError{
+		Phase:   reason,
+		Message: message,
+	}
 }
 
 // SetSkipped sets the status to indicate execution was skipped (not an error)
@@ -358,10 +362,10 @@ func (ec *ExecutionContext) GetCELVariables() map[string]interface{} {
 
 // ExecutorError represents an error during execution
 type ExecutorError struct {
+	Err     error
 	Phase   ExecutionPhase
 	Step    string
 	Message string
-	Err     error
 }
 
 func (e *ExecutorError) Error() string {
@@ -387,13 +391,13 @@ func NewExecutorError(phase ExecutionPhase, step, message string, err error) *Ex
 
 // PreconditionsOutcome represents the high-level result of precondition evaluation
 type PreconditionsOutcome struct {
-	// AllMatched indicates whether all preconditions were satisfied (business outcome)
-	AllMatched bool
-	// Results contains individual precondition results
-	Results []PreconditionResult
 	// Error contains execution errors (API failures, parse errors, etc.)
 	// nil if preconditions were evaluated successfully, even if not matched
 	Error error
 	// NotMetReason provides details when AllMatched is false
 	NotMetReason string
+	// Results contains individual precondition results
+	Results []PreconditionResult
+	// AllMatched indicates whether all preconditions were satisfied (business outcome)
+	AllMatched bool
 }

--- a/internal/executor/utils.go
+++ b/internal/executor/utils.go
@@ -98,9 +98,9 @@ func ExecuteAPICall(ctx context.Context, apiCall *config_loader.APICall, execCtx
 	// Add headers
 	headers := make(map[string]string)
 	for _, h := range apiCall.Headers {
-		headerValue, err := renderTemplate(h.Value, execCtx.Params)
-		if err != nil {
-			return nil, url, fmt.Errorf("failed to render header '%s' template: %w", h.Name, err)
+		headerValue, headerErr := renderTemplate(h.Value, execCtx.Params)
+		if headerErr != nil {
+			return nil, url, fmt.Errorf("failed to render header '%s' template: %w", h.Name, headerErr)
 		}
 		headers[h.Name] = headerValue
 	}
@@ -110,11 +110,11 @@ func ExecuteAPICall(ctx context.Context, apiCall *config_loader.APICall, execCtx
 
 	// Set timeout if specified
 	if apiCall.Timeout != "" {
-		timeout, err := time.ParseDuration(apiCall.Timeout)
-		if err == nil {
+		timeout, timeoutErr := time.ParseDuration(apiCall.Timeout)
+		if timeoutErr == nil {
 			opts = append(opts, hyperfleet_api.WithRequestTimeout(timeout))
 		} else {
-			log.Warnf(ctx, "failed to parse timeout '%s': %v, using default timeout", apiCall.Timeout, err)
+			log.Warnf(ctx, "failed to parse timeout '%s': %v, using default timeout", apiCall.Timeout, timeoutErr)
 		}
 	}
 

--- a/internal/executor/utils_test.go
+++ b/internal/executor/utils_test.go
@@ -89,9 +89,9 @@ func TestValidateAPIResponse_WithError_NonAPIError(t *testing.T) {
 func TestValidateAPIResponse_NonSuccessStatusCodes(t *testing.T) {
 	tests := []struct {
 		name        string
-		statusCode  int
 		status      string
 		body        []byte
+		statusCode  int
 		expectError bool
 		expectBody  bool
 	}{
@@ -206,8 +206,8 @@ func TestValidateAPIResponse_NonSuccessStatusCodes(t *testing.T) {
 func TestValidateAPIResponse_SuccessStatusCodes(t *testing.T) {
 	tests := []struct {
 		name       string
-		statusCode int
 		status     string
+		statusCode int
 	}{
 		{
 			name:       "200 OK",
@@ -437,8 +437,8 @@ func TestValidateAPIResponse_ResponseBodyString(t *testing.T) {
 func TestToConditionDefs(t *testing.T) {
 	tests := []struct {
 		name       string
-		conditions []config_loader.Condition
 		expected   []criteria.ConditionDef
+		conditions []config_loader.Condition
 	}{
 		{
 			name:       "empty conditions",
@@ -505,9 +505,9 @@ func TestToConditionDefs(t *testing.T) {
 // TestRenderTemplateBytes tests template rendering to bytes
 func TestRenderTemplateBytes(t *testing.T) {
 	tests := []struct {
+		data        map[string]interface{}
 		name        string
 		template    string
-		data        map[string]interface{}
 		expected    []byte
 		expectError bool
 	}{
@@ -555,9 +555,9 @@ func TestRenderTemplateBytes(t *testing.T) {
 // TestExecutionErrorToMap tests conversion of ExecutionError to map
 func TestExecutionErrorToMap(t *testing.T) {
 	tests := []struct {
-		name     string
-		execErr  *ExecutionError
 		expected interface{}
+		execErr  *ExecutionError
+		name     string
 	}{
 		{
 			name:     "nil error",
@@ -613,9 +613,9 @@ func TestExecutionErrorToMap(t *testing.T) {
 // TestAdapterMetadataToMap tests conversion of AdapterMetadata to map
 func TestAdapterMetadataToMap(t *testing.T) {
 	tests := []struct {
-		name     string
-		adapter  *AdapterMetadata
 		expected map[string]interface{}
+		adapter  *AdapterMetadata
+		name     string
 	}{
 		{
 			name:     "nil adapter",
@@ -715,9 +715,9 @@ func TestAdapterMetadataToMap(t *testing.T) {
 // TestExecuteLogAction tests log action execution
 func TestExecuteLogAction(t *testing.T) {
 	tests := []struct {
-		name       string
 		logAction  *config_loader.LogAction
 		params     map[string]interface{}
+		name       string
 		expectCall bool
 	}{
 		{
@@ -786,9 +786,9 @@ func TestExecuteLogAction(t *testing.T) {
 // TestConvertToStringKeyMap tests map key conversion
 func TestConvertToStringKeyMap(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    map[interface{}]interface{}
 		expected map[string]interface{}
+		input    map[interface{}]interface{}
+		name     string
 	}{
 		{
 			name:     "empty map",
@@ -870,8 +870,8 @@ func TestConvertToStringKeyMap(t *testing.T) {
 func TestConvertSlice(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    []interface{}
 		expected []interface{}
+		input    []interface{}
 	}{
 		{
 			name:     "empty slice",
@@ -938,9 +938,9 @@ func TestConvertSlice(t *testing.T) {
 // TestBuildResourcesMap tests building resources map for CEL
 func TestBuildResourcesMap(t *testing.T) {
 	tests := []struct {
-		name      string
-		resources map[string]*unstructured.Unstructured
 		expected  map[string]interface{}
+		resources map[string]*unstructured.Unstructured
+		name      string
 	}{
 		{
 			name:      "nil resources",
@@ -1028,9 +1028,9 @@ func TestBuildResourcesMap(t *testing.T) {
 // TestGetResourceAsMap tests resource to map conversion
 func TestGetResourceAsMap(t *testing.T) {
 	tests := []struct {
-		name     string
-		resource *unstructured.Unstructured
 		expected map[string]interface{}
+		resource *unstructured.Unstructured
+		name     string
 	}{
 		{
 			name:     "nil resource",
@@ -1095,10 +1095,10 @@ func TestGetResourceAsMap(t *testing.T) {
 
 func TestBuildHyperfleetAPICallURL(t *testing.T) {
 	tests := []struct {
-		name     string
-		url      string
 		execCtx  *ExecutionContext
+		name     string
 		expected string
+		url      string
 	}{
 		{
 			name:     "empty URL returns empty",

--- a/internal/generation/generation_test.go
+++ b/internal/generation/generation_test.go
@@ -13,11 +13,11 @@ import (
 func TestCompareGenerations(t *testing.T) {
 	tests := []struct {
 		name              string
+		expectedReason    string
+		expectedOperation Operation
 		newGen            int64
 		existingGen       int64
 		exists            bool
-		expectedOperation Operation
-		expectedReason    string
 	}{
 		{
 			name:              "resource does not exist - create",
@@ -156,8 +156,8 @@ func TestGetGeneration(t *testing.T) {
 
 func TestGetGenerationFromUnstructured(t *testing.T) {
 	tests := []struct {
-		name     string
 		obj      *unstructured.Unstructured
+		name     string
 		expected int64
 	}{
 		{
@@ -319,8 +319,8 @@ func TestValidateGeneration(t *testing.T) {
 
 func TestValidateGenerationFromUnstructured(t *testing.T) {
 	tests := []struct {
-		name        string
 		obj         *unstructured.Unstructured
+		name        string
 		expectError bool
 	}{
 		{
@@ -477,8 +477,8 @@ func TestValidateManifestWorkGeneration(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
 		work        *workv1.ManifestWork
+		name        string
 		expectError bool
 	}{
 		{
@@ -601,8 +601,8 @@ func TestValidateManifestWorkGeneration(t *testing.T) {
 
 func TestGetLatestGenerationFromList(t *testing.T) {
 	tests := []struct {
-		name         string
 		list         *unstructured.UnstructuredList
+		name         string
 		expectedName string
 		expectNil    bool
 	}{

--- a/internal/hyperfleet_api/types.go
+++ b/internal/hyperfleet_api/types.go
@@ -36,23 +36,23 @@ const (
 
 // ClientConfig holds the configuration for the HTTP client
 type ClientConfig struct {
+	// DefaultHeaders are headers added to all requests
+	DefaultHeaders map[string]string `yaml:"default_headers,omitempty" mapstructure:"default_headers"`
 	// BaseURL is the base URL for all API requests (must be set by caller)
 	// Relative URLs in requests will be prefixed with this
 	BaseURL string `yaml:"base_url,omitempty" mapstructure:"base_url"`
 	// Version is the HyperFleet API version (e.g., "v1")
 	Version string `yaml:"version,omitempty" mapstructure:"version"`
-	// Timeout is the HTTP client timeout for requests
-	Timeout time.Duration `yaml:"timeout,omitempty" mapstructure:"timeout"`
-	// RetryAttempts is the number of retry attempts for failed requests
-	RetryAttempts int `yaml:"retry_attempts,omitempty" mapstructure:"retry_attempts"`
 	// RetryBackoff is the backoff strategy for retries
 	RetryBackoff BackoffStrategy `yaml:"retry_backoff,omitempty" mapstructure:"retry_backoff"`
+	// Timeout is the HTTP client timeout for requests
+	Timeout time.Duration `yaml:"timeout,omitempty" mapstructure:"timeout"`
 	// BaseDelay is the initial delay for retry backoff
 	BaseDelay time.Duration `yaml:"base_delay,omitempty" mapstructure:"base_delay"`
 	// MaxDelay is the maximum delay for retry backoff
 	MaxDelay time.Duration `yaml:"max_delay,omitempty" mapstructure:"max_delay"`
-	// DefaultHeaders are headers added to all requests
-	DefaultHeaders map[string]string `yaml:"default_headers,omitempty" mapstructure:"default_headers"`
+	// RetryAttempts is the number of retry attempts for failed requests
+	RetryAttempts int `yaml:"retry_attempts,omitempty" mapstructure:"retry_attempts"`
 }
 
 // DefaultClientConfig returns a ClientConfig with default values
@@ -74,20 +74,20 @@ func DefaultClientConfig() *ClientConfig {
 
 // Request represents an HTTP request to the HyperFleet API
 type Request struct {
+	// Headers are the HTTP headers for the request
+	Headers map[string]string
+	// RetryBackoff overrides the client retry backoff for this request
+	RetryBackoff *BackoffStrategy
+	// RetryAttempts overrides the client retry attempts for this request
+	RetryAttempts *int
 	// Method is the HTTP method (GET, POST, PUT, PATCH, DELETE)
 	Method string
 	// URL is the full URL for the request
 	URL string
-	// Headers are the HTTP headers for the request
-	Headers map[string]string
 	// Body is the request body (for POST, PUT, PATCH)
 	Body []byte
 	// Timeout overrides the client timeout for this request
 	Timeout time.Duration
-	// RetryAttempts overrides the client retry attempts for this request
-	RetryAttempts *int
-	// RetryBackoff overrides the client retry backoff for this request
-	RetryBackoff *BackoffStrategy
 }
 
 // RequestOption is a functional option for configuring a request
@@ -160,16 +160,16 @@ func WithRequestRetryBackoff(backoff BackoffStrategy) RequestOption {
 
 // Response represents an HTTP response from the HyperFleet API
 type Response struct {
-	// StatusCode is the HTTP status code
-	StatusCode int
-	// Status is the HTTP status string (e.g., "200 OK")
-	Status string
 	// Headers are the response headers
 	Headers map[string][]string
+	// Status is the HTTP status string (e.g., "200 OK")
+	Status string
 	// Body is the response body
 	Body []byte
 	// Duration is how long the request took
 	Duration time.Duration
+	// StatusCode is the HTTP status code
+	StatusCode int
 	// Attempts is how many attempts were made (including retries)
 	Attempts int
 }

--- a/internal/k8s_client/README.md
+++ b/internal/k8s_client/README.md
@@ -112,7 +112,7 @@ client, err := NewClient(ctx, config, log)
 
 ```go
 // ✅ CORRECT: Extract from adapter config
-gvk, err := GVKFromKindAndApiVersion("Deployment", "apps/v1")
+gvk, err := GVKFromKindAndAPIVersion("Deployment", "apps/v1")
 if err != nil {
     return fmt.Errorf("invalid GVK: %w", err)
 }
@@ -149,7 +149,7 @@ cm := &unstructured.Unstructured{
         },
     },
 }
-gvk, _ := GVKFromKindAndApiVersion("ConfigMap", "v1")
+gvk, _ := GVKFromKindAndAPIVersion("ConfigMap", "v1")
 cm.SetGroupVersionKind(gvk)
 
 created, err := client.CreateResource(ctx, cm)
@@ -159,7 +159,7 @@ created, err := client.CreateResource(ctx, cm)
 
 ```go
 // Get a custom resource
-gvk, _ := GVKFromKindAndApiVersion("MyResource", "example.com/v1")
+gvk, _ := GVKFromKindAndAPIVersion("MyResource", "example.com/v1")
 resource, err := client.GetResource(ctx, gvk, "default", "my-resource")
 
 if err != nil {
@@ -186,7 +186,7 @@ if found {
 The `DiscoverResources` method provides flexible resource discovery:
 
 ```go
-gvk, _ := GVKFromKindAndApiVersion("Pod", "v1")
+gvk, _ := GVKFromKindAndAPIVersion("Pod", "v1")
 
 // List by label selector
 discovery := &k8s_client.DiscoveryConfig{
@@ -216,7 +216,7 @@ list, err := client.DiscoverResources(ctx, gvk, discovery)
 For simple listing without the Discovery interface:
 
 ```go
-gvk, _ := GVKFromKindAndApiVersion("Pod", "v1")
+gvk, _ := GVKFromKindAndAPIVersion("Pod", "v1")
 
 // List by label selector
 list, err := client.ListResources(ctx, gvk, "default", "app=myapp,env=prod")
@@ -312,7 +312,7 @@ See `test/integration/k8s_client/` for integration test examples and setup guide
 
 ## Best Practices
 
-1. **Always extract GVK from config** using `GVKFromKindAndApiVersion()`
+1. **Always extract GVK from config** using `GVKFromKindAndAPIVersion()`
 2. **Use in-cluster auth for production** (empty `KubeConfigPath`)
 3. **Set appropriate rate limits** to avoid overwhelming the API server
 4. **Handle errors gracefully** - check for `IsNotFound`, `IsAlreadyExists`, etc.

--- a/internal/k8s_client/test_helpers_test.go
+++ b/internal/k8s_client/test_helpers_test.go
@@ -10,7 +10,7 @@ import (
 // CommonResourceKinds provides commonly used GroupVersionKinds for testing purposes ONLY.
 //
 // This is a test helper and should NOT be used in production code.
-// Production code must extract GVK from config using GVKFromKindAndApiVersion().
+// Production code must extract GVK from config using GVKFromKindAndAPIVersion().
 //
 // Available only in test builds for:
 //   - Unit tests (internal/k8s_client/*_test.go)

--- a/internal/k8s_client/types.go
+++ b/internal/k8s_client/types.go
@@ -5,7 +5,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// GVKFromKindAndApiVersion creates a GroupVersionKind from kind and apiVersion strings.
+// GVKFromKindAndAPIVersion creates a GroupVersionKind from kind and apiVersion strings.
 //
 // This is the PRIMARY method for extracting GVK from adapter config templates.
 // All production code should use this function with values from the config YAML.
@@ -16,14 +16,14 @@ import (
 //	//   - kind: "Deployment"
 //	//     apiVersion: "apps/v1"
 //
-//	gvk, err := GVKFromKindAndApiVersion(resource.Kind, resource.ApiVersion)
+//	gvk, err := GVKFromKindAndAPIVersion(resource.Kind, resource.ApiVersion)
 //	if err != nil {
 //	    return fmt.Errorf("invalid GVK in config: %w", err)
 //	}
 //
 //	// Now use gvk with client operations:
 //	obj, err := client.GetResource(ctx, gvk, namespace, name)
-func GVKFromKindAndApiVersion(kind, apiVersion string) (schema.GroupVersionKind, error) {
+func GVKFromKindAndAPIVersion(kind, apiVersion string) (schema.GroupVersionKind, error) {
 	gv, err := schema.ParseGroupVersion(apiVersion)
 	if err != nil {
 		return schema.GroupVersionKind{}, err
@@ -55,4 +55,4 @@ func GVKFromUnstructured(obj *unstructured.Unstructured) schema.GroupVersionKind
 
 // NOTE: CommonResourceKinds has been moved to test_helpers.go
 // It is for testing purposes only and should not be used in production code.
-// Production code must extract GVK from config using GVKFromKindAndApiVersion().
+// Production code must extract GVK from config using GVKFromKindAndAPIVersion().

--- a/internal/k8s_client/types_test.go
+++ b/internal/k8s_client/types_test.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func TestGVKFromKindAndApiVersion(t *testing.T) {
+func TestGVKFromKindAndAPIVersion(t *testing.T) {
 	tests := []struct {
 		name       string
 		kind       string
@@ -95,20 +95,20 @@ func TestGVKFromKindAndApiVersion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GVKFromKindAndApiVersion(tt.kind, tt.apiVersion)
+			got, err := GVKFromKindAndAPIVersion(tt.kind, tt.apiVersion)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("GVKFromKindAndApiVersion() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("GVKFromKindAndAPIVersion() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !tt.wantErr {
 				if got.Group != tt.want.Group {
-					t.Errorf("GVKFromKindAndApiVersion() Group = %v, want %v", got.Group, tt.want.Group)
+					t.Errorf("GVKFromKindAndAPIVersion() Group = %v, want %v", got.Group, tt.want.Group)
 				}
 				if got.Version != tt.want.Version {
-					t.Errorf("GVKFromKindAndApiVersion() Version = %v, want %v", got.Version, tt.want.Version)
+					t.Errorf("GVKFromKindAndAPIVersion() Version = %v, want %v", got.Version, tt.want.Version)
 				}
 				if got.Kind != tt.want.Kind {
-					t.Errorf("GVKFromKindAndApiVersion() Kind = %v, want %v", got.Kind, tt.want.Kind)
+					t.Errorf("GVKFromKindAndAPIVersion() Kind = %v, want %v", got.Kind, tt.want.Kind)
 				}
 			}
 		})

--- a/internal/maestro_client/client.go
+++ b/internal/maestro_client/client.go
@@ -155,9 +155,9 @@ func NewMaestroClient(ctx context.Context, config *Config, log logger.Logger) (*
 	}).Info(ctx, "Creating Maestro client")
 
 	// Create HTTP client with appropriate TLS configuration
-	httpTransport, err := createHTTPTransport(config)
-	if err != nil {
-		return nil, apperrors.ConfigurationError("failed to create HTTP transport: %v", err)
+	httpTransport, transportErr := createHTTPTransport(config)
+	if transportErr != nil {
+		return nil, apperrors.ConfigurationError("failed to create HTTP transport: %v", transportErr)
 	}
 
 	// Create Maestro HTTP API client (OpenAPI)
@@ -186,8 +186,8 @@ func NewMaestroClient(ctx context.Context, config *Config, log logger.Logger) (*
 	grpcOptions.Dialer.URL = config.GRPCServerAddr
 
 	// Configure TLS if certificates are provided
-	if err := configureTLS(config, grpcOptions); err != nil {
-		return nil, apperrors.ConfigurationError("failed to configure TLS: %v", err)
+	if tlsErr := configureTLS(config, grpcOptions); tlsErr != nil {
+		return nil, apperrors.ConfigurationError("failed to configure TLS: %v", tlsErr)
 	}
 
 	// Create the Maestro gRPC work client using the official pattern
@@ -307,34 +307,34 @@ func configureTLS(config *Config, grpcOptions *grpcopts.GRPCOptions) error {
 
 	// Option 2: Token-based authentication with CA
 	if config.CAFile != "" && config.TokenFile != "" {
-		token, err := readTokenFile(config.TokenFile)
-		if err != nil {
-			return err
+		token, tokenErr := readTokenFile(config.TokenFile)
+		if tokenErr != nil {
+			return tokenErr
 		}
 		grpcOptions.Dialer.Token = token
 
 		certConfig := cert.CertConfig{
 			CAFile: config.CAFile,
 		}
-		if err := certConfig.EmbedCerts(); err != nil {
-			return err
+		if embedErr := certConfig.EmbedCerts(); embedErr != nil {
+			return embedErr
 		}
 
-		tlsConfig, err := cert.AutoLoadTLSConfig(
+		tlsConfig, tlsErr := cert.AutoLoadTLSConfig(
 			certConfig,
 			func() (*cert.CertConfig, error) {
 				c := cert.CertConfig{
 					CAFile: config.CAFile,
 				}
-				if err := c.EmbedCerts(); err != nil {
-					return nil, err
+				if embedErr := c.EmbedCerts(); embedErr != nil {
+					return nil, embedErr
 				}
 				return &c, nil
 			},
 			grpcOptions.Dialer,
 		)
-		if err != nil {
-			return err
+		if tlsErr != nil {
+			return tlsErr
 		}
 		grpcOptions.Dialer.TLSConfig = tlsConfig
 		return nil

--- a/internal/maestro_client/operations_test.go
+++ b/internal/maestro_client/operations_test.go
@@ -17,8 +17,8 @@ import (
 
 func TestIsConsumerNotFoundError(t *testing.T) {
 	tests := []struct {
-		name     string
 		err      error
+		name     string
 		expected bool
 	}{
 		{
@@ -53,8 +53,8 @@ func TestIsConsumerNotFoundError(t *testing.T) {
 
 func TestGetGenerationFromManifestWork(t *testing.T) {
 	tests := []struct {
-		name     string
 		work     *workv1.ManifestWork
+		name     string
 		expected int64
 	}{
 		{
@@ -162,10 +162,10 @@ func TestBuildManifestWorkName(t *testing.T) {
 func TestGenerationComparison(t *testing.T) {
 	tests := []struct {
 		name               string
+		description        string
 		existingGeneration int64
 		newGeneration      int64
 		shouldUpdate       bool
-		description        string
 	}{
 		{
 			name:               "same generation - no update",

--- a/internal/manifest/generation_test.go
+++ b/internal/manifest/generation_test.go
@@ -13,11 +13,11 @@ import (
 func TestCompareGenerations(t *testing.T) {
 	tests := []struct {
 		name              string
+		expectedReason    string
+		expectedOperation Operation
 		newGen            int64
 		existingGen       int64
 		exists            bool
-		expectedOperation Operation
-		expectedReason    string
 	}{
 		{
 			name:              "resource does not exist - create",
@@ -156,8 +156,8 @@ func TestGetGeneration(t *testing.T) {
 
 func TestGetGenerationFromUnstructured(t *testing.T) {
 	tests := []struct {
-		name     string
 		obj      *unstructured.Unstructured
+		name     string
 		expected int64
 	}{
 		{
@@ -319,8 +319,8 @@ func TestValidateGeneration(t *testing.T) {
 
 func TestValidateGenerationFromUnstructured(t *testing.T) {
 	tests := []struct {
-		name        string
 		obj         *unstructured.Unstructured
+		name        string
 		expectError bool
 	}{
 		{
@@ -477,8 +477,8 @@ func TestValidateManifestWorkGeneration(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
 		work        *workv1.ManifestWork
+		name        string
 		expectError bool
 	}{
 		{
@@ -601,9 +601,9 @@ func TestValidateManifestWorkGeneration(t *testing.T) {
 
 func TestEnrichWithResourceStatus(t *testing.T) {
 	tests := []struct {
-		name                 string
 		parent               *unstructured.Unstructured
 		nested               *unstructured.Unstructured
+		name                 string
 		expectStatusFeedback bool
 		expectConditions     bool
 	}{

--- a/pkg/errors/api_error.go
+++ b/pkg/errors/api_error.go
@@ -14,22 +14,22 @@ import (
 // APIError represents an error from an HTTP API call with detailed context.
 // This allows the adapter runtime to capture and handle request errors properly.
 type APIError struct {
+	// Err is the underlying error
+	Err error
 	// Method is the HTTP method used (GET, POST, PUT, PATCH, DELETE)
 	Method string
 	// URL is the request URL
 	URL string
-	// StatusCode is the HTTP status code (0 if request failed before getting response)
-	StatusCode int
 	// Status is the HTTP status string (e.g., "503 Service Unavailable")
 	Status string
 	// ResponseBody is the response body (may contain error details from the API)
 	ResponseBody []byte
-	// Attempts is how many attempts were made (including retries)
-	Attempts int
 	// Duration is the total duration including retries
 	Duration time.Duration
-	// Err is the underlying error
-	Err error
+	// StatusCode is the HTTP status code (0 if request failed before getting response)
+	StatusCode int
+	// Attempts is how many attempts were made (including retries)
+	Attempts int
 }
 
 // Error implements the error interface.

--- a/pkg/errors/cel_error.go
+++ b/pkg/errors/cel_error.go
@@ -20,14 +20,14 @@ const (
 
 // CELError represents an error during CEL expression processing
 type CELError struct {
-	// Type is the error type (parse, program, evaluation)
-	Type CELErrorType
 	// Expression is the CEL expression that caused the error
 	Expression string
 	// Reason provides a human-readable error description
 	Reason string
 	// Err is the underlying error
 	Err error
+	// Type is the error type (parse, program, evaluation)
+	Type CELErrorType
 }
 
 // Error implements the error interface
@@ -106,8 +106,8 @@ func (e *CELError) IsEval() bool {
 
 // CELEnvError represents an error when creating a CEL environment
 type CELEnvError struct {
-	Reason string
 	Err    error
+	Reason string
 }
 
 // Error implements the error interface
@@ -137,6 +137,8 @@ func NewCELEnvError(reason string, err error) *CELEnvError {
 
 // CELConversionError represents an error during condition to CEL conversion
 type CELConversionError struct {
+	// Err is the underlying error
+	Err error
 	// Field is the field being converted (for condition errors)
 	Field string
 	// Operator is the operator being used
@@ -147,8 +149,6 @@ type CELConversionError struct {
 	Reason string
 	// Index is the condition index (for multiple conditions)
 	Index int
-	// Err is the underlying error
-	Err error
 }
 
 // Error implements the error interface

--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -82,33 +82,33 @@ func Find(code ServiceErrorCode) (bool, *ServiceError) {
 
 func Errors() ServiceErrors {
 	return ServiceErrors{
-		ServiceError{ErrorNotFound, "Resource not found", http.StatusNotFound},
-		ServiceError{ErrorValidation, "General validation failure", http.StatusBadRequest},
-		ServiceError{ErrorConflict, "An entity with the specified unique values already exists", http.StatusConflict},
-		ServiceError{ErrorForbidden, "Forbidden to perform this action", http.StatusForbidden},
-		ServiceError{ErrorUnauthorized, "Account is unauthorized to perform this action", http.StatusForbidden},
-		ServiceError{ErrorUnauthenticated, "Account authentication could not be verified", http.StatusUnauthorized},
-		ServiceError{ErrorBadRequest, "Bad request", http.StatusBadRequest},
-		ServiceError{ErrorMalformedRequest, "Unable to read request body", http.StatusBadRequest},
-		ServiceError{ErrorNotImplemented, "HTTP Method not implemented for this endpoint", http.StatusMethodNotAllowed},
-		ServiceError{ErrorGeneral, "Unspecified error", http.StatusInternalServerError},
-		ServiceError{ErrorAdapterConfigNotFound, "Adapter configuration not found", http.StatusNotFound},
-		ServiceError{ErrorBrokerConnectionError, "Failed to connect to message broker", http.StatusInternalServerError},
-		ServiceError{ErrorKubernetesError, "Kubernetes API error", http.StatusInternalServerError},
-		ServiceError{ErrorHyperFleetAPIError, "HyperFleet API error", http.StatusInternalServerError},
-		ServiceError{ErrorInvalidCloudEvent, "Invalid CloudEvent", http.StatusBadRequest},
-		ServiceError{ErrorMaestroError, "Maestro API error", http.StatusInternalServerError},
-		ServiceError{ErrorConfigurationError, "Configuration error", http.StatusInternalServerError},
+		ServiceError{Code: ErrorNotFound, Reason: "Resource not found", HTTPCode: http.StatusNotFound},
+		ServiceError{Code: ErrorValidation, Reason: "General validation failure", HTTPCode: http.StatusBadRequest},
+		ServiceError{Code: ErrorConflict, Reason: "An entity with the specified unique values already exists", HTTPCode: http.StatusConflict},
+		ServiceError{Code: ErrorForbidden, Reason: "Forbidden to perform this action", HTTPCode: http.StatusForbidden},
+		ServiceError{Code: ErrorUnauthorized, Reason: "Account is unauthorized to perform this action", HTTPCode: http.StatusForbidden},
+		ServiceError{Code: ErrorUnauthenticated, Reason: "Account authentication could not be verified", HTTPCode: http.StatusUnauthorized},
+		ServiceError{Code: ErrorBadRequest, Reason: "Bad request", HTTPCode: http.StatusBadRequest},
+		ServiceError{Code: ErrorMalformedRequest, Reason: "Unable to read request body", HTTPCode: http.StatusBadRequest},
+		ServiceError{Code: ErrorNotImplemented, Reason: "HTTP Method not implemented for this endpoint", HTTPCode: http.StatusMethodNotAllowed},
+		ServiceError{Code: ErrorGeneral, Reason: "Unspecified error", HTTPCode: http.StatusInternalServerError},
+		ServiceError{Code: ErrorAdapterConfigNotFound, Reason: "Adapter configuration not found", HTTPCode: http.StatusNotFound},
+		ServiceError{Code: ErrorBrokerConnectionError, Reason: "Failed to connect to message broker", HTTPCode: http.StatusInternalServerError},
+		ServiceError{Code: ErrorKubernetesError, Reason: "Kubernetes API error", HTTPCode: http.StatusInternalServerError},
+		ServiceError{Code: ErrorHyperFleetAPIError, Reason: "HyperFleet API error", HTTPCode: http.StatusInternalServerError},
+		ServiceError{Code: ErrorInvalidCloudEvent, Reason: "Invalid CloudEvent", HTTPCode: http.StatusBadRequest},
+		ServiceError{Code: ErrorMaestroError, Reason: "Maestro API error", HTTPCode: http.StatusInternalServerError},
+		ServiceError{Code: ErrorConfigurationError, Reason: "Configuration error", HTTPCode: http.StatusInternalServerError},
 	}
 }
 
 type ServiceError struct {
-	// Code is the numeric and distinct ID for the error
-	Code ServiceErrorCode
 	// Reason is the context-specific reason the error was generated
 	Reason string
-	// HttpCode is the HttpCode associated with the error when the error is returned as an API response
-	HttpCode int
+	// Code is the numeric and distinct ID for the error
+	Code ServiceErrorCode
+	// HTTPCode is the HTTPCode associated with the error when the error is returned as an API response
+	HTTPCode int
 }
 
 // New Reason can be a string with format verbs, which will be replaced by the specified values
@@ -119,7 +119,7 @@ func New(code ServiceErrorCode, reason string, values ...interface{}) *ServiceEr
 	if !exists {
 		// Log undefined error code - using fmt.Printf as fallback since we don't have logger here
 		fmt.Printf("Undefined error code used: %d\n", code)
-		err = &ServiceError{ErrorGeneral, "Unspecified error", http.StatusInternalServerError}
+		err = &ServiceError{Code: ErrorGeneral, Reason: "Unspecified error", HTTPCode: http.StatusInternalServerError}
 	}
 
 	// If the reason is specified, use it (with formatting)

--- a/pkg/errors/error_test.go
+++ b/pkg/errors/error_test.go
@@ -8,10 +8,10 @@ import (
 func TestFind(t *testing.T) {
 	tests := []struct {
 		name       string
-		code       ServiceErrorCode
-		shouldFind bool
 		wantReason string
+		code       ServiceErrorCode
 		wantHTTP   int
+		shouldFind bool
 	}{
 		{
 			name:       "find_not_found_error",
@@ -59,8 +59,8 @@ func TestFind(t *testing.T) {
 				if err.Reason != tt.wantReason {
 					t.Errorf("Expected reason '%s', got '%s'", tt.wantReason, err.Reason)
 				}
-				if err.HttpCode != tt.wantHTTP {
-					t.Errorf("Expected HTTP code %d, got %d", tt.wantHTTP, err.HttpCode)
+				if err.HTTPCode != tt.wantHTTP {
+					t.Errorf("Expected HTTP code %d, got %d", tt.wantHTTP, err.HTTPCode)
 				}
 			}
 		})
@@ -112,11 +112,11 @@ func TestErrors(t *testing.T) {
 func TestNew(t *testing.T) {
 	tests := []struct {
 		name         string
-		code         ServiceErrorCode
 		reason       string
-		values       []interface{}
-		wantCode     ServiceErrorCode
 		wantReason   string
+		values       []interface{}
+		code         ServiceErrorCode
+		wantCode     ServiceErrorCode
 		wantHTTPCode int
 	}{
 		{
@@ -173,8 +173,8 @@ func TestNew(t *testing.T) {
 				t.Errorf("Expected reason '%s', got '%s'", tt.wantReason, err.Reason)
 			}
 
-			if err.HttpCode != tt.wantHTTPCode {
-				t.Errorf("Expected HTTP code %d, got %d", tt.wantHTTPCode, err.HttpCode)
+			if err.HTTPCode != tt.wantHTTPCode {
+				t.Errorf("Expected HTTP code %d, got %d", tt.wantHTTPCode, err.HTTPCode)
 			}
 		})
 	}
@@ -229,8 +229,8 @@ func TestServiceError_AsError(t *testing.T) {
 
 func TestServiceError_Is404(t *testing.T) {
 	tests := []struct {
-		name string
 		err  *ServiceError
+		name string
 		want bool
 	}{
 		{
@@ -261,8 +261,8 @@ func TestServiceError_Is404(t *testing.T) {
 
 func TestServiceError_IsConflict(t *testing.T) {
 	tests := []struct {
-		name string
 		err  *ServiceError
+		name string
 		want bool
 	}{
 		{
@@ -288,8 +288,8 @@ func TestServiceError_IsConflict(t *testing.T) {
 
 func TestServiceError_IsForbidden(t *testing.T) {
 	tests := []struct {
-		name string
 		err  *ServiceError
+		name string
 		want bool
 	}{
 		{
@@ -316,8 +316,8 @@ func TestServiceError_IsForbidden(t *testing.T) {
 func TestCodeStr(t *testing.T) {
 	tests := []struct {
 		name string
-		code ServiceErrorCode
 		want string
+		code ServiceErrorCode
 	}{
 		{
 			name: "not_found_code_string",
@@ -352,8 +352,8 @@ func TestCodeStr(t *testing.T) {
 func TestHref(t *testing.T) {
 	tests := []struct {
 		name string
-		code ServiceErrorCode
 		want string
+		code ServiceErrorCode
 	}{
 		{
 			name: "not_found_href",
@@ -523,8 +523,8 @@ func TestHelperFunctions(t *testing.T) {
 				t.Errorf("Expected code %d, got %d", tt.wantCode, err.Code)
 			}
 
-			if err.HttpCode != tt.wantHTTPCode {
-				t.Errorf("Expected HTTP code %d, got %d", tt.wantHTTPCode, err.HttpCode)
+			if err.HTTPCode != tt.wantHTTPCode {
+				t.Errorf("Expected HTTP code %d, got %d", tt.wantHTTPCode, err.HTTPCode)
 			}
 
 			// Check formatted reason
@@ -603,8 +603,8 @@ func TestHTTPCodeMapping(t *testing.T) {
 				t.Fatal("Find() returned nil")
 			}
 
-			if err.HttpCode != tt.wantHTTP {
-				t.Errorf("Expected HTTP code %d, got %d", tt.wantHTTP, err.HttpCode)
+			if err.HTTPCode != tt.wantHTTP {
+				t.Errorf("Expected HTTP code %d, got %d", tt.wantHTTP, err.HTTPCode)
 			}
 		})
 	}

--- a/pkg/errors/k8s_error.go
+++ b/pkg/errors/k8s_error.go
@@ -14,6 +14,8 @@ import (
 // K8sOperationError represents a structured Kubernetes operation error with detailed context.
 // This allows callers to handle K8s errors with full information about what failed.
 type K8sOperationError struct {
+	// Err is the underlying error
+	Err error
 	// Operation is the operation that failed: "create", "update", "delete", "get", "patch", "list"
 	Operation string
 	// Resource is the resource name
@@ -24,8 +26,6 @@ type K8sOperationError struct {
 	Namespace string
 	// Message is the error message
 	Message string
-	// Err is the underlying error
-	Err error
 }
 
 // Error implements the error interface
@@ -103,12 +103,18 @@ func NewK8sInvalidPathError(resourceType, path, expectedFormat string) *K8sInval
 
 // K8sResourceDataError represents an error when accessing or parsing resource data
 type K8sResourceDataError struct {
-	ResourceType string // "Secret" or "ConfigMap"
-	Namespace    string
+	// Err is the underlying error
+	Err error
+	// ResourceType is "Secret" or "ConfigMap"
+	ResourceType string
+	// ResourceName is the resource name
 	ResourceName string
-	Field        string // e.g., "data", or specific key name
-	Reason       string // What went wrong
-	Err          error  // Underlying error
+	// Namespace is the resource namespace
+	Namespace string
+	// Field is the field name (e.g., "data", or specific key name)
+	Field string
+	// Reason explains what went wrong
+	Reason string
 }
 
 // Error implements the error interface

--- a/pkg/errors/k8s_error_test.go
+++ b/pkg/errors/k8s_error_test.go
@@ -24,8 +24,8 @@ func TestIsRetryableDiscoveryError_Nil(t *testing.T) {
 
 func TestIsRetryableDiscoveryError_RetryableK8sErrors(t *testing.T) {
 	tests := []struct {
-		name string
 		err  error
+		name string
 	}{
 		{
 			name: "Timeout error",
@@ -74,8 +74,8 @@ func TestIsRetryableDiscoveryError_RetryableK8sErrors(t *testing.T) {
 
 func TestIsRetryableDiscoveryError_NonRetryableK8sErrors(t *testing.T) {
 	tests := []struct {
-		name string
 		err  error
+		name string
 	}{
 		{
 			name: "Forbidden error",
@@ -138,8 +138,8 @@ func TestIsRetryableDiscoveryError_NonRetryableK8sErrors(t *testing.T) {
 
 func TestIsRetryableDiscoveryError_NetworkErrors(t *testing.T) {
 	tests := []struct {
-		name string
 		err  error
+		name string
 	}{
 		{
 			name: "Connection refused",
@@ -181,8 +181,8 @@ func TestIsRetryableDiscoveryError_NetworkErrors(t *testing.T) {
 
 func TestIsRetryableDiscoveryError_UnknownErrors(t *testing.T) {
 	tests := []struct {
-		name string
 		err  error
+		name string
 	}{
 		{
 			name: "Generic error",
@@ -223,8 +223,8 @@ func TestIsRetryableDiscoveryError_NotFoundError(t *testing.T) {
 
 func TestIsRetryableDiscoveryError_WrappedK8sErrors(t *testing.T) {
 	tests := []struct {
-		name     string
 		err      error
+		name     string
 		expected bool
 	}{
 		{
@@ -258,10 +258,10 @@ func TestIsRetryableDiscoveryError_RetryBehaviorMatrix(t *testing.T) {
 	// It serves as documentation for operators and developers
 
 	type testCase struct {
-		name           string
 		err            error
-		shouldRetry    bool
+		name           string
 		expectedAction string
+		shouldRetry    bool
 	}
 
 	tests := []testCase{

--- a/pkg/errors/network_error_test.go
+++ b/pkg/errors/network_error_test.go
@@ -15,9 +15,9 @@ import (
 
 // mockNetError implements net.Error for testing
 type mockNetError struct {
+	msg       string
 	timeout   bool
 	temporary bool
-	msg       string
 }
 
 func (e *mockNetError) Error() string   { return e.msg }
@@ -30,8 +30,8 @@ func TestIsNetworkError_Nil(t *testing.T) {
 
 func TestIsNetworkError_SyscallErrors(t *testing.T) {
 	tests := []struct {
-		name     string
 		err      error
+		name     string
 		expected bool
 	}{
 		{
@@ -91,8 +91,8 @@ func TestIsNetworkError_SyscallErrors(t *testing.T) {
 
 func TestIsNetworkError_WrappedSyscallErrors(t *testing.T) {
 	tests := []struct {
-		name     string
 		err      error
+		name     string
 		expected bool
 	}{
 		{
@@ -122,8 +122,8 @@ func TestIsNetworkError_WrappedSyscallErrors(t *testing.T) {
 
 func TestIsNetworkError_NetOpError(t *testing.T) {
 	tests := []struct {
-		name     string
 		err      error
+		name     string
 		expected bool
 	}{
 		{
@@ -165,8 +165,8 @@ func TestIsNetworkError_NetOpError(t *testing.T) {
 
 func TestIsNetworkError_URLError(t *testing.T) {
 	tests := []struct {
-		name     string
 		err      error
+		name     string
 		expected bool
 	}{
 		{
@@ -203,8 +203,8 @@ func TestIsNetworkError_URLError(t *testing.T) {
 
 func TestIsNetworkError_TimeoutErrors(t *testing.T) {
 	tests := []struct {
-		name     string
 		err      error
+		name     string
 		expected bool
 	}{
 		{
@@ -229,8 +229,8 @@ func TestIsNetworkError_TimeoutErrors(t *testing.T) {
 
 func TestIsNetworkError_EOFErrors(t *testing.T) {
 	tests := []struct {
-		name     string
 		err      error
+		name     string
 		expected bool
 	}{
 		{
@@ -262,8 +262,8 @@ func TestIsNetworkError_EOFErrors(t *testing.T) {
 
 func TestIsNetworkError_NonNetworkErrors(t *testing.T) {
 	tests := []struct {
-		name string
 		err  error
+		name string
 	}{
 		{
 			name: "simple error",

--- a/pkg/health/metrics.go
+++ b/pkg/health/metrics.go
@@ -14,9 +14,9 @@ import (
 type MetricsServer struct {
 	server    *http.Server
 	log       logger.Logger
-	port      string
-	upGauge   prometheus.Gauge
 	buildInfo *prometheus.GaugeVec
+	upGauge   prometheus.Gauge
+	port      string
 }
 
 // MetricsConfig holds configuration for metrics registration.

--- a/pkg/health/server.go
+++ b/pkg/health/server.go
@@ -29,26 +29,24 @@ type HealthResponse struct {
 
 // ReadyResponse represents the JSON response for /readyz endpoint per HyperFleet standard.
 type ReadyResponse struct {
+	Checks  map[string]CheckStatus `json:"checks,omitempty"`
 	Status  string                 `json:"status"`
 	Message string                 `json:"message,omitempty"`
-	Checks  map[string]CheckStatus `json:"checks,omitempty"`
 }
 
 // Server provides HTTP health check endpoints.
 type Server struct {
-	server    *http.Server
-	log       logger.Logger
-	port      string
-	component string
-
+	log        logger.Logger
+	server     *http.Server
+	checks     map[string]CheckStatus
+	port       string
+	component  string
+	configYAML []byte // set only when debug_config is true
+	mu         sync.RWMutex
 	// shuttingDown is an atomic flag that indicates the server is shutting down.
 	// When true, /readyz immediately returns 503 regardless of other checks.
 	// This follows the HyperFleet Graceful Shutdown Standard.
 	shuttingDown atomic.Bool
-
-	mu         sync.RWMutex
-	checks     map[string]CheckStatus
-	configYAML []byte // set only when debug_config is true
 }
 
 // NewServer creates a new health check server.

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -74,9 +74,9 @@ func TestLoggerWith(t *testing.T) {
 	}
 
 	tests := []struct {
+		value interface{}
 		name  string
 		key   string
-		value interface{}
 	}{
 		{
 			name:  "add_string_field",
@@ -275,8 +275,8 @@ func TestLoggerChaining(t *testing.T) {
 		}()
 
 		err := &testError{msg: "test error"}
-		ctx := WithErrorField(ctx, err)
-		log.With("extra", "info").Error(ctx, "Error with context")
+		ctxWithErr := WithErrorField(ctx, err)
+		log.With("extra", "info").Error(ctxWithErr, "Error with context")
 	})
 }
 
@@ -331,16 +331,16 @@ func TestContextHelpers(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("WithEventID", func(t *testing.T) {
-		ctx := WithEventID(ctx, "evt-123")
-		fields := GetLogFields(ctx)
+		ctxWithEvent := WithEventID(ctx, "evt-123")
+		fields := GetLogFields(ctxWithEvent)
 		if fields["event_id"] != "evt-123" {
 			t.Errorf("Expected evt-123, got %v", fields["event_id"])
 		}
 	})
 
 	t.Run("WithTraceID", func(t *testing.T) {
-		ctx := WithTraceID(ctx, "trace-789")
-		fields := GetLogFields(ctx)
+		ctxWithTrace := WithTraceID(ctx, "trace-789")
+		fields := GetLogFields(ctxWithTrace)
 		if fields["trace_id"] != "trace-789" {
 			t.Errorf("Expected trace-789, got %v", fields["trace_id"])
 		}

--- a/pkg/logger/with_error_field_test.go
+++ b/pkg/logger/with_error_field_test.go
@@ -78,8 +78,8 @@ func TestWithErrorField(t *testing.T) {
 
 func TestShouldCaptureStackTrace_ContextErrors(t *testing.T) {
 	tests := []struct {
-		name          string
 		err           error
+		name          string
 		expectCapture bool
 	}{
 		{
@@ -116,8 +116,8 @@ func TestShouldCaptureStackTrace_ContextErrors(t *testing.T) {
 
 func TestShouldCaptureStackTrace_K8sAPIErrors(t *testing.T) {
 	tests := []struct {
-		name          string
 		err           error
+		name          string
 		expectCapture bool
 	}{
 		{
@@ -179,8 +179,8 @@ func TestShouldCaptureStackTrace_K8sAPIErrors(t *testing.T) {
 
 func TestShouldCaptureStackTrace_K8sResourceDataErrors(t *testing.T) {
 	tests := []struct {
-		name          string
 		err           error
+		name          string
 		expectCapture bool
 	}{
 		{
@@ -212,8 +212,8 @@ func TestShouldCaptureStackTrace_K8sResourceDataErrors(t *testing.T) {
 
 func TestShouldCaptureStackTrace_APIErrors(t *testing.T) {
 	tests := []struct {
-		name          string
 		err           error
+		name          string
 		expectCapture bool
 	}{
 		{
@@ -270,8 +270,8 @@ func TestShouldCaptureStackTrace_APIErrors(t *testing.T) {
 
 func TestShouldCaptureStackTrace_UnexpectedErrors(t *testing.T) {
 	tests := []struct {
-		name          string
 		err           error
+		name          string
 		expectCapture bool
 	}{
 		{

--- a/test/integration/executor/executor_integration_test.go
+++ b/test/integration/executor/executor_integration_test.go
@@ -755,8 +755,8 @@ func TestExecutor_MissingRequiredParam(t *testing.T) {
 	}
 
 	// Unset the env var after executor creation
-	if err := os.Unsetenv("HYPERFLEET_API_BASE_URL"); err != nil {
-		t.Fatalf("Failed to unset env var: %v", err)
+	if unsetErr := os.Unsetenv("HYPERFLEET_API_BASE_URL"); unsetErr != nil {
+		t.Fatalf("Failed to unset env var: %v", unsetErr)
 	}
 
 	evt := createTestEvent("cluster-missing-param")

--- a/test/integration/executor/executor_k8s_integration_test.go
+++ b/test/integration/executor/executor_k8s_integration_test.go
@@ -25,10 +25,10 @@ import (
 // k8sTestAPIServer creates a mock API server for K8s integration tests
 type k8sTestAPIServer struct {
 	server          *httptest.Server
-	mu              sync.Mutex
 	requests        []k8sTestRequest
 	clusterResponse map[string]interface{}
 	statusResponses []map[string]interface{}
+	mu              sync.Mutex
 }
 
 type k8sTestRequest struct {

--- a/test/integration/executor/main_test.go
+++ b/test/integration/executor/main_test.go
@@ -140,9 +140,9 @@ func setupSharedK8sEnvtestEnv() (*K8sTestEnv, error) {
 
 	// Wait for API server to be ready
 	println("   Waiting for API server to be fully ready...")
-	if err := waitForAPIServerReady(restConfig, 30*time.Second); err != nil {
+	if waitErr := waitForAPIServerReady(restConfig, 30*time.Second); waitErr != nil {
 		sharedContainer.Cleanup()
-		return nil, fmt.Errorf("API server failed to become ready: %w", err)
+		return nil, fmt.Errorf("API server failed to become ready: %w", waitErr)
 	}
 	println("   ✅ API server is ready!")
 

--- a/test/integration/k8s_client/client_integration_test.go
+++ b/test/integration/k8s_client/client_integration_test.go
@@ -689,8 +689,8 @@ func TestIntegration_DifferentResourceTypes(t *testing.T) {
 			}
 			pod.SetGroupVersionKind(gvk.Pod)
 
-			_, err := env.GetClient().CreateResource(env.GetContext(), pod)
-			require.NoError(t, err)
+			_, createErr := env.GetClient().CreateResource(env.GetContext(), pod)
+			require.NoError(t, createErr)
 		}
 
 		// List pods with label selector

--- a/test/integration/k8s_client/helper_envtest_prebuilt.go
+++ b/test/integration/k8s_client/helper_envtest_prebuilt.go
@@ -139,9 +139,9 @@ func setupSharedTestEnv() (*TestEnvPrebuilt, error) {
 
 	// Wait for API server to be fully ready with auth
 	println("   Waiting for API server to be fully ready...")
-	if err := waitForAPIServerReady(kubeAPIServer, 30*time.Second); err != nil {
+	if waitErr := waitForAPIServerReady(kubeAPIServer, 30*time.Second); waitErr != nil {
 		sharedContainer.Cleanup()
-		return nil, fmt.Errorf("API server failed to become ready: %w", err)
+		return nil, fmt.Errorf("API server failed to become ready: %w", waitErr)
 	}
 	println("   ✅ API server is ready!")
 

--- a/test/integration/maestro_client/setup_test.go
+++ b/test/integration/maestro_client/setup_test.go
@@ -53,9 +53,9 @@ func setupMaestroTestEnv() (*MaestroTestEnv, error) {
 
 	// Step 2: Run Maestro migration
 	println("   🔄 Running Maestro database migration...")
-	if err := runMaestroMigration(ctx, env); err != nil {
+	if migrationErr := runMaestroMigration(ctx, env); migrationErr != nil {
 		_ = pgContainer.Terminate(ctx)
-		return nil, fmt.Errorf("failed to run Maestro migration: %w", err)
+		return nil, fmt.Errorf("failed to run Maestro migration: %w", migrationErr)
 	}
 	println("   ✅ Database migration complete")
 
@@ -317,8 +317,8 @@ func setupTLSMaestroEnv(env *MaestroTestEnv) error {
 	if err != nil {
 		return fmt.Errorf("failed to generate test certs: %w", err)
 	}
-	if err := certs.WriteToTempDir(); err != nil {
-		return fmt.Errorf("failed to write certs to temp dir: %w", err)
+	if writeErr := certs.WriteToTempDir(); writeErr != nil {
+		return fmt.Errorf("failed to write certs to temp dir: %w", writeErr)
 	}
 	env.TLSCerts = certs
 

--- a/test/integration/maestro_client/tls_helper_test.go
+++ b/test/integration/maestro_client/tls_helper_test.go
@@ -16,13 +16,13 @@ import (
 
 // TLSTestCerts holds all PEM-encoded certificates and keys for TLS integration tests.
 type TLSTestCerts struct {
+	TempDir    string
 	CACert     []byte
 	CAKey      []byte
 	ServerCert []byte
 	ServerKey  []byte
 	ClientCert []byte
 	ClientKey  []byte
-	TempDir    string
 }
 
 // generateTestCerts creates a self-signed CA, server cert (with localhost SANs),

--- a/test/integration/testutil/container.go
+++ b/test/integration/testutil/container.go
@@ -18,48 +18,37 @@ import (
 
 // ContainerConfig holds configuration for starting a container
 type ContainerConfig struct {
-	// Image is the container image to use (required)
-	Image string
-
-	// ExposedPorts is a list of ports to expose (e.g., "8080/tcp")
-	ExposedPorts []string
-
-	// Cmd is the command to run in the container
-	Cmd []string
-
-	// Env is a map of environment variables to set
-	Env map[string]string
-
 	// WaitStrategy is the strategy to wait for container readiness
 	WaitStrategy wait.Strategy
-
+	// Env is a map of environment variables to set
+	Env map[string]string
+	// Image is the container image to use (required)
+	Image string
+	// Name is a human-readable name for logging purposes
+	Name string
+	// ExposedPorts is a list of ports to expose (e.g., "8080/tcp")
+	ExposedPorts []string
+	// Cmd is the command to run in the container
+	Cmd []string
 	// StartupTimeout is the maximum time to wait for container to start (default: 180s)
 	StartupTimeout time.Duration
-
 	// CleanupTimeout is the maximum time to wait for container cleanup (default: 60s)
 	// Note: The cleanup path enforces a minimum of 60s to ensure containers have time to stop gracefully.
 	CleanupTimeout time.Duration
-
-	// MaxRetries is the number of times to retry container creation (default: 1, no retries)
-	MaxRetries int
-
 	// RetryDelay is the base delay between retries (default: 1s, increases with attempt number)
 	RetryDelay time.Duration
-
-	// Name is a human-readable name for logging purposes
-	Name string
+	// MaxRetries is the number of times to retry container creation (default: 1, no retries)
+	MaxRetries int
 }
 
 // ContainerResult holds the result of starting a container
 type ContainerResult struct {
 	// Container is the testcontainers container instance
 	Container testcontainers.Container
-
-	// Host is the container host
-	Host string
-
 	// Ports maps exposed port specs (e.g., "8080/tcp") to their mapped ports
 	Ports map[string]string
+	// Host is the container host
+	Host string
 }
 
 // GetEndpoint returns the host:port endpoint for the given port spec
@@ -158,8 +147,8 @@ func StartContainer(t *testing.T, config ContainerConfig) (*ContainerResult, err
 		// ensure we terminate it before retrying to avoid leaks
 		if container != nil {
 			t.Logf("Attempt %d failed but container was created. Terminating...", attempt)
-			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-			if termErr := container.Terminate(ctx); termErr != nil {
+			terminateCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			if termErr := container.Terminate(terminateCtx); termErr != nil {
 				t.Logf("Warning: Failed to terminate failed container from attempt %d: %v", attempt, termErr)
 				// Try force cleanup
 				if cid := container.GetContainerID(); cid != "" {

--- a/test/integration/testutil/mock_api_server.go
+++ b/test/integration/testutil/mock_api_server.go
@@ -27,13 +27,13 @@ type MockRequest struct {
 // TODO: Replace with testcontainers using hyperfleet-api image when available.
 type MockAPIServer struct {
 	server           *httptest.Server
-	mu               sync.Mutex
-	requests         []MockRequest
+	t                *testing.T
 	clusterResponse  map[string]interface{}
+	requests         []MockRequest
 	statusResponses  []map[string]interface{}
+	mu               sync.Mutex
 	failPrecondition bool
 	failPostAction   bool // If true, POST to /status endpoint returns 500
-	t                *testing.T
 }
 
 // NewMockAPIServer creates a new MockAPIServer for testing.


### PR DESCRIPTION
## Summary

- Enable `revive` linter with HyperFleet standard rules (`var-naming` and `unexported-return` enabled, `exported` disabled)
- Fix pre-existing lint violations surfaced by enabled rules:
  - `internal/k8s_client/types.go`: rename `GVKFromKindAndApiVersion` to `GVKFromKindAndAPIVersion` (revive var-naming)
  - `pkg/errors/error.go`: rename struct field `HttpCode` to `HTTPCode` (revive var-naming)
- Align `.golangci.yml` settings with architecture standard (`goconst.min-occurrences`, `unused.check-exported`, `unparam.check-exported`, `exhaustive.check-generated`)
- Add exclusions for underscore package names (structural renaming is out of scope for this ticket)

## Test plan

- [x] `make lint` passes with 0 issues
- [x] `make test` passes - all unit tests green
- [x] `make test-integration` passes - config-loader and executor suites green (k8s_client fails due to local Docker network issue, maestro skipped on ARM64)

## JIRA

https://redhat.atlassian.net/browse/HYPERFLEET-769

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Kubernetes client docs/examples updated to use the clarified GVK API name.

* **New Features**
  * Readiness payload now includes per-check details; server can expose stored config YAML.
  * Clients gain per-request headers and retry options; container test helpers expose host/env/name.

* **Refactor**
  * Public GVK API renamed for clearer naming.
  * Service error field renamed to HTTPCode and error structs standardized.

* **Chores**
  * Linting configuration and formatter rules revised.

* **Tests**
  * Tests and examples updated to match renamed APIs and adjusted structs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->