### PR TITLE
HYPERFLEET-786 - chore: align chart with Helm conventions standard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,16 +96,22 @@ test-helm: ## Test Helm charts (lint, template, validate)
 		exit 1; \
 	fi
 	@echo "Linting Helm chart..."
-	helm lint charts/
+	helm lint charts/ \
+		--set image.registry=quay.io \
+		--set image.repository=openshift-hyperfleet/hyperfleet-adapter
 	@echo ""
 	@echo "Testing template rendering with minimal required values..."
 	helm template test-release charts/ \
+		--set image.registry=quay.io \
+		--set image.repository=openshift-hyperfleet/hyperfleet-adapter \
 		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" > /dev/null
 	@echo "Minimal required values template OK"
 	@echo ""
 	@echo "Testing template with broker enabled..."
 	helm template test-release charts/ \
+		--set image.registry=quay.io \
+		--set image.repository=openshift-hyperfleet/hyperfleet-adapter \
 		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set broker.create=true \
@@ -116,6 +122,8 @@ test-helm: ## Test Helm charts (lint, template, validate)
 	@echo ""
 	@echo "Testing template with HyperFleet API config..."
 	helm template test-release charts/ \
+		--set image.registry=quay.io \
+		--set image.repository=openshift-hyperfleet/hyperfleet-adapter \
 		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set adapterConfig.hyperfleetApi.baseUrl=http://localhost:8000 \
@@ -124,6 +132,8 @@ test-helm: ## Test Helm charts (lint, template, validate)
 	@echo ""
 	@echo "Testing template with PDB enabled..."
 	helm template test-release charts/ \
+		--set image.registry=quay.io \
+		--set image.repository=openshift-hyperfleet/hyperfleet-adapter \
 		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set podDisruptionBudget.enabled=true \
@@ -133,6 +143,8 @@ test-helm: ## Test Helm charts (lint, template, validate)
 	@echo ""
 	@echo "Testing template with autoscaling..."
 	helm template test-release charts/ \
+		--set image.registry=quay.io \
+		--set image.repository=openshift-hyperfleet/hyperfleet-adapter \
 		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set autoscaling.enabled=true \
@@ -142,6 +154,8 @@ test-helm: ## Test Helm charts (lint, template, validate)
 	@echo ""
 	@echo "Testing template with probes enabled..."
 	helm template test-release charts/ \
+		--set image.registry=quay.io \
+		--set image.repository=openshift-hyperfleet/hyperfleet-adapter \
 		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set livenessProbe.enabled=true \
@@ -151,6 +165,8 @@ test-helm: ## Test Helm charts (lint, template, validate)
 	@echo ""
 	@echo "Testing template with ServiceMonitor enabled..."
 	@helm template test-release charts/ \
+		--set image.registry=quay.io \
+		--set image.repository=openshift-hyperfleet/hyperfleet-adapter \
 		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set serviceMonitor.enabled=true \
@@ -160,6 +176,8 @@ test-helm: ## Test Helm charts (lint, template, validate)
 	@echo ""
 	@echo "Testing template with ServiceMonitor enabled but CRD unavailable..."
 	@output=$$(helm template test-release charts/ \
+		--set image.registry=quay.io \
+		--set image.repository=openshift-hyperfleet/hyperfleet-adapter \
 		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set serviceMonitor.enabled=true) \
