### PR TITLE
HYPERFLEET-725 - chore: remove unused GIT_TAG variable and Tag field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ BINARY_NAME := $(BIN_DIR)/hyperfleet-adapter
 BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 GIT_SHA ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 GIT_DIRTY ?= $(shell [ -z "$$(git status --porcelain 2>/dev/null)" ] || echo "-modified")
-GIT_TAG ?= $(shell git describe --tags --exact-match 2>/dev/null || echo "")
 APP_VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "0.0.0-dev")
 
 # Go build flags
@@ -23,9 +22,6 @@ LDFLAGS := -s -w \
            -X $(VERSION_PKG).Version=$(APP_VERSION) \
            -X $(VERSION_PKG).Commit=$(GIT_SHA) \
            -X $(VERSION_PKG).BuildDate=$(BUILD_DATE)
-ifneq ($(GIT_TAG),)
-LDFLAGS += -X $(VERSION_PKG).Tag=$(GIT_TAG)
-endif
 
 # Container tool (docker or podman)
 CONTAINER_TOOL ?= $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)

--- a/cmd/adapter/main.go
+++ b/cmd/adapter/main.go
@@ -155,7 +155,6 @@ Priority order (lowest to highest): config file < env vars < CLI flags`,
 			fmt.Printf("  Version:    %s\n", info.Version)
 			fmt.Printf("  Commit:     %s\n", info.Commit)
 			fmt.Printf("  Built:      %s\n", info.BuildDate)
-			fmt.Printf("  Tag:        %s\n", info.Tag)
 		},
 	}
 
@@ -387,7 +386,7 @@ func runServe(flags *pflag.FlagSet) error {
 		return fmt.Errorf("failed to create logger: %w", err)
 	}
 
-	log.Infof(ctx, "Starting Hyperfleet Adapter version=%s commit=%s built=%s tag=%s", version.Version, version.Commit, version.BuildDate, version.Tag)
+	log.Infof(ctx, "Starting Hyperfleet Adapter version=%s commit=%s built=%s", version.Version, version.Commit, version.BuildDate)
 
 	// Load unified configuration (deployment + task configs)
 	config, err := loadConfig(ctx, log, flags)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -18,9 +18,6 @@ var (
 
 	// BuildDate is the date when the binary was built
 	BuildDate = "unknown"
-
-	// Tag is the git tag (if any)
-	Tag = "none"
 )
 
 // UserAgent returns the User-Agent string for HTTP clients.
@@ -39,7 +36,6 @@ func Info() VersionInfo {
 		Version:   Version,
 		Commit:    Commit,
 		BuildDate: BuildDate,
-		Tag:       Tag,
 	}
 }
 
@@ -48,5 +44,4 @@ type VersionInfo struct {
 	Version   string
 	Commit    string
 	BuildDate string
-	Tag       string
 }


### PR DESCRIPTION
https://redhat.atlassian.net/browse/HYPERFLEET-725

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified version information output by removing Git tag details from startup logs and version command displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->