### PR TITLE
HYPERFLEET-794 - chore: standardize appVersion and image.tag handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,12 +98,14 @@ test-helm: ## Test Helm charts (lint, template, validate)
 	@echo "Linting Helm chart..."
 	helm lint charts/ \
 		--set image.registry=quay.io \
-		--set image.repository=openshift-hyperfleet/hyperfleet-adapter
+		--set image.repository=openshift-hyperfleet/hyperfleet-adapter \
+		--set image.tag=test
 	@echo ""
 	@echo "Testing template rendering with minimal required values..."
 	helm template test-release charts/ \
 		--set image.registry=quay.io \
 		--set image.repository=openshift-hyperfleet/hyperfleet-adapter \
+		--set image.tag=test \
 		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" > /dev/null
 	@echo "Minimal required values template OK"
@@ -112,6 +114,7 @@ test-helm: ## Test Helm charts (lint, template, validate)
 	helm template test-release charts/ \
 		--set image.registry=quay.io \
 		--set image.repository=openshift-hyperfleet/hyperfleet-adapter \
+		--set image.tag=test \
 		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set broker.create=true \
@@ -124,6 +127,7 @@ test-helm: ## Test Helm charts (lint, template, validate)
 	helm template test-release charts/ \
 		--set image.registry=quay.io \
 		--set image.repository=openshift-hyperfleet/hyperfleet-adapter \
+		--set image.tag=test \
 		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set adapterConfig.hyperfleetApi.baseUrl=http://localhost:8000 \
@@ -134,6 +138,7 @@ test-helm: ## Test Helm charts (lint, template, validate)
 	helm template test-release charts/ \
 		--set image.registry=quay.io \
 		--set image.repository=openshift-hyperfleet/hyperfleet-adapter \
+		--set image.tag=test \
 		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set podDisruptionBudget.enabled=true \
@@ -145,6 +150,7 @@ test-helm: ## Test Helm charts (lint, template, validate)
 	helm template test-release charts/ \
 		--set image.registry=quay.io \
 		--set image.repository=openshift-hyperfleet/hyperfleet-adapter \
+		--set image.tag=test \
 		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set autoscaling.enabled=true \
@@ -156,6 +162,7 @@ test-helm: ## Test Helm charts (lint, template, validate)
 	helm template test-release charts/ \
 		--set image.registry=quay.io \
 		--set image.repository=openshift-hyperfleet/hyperfleet-adapter \
+		--set image.tag=test \
 		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set livenessProbe.enabled=true \
@@ -167,6 +174,7 @@ test-helm: ## Test Helm charts (lint, template, validate)
 	@helm template test-release charts/ \
 		--set image.registry=quay.io \
 		--set image.repository=openshift-hyperfleet/hyperfleet-adapter \
+		--set image.tag=test \
 		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set serviceMonitor.enabled=true \
@@ -178,6 +186,7 @@ test-helm: ## Test Helm charts (lint, template, validate)
 	@output=$$(helm template test-release charts/ \
 		--set image.registry=quay.io \
 		--set image.repository=openshift-hyperfleet/hyperfleet-adapter \
+		--set image.tag=test \
 		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set serviceMonitor.enabled=true) \
@@ -189,6 +198,7 @@ test-helm: ## Test Helm charts (lint, template, validate)
 	@output=$$(helm template test-release charts/ \
 		--set image.registry=quay.io \
 		--set image.repository=openshift-hyperfleet/hyperfleet-adapter \
+		--set image.tag=test \
 		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set serviceMonitor.enabled=false \

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -3,7 +3,7 @@ name: hyperfleet-adapter
 description: HyperFleet Adapter - Event-driven adapter services for HyperFleet cluster provisioning
 type: application
 version: 2.0.0
-appVersion: "1.0.0"
+appVersion: "0.0.0-dev"
 maintainers:
   - name: HyperFleet Team
     email: hyperfleet-team@redhat.com

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -36,9 +36,7 @@ Common labels
 {{- define "hyperfleet-adapter.labels" -}}
 helm.sh/chart: {{ include "hyperfleet-adapter.chart" . }}
 {{ include "hyperfleet-adapter.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
+app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
@@ -221,11 +219,16 @@ rbac.authorization.k8s.io
 Validate required values that must not remain as placeholders.
 */}}
 {{- define "hyperfleet-adapter.validateValues" -}}
-{{- if eq .Values.image.registry "CHANGE_ME" -}}
+{{- $registry := trim (toString .Values.image.registry) -}}
+{{- if or (not $registry) (eq $registry "CHANGE_ME") -}}
 {{- fail "image.registry must be set (e.g. --set image.registry=quay.io)" -}}
 {{- end -}}
-{{- if eq .Values.image.repository "CHANGE_ME" -}}
+{{- $repository := trim (toString .Values.image.repository) -}}
+{{- if or (not $repository) (eq $repository "CHANGE_ME") -}}
 {{- fail "image.repository must be set (e.g. --set image.repository=openshift-hyperfleet/hyperfleet-adapter)" -}}
+{{- end -}}
+{{- if not (trim (toString .Values.image.tag)) -}}
+{{- fail "image.tag must be set (e.g. --set image.tag=abc1234)" -}}
 {{- end -}}
 {{- end }}
 

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.command }}
           command:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -130,7 +130,7 @@ image:
   pullPolicy: Always
   registry: CHANGE_ME # e.g. quay.io
   repository: CHANGE_ME # e.g. openshift-hyperfleet/hyperfleet-adapter
-  tag: "" # defaults to Chart.AppVersion
+  tag: "" # Required — no default. Set via --set image.tag=<version>
 imagePullSecrets: []
 # Init containers
 initContainers: []


### PR DESCRIPTION
## Summary
- Set `appVersion` to `"0.0.0-dev"` (CI stamps real version at release)
- Remove `.Chart.AppVersion` fallback from image tag in `deployment.yaml`
- Add validation guard in `_helpers.tpl` requiring `image.tag` to be set
- Use `image.tag` for `app.kubernetes.io/version` label with AppVersion fallback
- Update Makefile helm tests to pass `image.tag`

## Test plan
- [x] `make test-helm` passes
- [x] `helm template` renders `app.kubernetes.io/version` with image tag value
- [x] Deployed to GKE dev cluster — pods running, labels correct

Relates to: [HYPERFLEET-794](https://redhat.atlassian.net/browse/HYPERFLEET-794)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Chart appVersion changed to 0.0.0-dev.
  * Deployments now require an explicit image tag—no automatic default.
  * Chart validation tightened to require a non-empty image tag and trim/validate image registry/repository values.
  * Templates will always emit an app.kubernetes.io/version label based on the image tag.
  * Test/validation runs now explicitly set the image tag during rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->