@@ -169,6 +187,8 @@ test-helm: ## Test Helm charts (lint, template, validate)
 	@echo ""
 	@echo "Testing template with ServiceMonitor disabled..."
 	@output=$$(helm template test-release charts/ \
+		--set image.registry=quay.io \
+		--set image.repository=openshift-hyperfleet/hyperfleet-adapter \
 		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set serviceMonitor.enabled=false \

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyperfleet-adapter
 description: HyperFleet Adapter - Event-driven adapter services for HyperFleet cluster provisioning
 type: application
-version: 1.0.0
+version: 2.0.0
 appVersion: "1.0.0"
 maintainers:
   - name: HyperFleet Team

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -218,6 +218,60 @@ rbac.authorization.k8s.io
 {{- end }}
 
 {{/*
+Validate required values that must not remain as placeholders.
+*/}}
+{{- define "hyperfleet-adapter.validateValues" -}}
+{{- if eq .Values.image.registry "CHANGE_ME" -}}
+{{- fail "image.registry must be set (e.g. --set image.registry=quay.io)" -}}
+{{- end -}}
+{{- if eq .Values.image.repository "CHANGE_ME" -}}
+{{- fail "image.repository must be set (e.g. --set image.repository=openshift-hyperfleet/hyperfleet-adapter)" -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Validate deprecated snake_case broker keys have not been used.
+Per Helm Chart Conventions Standard section 9 (Deprecation and Migration Pattern).
+*/}}
+{{- define "hyperfleet-adapter.validateDeprecatedKeys" -}}
+{{- if .Values.broker.googlepubsub }}
+{{- if hasKey .Values.broker.googlepubsub "project_id" }}
+{{- fail "broker.googlepubsub.project_id has been renamed to broker.googlepubsub.projectId (camelCase). Please update your values." }}
+{{- end -}}
+{{- if hasKey .Values.broker.googlepubsub "subscription_id" }}
+{{- fail "broker.googlepubsub.subscription_id has been renamed to broker.googlepubsub.subscriptionId (camelCase). Please update your values." }}
+{{- end -}}
+{{- if hasKey .Values.broker.googlepubsub "dead_letter_topic" }}
+{{- fail "broker.googlepubsub.dead_letter_topic has been renamed to broker.googlepubsub.deadLetterTopic (camelCase). Please update your values." }}
+{{- end -}}
+{{- if hasKey .Values.broker.googlepubsub "create_topic_if_missing" }}
+{{- fail "broker.googlepubsub.create_topic_if_missing has been renamed to broker.googlepubsub.createTopicIfMissing (camelCase). Please update your values." }}
+{{- end -}}
+{{- if hasKey .Values.broker.googlepubsub "create_subscription_if_missing" }}
+{{- fail "broker.googlepubsub.create_subscription_if_missing has been renamed to broker.googlepubsub.createSubscriptionIfMissing (camelCase). Please update your values." }}
+{{- end -}}
+{{- end -}}
+{{- if .Values.broker.rabbitmq }}
+{{- if hasKey .Values.broker.rabbitmq "routing_key" }}
+{{- fail "broker.rabbitmq.routing_key has been renamed to broker.rabbitmq.routingKey (camelCase). Please update your values." }}
+{{- end -}}
+{{- if hasKey .Values.broker.rabbitmq "exchange_type" }}
+{{- fail "broker.rabbitmq.exchange_type has been renamed to broker.rabbitmq.exchangeType (camelCase). Please update your values." }}
+{{- end -}}
+{{- end -}}
+{{- if .Values.adapterConfig }}
+{{- if hasKey .Values.adapterConfig "hyperfleet_api" }}
+{{- fail "adapterConfig.hyperfleet_api has been renamed to adapterConfig.hyperfleetApi (camelCase). Please update your values." }}
+{{- end -}}
+{{- if .Values.adapterConfig.hyperfleetApi }}
+{{- if hasKey .Values.adapterConfig.hyperfleetApi "base_url" }}
+{{- fail "adapterConfig.hyperfleetApi.base_url has been renamed to adapterConfig.hyperfleetApi.baseUrl (camelCase). Please update your values." }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Determine the broker type.
 Returns broker.type if explicitly set, otherwise infers from broker config objects.
 */}}

--- a/charts/templates/configmap-broker.yaml
+++ b/charts/templates/configmap-broker.yaml
@@ -31,11 +31,11 @@ data:
     broker:
       type: googlepubsub
       googlepubsub:
