### PR TITLE
HYPERFLEET-723 - fix: go-toolset VERSION env var leaks into binary, b…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@ FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
 ARG GIT_SHA=unknown
 ARG GIT_DIRTY=""
 ARG BUILD_DATE=""
-ARG VERSION=""
+# APP_VERSION avoids collision with the go-toolset base image's
+# ENV VERSION=<go-version> which shadows a same-named ARG in RUN commands.
+ARG APP_VERSION=""
 
 # Install make as root (UBI9 go-toolset doesn't include it), then switch back to non-root.
 USER root
@@ -29,7 +31,7 @@ COPY --chown=1001:0 . .
 RUN --mount=type=cache,target=/opt/app-root/src/go/pkg/mod,uid=1001 \
     --mount=type=cache,target=/opt/app-root/src/.cache/go-build,uid=1001 \
     CGO_ENABLED=0 GOOS=linux \
-    GIT_SHA=${GIT_SHA} GIT_DIRTY=${GIT_DIRTY} BUILD_DATE=${BUILD_DATE} VERSION=${VERSION} \
+    GIT_SHA=${GIT_SHA} GIT_DIRTY=${GIT_DIRTY} BUILD_DATE=${BUILD_DATE} ${APP_VERSION:+VERSION=${APP_VERSION}} \
     make build
 
 # Runtime stage
@@ -46,9 +48,9 @@ EXPOSE 8080
 ENTRYPOINT ["/app/adapter"]
 CMD ["serve"]
 
-ARG VERSION=""
+ARG APP_VERSION=""
 LABEL name="hyperfleet-adapter" \
       vendor="Red Hat" \
-      version="${VERSION}" \
+      version="${APP_VERSION}" \
       summary="HyperFleet Adapter - Event-driven adapter services for HyperFleet cluster provisioning" \
       description="Handles CloudEvents consumption, AdapterConfig CRD integration, precondition evaluation, Kubernetes Job creation/monitoring, and status reporting via API"

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,15 @@ BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 GIT_SHA ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 GIT_DIRTY ?= $(shell [ -z "$$(git status --porcelain 2>/dev/null)" ] || echo "-modified")
 GIT_TAG ?= $(shell git describe --tags --exact-match 2>/dev/null || echo "")
-VERSION ?= $(GIT_SHA)$(GIT_DIRTY)
+
+# VERSION is the adapter's semver, injected into the binary via ldflags.
+# When building from a git tag (e.g. v1.2.0), strip the leading 'v';
+# otherwise keep the default that matches pkg/version/version.go.
+ifneq ($(GIT_TAG),)
+VERSION ?= $(patsubst v%,%,$(GIT_TAG))
+else
+VERSION ?= 0.1.0
+endif
 
 # Go build flags
 GOFLAGS ?= -trimpath
@@ -39,7 +47,7 @@ DEV_BASE_IMAGE ?= registry.access.redhat.com/ubi9/ubi-minimal:latest
 # =============================================================================
 IMAGE_REGISTRY ?= quay.io/openshift-hyperfleet
 IMAGE_NAME ?= hyperfleet-adapter
-IMAGE_TAG ?= $(VERSION)
+IMAGE_TAG ?= $(GIT_SHA)$(GIT_DIRTY)
 
 # Dev image configuration - set QUAY_USER to push to personal registry
 # Usage: QUAY_USER=myuser make image-dev
@@ -210,7 +218,7 @@ image: check-container-tool ## Build container image
 		--build-arg GIT_SHA=$(GIT_SHA) \
 		--build-arg GIT_DIRTY=$(GIT_DIRTY) \
 		--build-arg BUILD_DATE=$(BUILD_DATE) \
-		--build-arg VERSION=$(VERSION) \
+		--build-arg APP_VERSION=$(VERSION) \
 		-t $(IMAGE_REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG) .
 	@echo "Image built: $(IMAGE_REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)"
 
@@ -237,7 +245,7 @@ endif
 		--build-arg GIT_SHA=$(GIT_SHA) \
 		--build-arg GIT_DIRTY=$(GIT_DIRTY) \
 		--build-arg BUILD_DATE=$(BUILD_DATE) \
-		--build-arg VERSION=$(VERSION) \
+		--build-arg APP_VERSION=$(VERSION) \
 		-t quay.io/$(QUAY_USER)/$(IMAGE_NAME):$(DEV_TAG) .
 	@echo "Pushing dev image..."
 	$(CONTAINER_TOOL) push quay.io/$(QUAY_USER)/$(IMAGE_NAME):$(DEV_TAG)


### PR DESCRIPTION
…reaking version validation

When APP_VERSION is not set, the empty VERSION= override prevented the Makefile default (0.1.0) from applying, resulting in a binary with blank version metadata. Use shell parameter expansion so VERSION is only passed when APP_VERSION is non-empty.

## Summary

<!-- Brief description of the changes. Reference the Jira ticket. -->

- HYPERFLEET-XXX

## Test Plan

- [x] Unit tests added/updated
- [x] `make test-all` passes
- [x] `make lint` passes
- [ ] Helm chart changes validated with `make test-helm` (if applicable)
- [ ] Deployed to a development cluster and verified (if Helm/config changes)
- [ ] E2E tests passed (if cross-component or major changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version detection to use semantic versioning from git tags when available, defaulting to 0.1.0
  * Container image tags now reference commit SHA instead of version string for improved specificity
  * Build system updated to align versioning and container tagging mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->