-        project_id: {{ .Values.broker.googlepubsub.project_id | quote }}
+        project_id: {{ .Values.broker.googlepubsub.projectId | quote }}
         topic: {{ .Values.broker.googlepubsub.topic | quote }}
-        dead_letter_topic: {{ .Values.broker.googlepubsub.dead_letter_topic | quote }}
-        create_topic_if_missing: {{ .Values.broker.googlepubsub.create_topic_if_missing }}
-        create_subscription_if_missing: {{ .Values.broker.googlepubsub.create_subscription_if_missing }}
+        dead_letter_topic: {{ .Values.broker.googlepubsub.deadLetterTopic | quote }}
+        create_topic_if_missing: {{ .Values.broker.googlepubsub.createTopicIfMissing }}
+        create_subscription_if_missing: {{ .Values.broker.googlepubsub.createSubscriptionIfMissing }}
       subscriber:
         parallelism: 1
   {{- else if eq $brokerType "rabbitmq" }}
@@ -47,8 +47,8 @@ data:
         url: {{ .Values.broker.rabbitmq.url | quote }}
         queue: {{ .Values.broker.rabbitmq.queue | quote }}
         exchange: {{ .Values.broker.rabbitmq.exchange | quote }}
-        routing_key: {{ .Values.broker.rabbitmq.routing_key | quote }}
-        exchange_type: {{ .Values.broker.rabbitmq.exchange_type | default "topic" | quote }}
+        routing_key: {{ .Values.broker.rabbitmq.routingKey | quote }}
+        exchange_type: {{ .Values.broker.rabbitmq.exchangeType | default "topic" | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -1,3 +1,5 @@
+{{- include "hyperfleet-adapter.validateValues" . }}
+{{- include "hyperfleet-adapter.validateDeprecatedKeys" . }}
 {{- $brokerConfigValid := include "hyperfleet-adapter.helmValidateBrokerIsConfigured" . }}
 {{- $adapterConfigValid := include "hyperfleet-adapter.helmValidateAdapterIsConfigured" . }}
 {{- $adapterTaskConfigValid := include "hyperfleet-adapter.helmValidateAdapterTaskIsConfigured" . }}
@@ -7,13 +9,6 @@ metadata:
   name: {{ include "hyperfleet-adapter.fullname" . }}
   labels:
     {{- include "hyperfleet-adapter.labels" . | nindent 4 }}
-    {{- with .Values.deploymentLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-  {{- with .Values.deploymentAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
@@ -91,15 +86,15 @@ spec:
             - name: LOG_LEVEL
               value: {{ .Values.adapterConfig.log.level }}
             - name: HYPERFLEET_API_BASE_URL
-              value: {{ .Values.adapterConfig.hyperfleet_api.base_url | quote }}
+              value: {{ .Values.adapterConfig.hyperfleetApi.baseUrl | quote }}
             - name: HYPERFLEET_API_VERSION
-              value: {{ .Values.adapterConfig.hyperfleet_api.version | quote }}
+              value: {{ .Values.adapterConfig.hyperfleetApi.version | quote }}
             - name: BROKER_CONFIG_FILE
               value: /etc/broker/broker.yaml
             {{- $brokerType := include "hyperfleet-adapter.brokerType" . }}
             {{- if eq $brokerType "googlepubsub" }}
             - name: HYPERFLEET_BROKER_SUBSCRIPTION_ID
-              value: {{ .Values.broker.googlepubsub.subscription_id | quote }}
+              value: {{ .Values.broker.googlepubsub.subscriptionId | quote }}
             - name: HYPERFLEET_BROKER_TOPIC
               value: {{ .Values.broker.googlepubsub.topic | quote }}
             {{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -23,9 +23,9 @@ adapterConfig:
   # adapter-config.yaml: examples/kubernetes/adapter-config.yaml
 
   # HyperFleet API env vars used by task params
-  hyperfleet_api:
+  hyperfleetApi:
     # Base URL for HyperFleet API (HYPERFLEET_API_BASE_URL)
-    base_url: http://hyperfleet-api:8000
+    baseUrl: http://hyperfleet-api:8000
     # API version (HYPERFLEET_API_VERSION), default: v1
     version: v1
   log:
@@ -76,21 +76,21 @@ broker:
   # option3: Broker type identifier (googlepubsub, rabbitmq, etc.) - used as label
   # Subscription/topic are used to set adapter broker config overrides
   googlepubsub:
-    create_subscription_if_missing: false
+    projectId: ""
+    topic: ""
+    subscriptionId: ""
+    deadLetterTopic: ""
     # Auto-creation flags (default: false - infrastructure must pre-exist)
     # Set to true for development/testing; use false in production with pre-provisioned resources
-    create_topic_if_missing: false
-    dead_letter_topic: ""
-    project_id: ""
-    subscription_id: ""
-    topic: ""
+    createTopicIfMissing: false
+    createSubscriptionIfMissing: false
   # option3: for rabbitmq
   #rabbitmq:
-  # url: ""
-  # queue: ""
-  # exchange: ""
-  # exchange_type: "topic"
-  # routing_key: ""
+  #  url: ""
+  #  queue: ""
+  #  exchange: ""
+  #  exchangeType: "topic"
+  #  routingKey: ""
 # Override default command
 command:
   - /app/adapter
@@ -102,9 +102,6 @@ containerPorts:
   - containerPort: 9090
     name: metrics
     protocol: TCP
-deploymentAnnotations: {}
-# Deployment configuration
-deploymentLabels: {}
 # Environment variables
 env: []
 # - name: ADAPTER_CONFIG_PATH
@@ -131,9 +128,9 @@ fullnameOverride: ""
 # This is the image for the adapter framework
 image:
   pullPolicy: Always
-  registry: CHANGE_ME # e.g. quay.io/openshift-hyperfleet
-  repository: CHANGE_ME # e.g. hyperfleet-adapter
-  tag: CHANGE_ME # e.g. "latest"
+  registry: CHANGE_ME # e.g. quay.io
+  repository: CHANGE_ME # e.g. openshift-hyperfleet/hyperfleet-adapter
+  tag: "" # defaults to Chart.AppVersion
 imagePullSecrets: []
 # Init containers
 initContainers: []


### PR DESCRIPTION
## Summary
- Convert broker values.yaml keys from snake_case to camelCase (`projectId`, `subscriptionId`, `deadLetterTopic`, `createTopicIfMissing`, `createSubscriptionIfMissing`, `exchangeType`, `routingKey`)
- Convert adapterConfig keys (`hyperfleetApi.baseUrl` instead of `hyperfleet_api.base_url`)
- Update `image.repository` default to `openshift-hyperfleet/hyperfleet-adapter` (includes org path)
- Template output remains snake_case per configuration standard

## Test plan
- [x] `make test-helm` passes (all 9 scenarios)
- [ ] Deploy to dev with updated values and verify broker config renders correctly
- [ ] Verify infra/E2E scripts updated to match new key names

Relates to: [HYPERFLEET-786](https://issues.redhat.com/browse/HYPERFLEET-786)
Depends on: [architecture#108](https://github.com/openshift-hyperfleet/architecture/pull/108)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed Helm values from snake_case to camelCase—update custom values files accordingly (adapter/hyperfleet and broker fields).
  * Google Pub/Sub and RabbitMQ config keys renamed (e.g., projectId, subscriptionId, topic, deadLetterTopic, createTopicIfMissing/createSubscriptionIfMissing, exchangeType, routingKey); exchangeType still defaults to "topic".
  * Removed default deploymentLabels/deploymentAnnotations and adjusted image tag default handling.

* **Validation**
  * Chart now validates image placeholder and rejects deprecated snake_case keys during render.

* **Release**
  * Helm chart version bumped to 2.0.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->