### PR TITLE
HYPERFLEET-819 - Standardize command and format for printing version of components

### DIFF
--- a/cmd/adapter/main.go
+++ b/cmd/adapter/main.go
@@ -151,10 +151,9 @@ Priority order (lowest to highest): config file < env vars < CLI flags`,
 		Short: "Print version information",
 		Run: func(cmd *cobra.Command, args []string) {
 			info := version.Info()
-			fmt.Printf("HyperFleet Adapter\n")
-			fmt.Printf("  Version:    %s\n", info.Version)
-			fmt.Printf("  Commit:     %s\n", info.Commit)
-			fmt.Printf("  Built:      %s\n", info.BuildDate)
+			fmt.Printf("Version:    %s\n", info.Version)
+			fmt.Printf("Commit:     %s\n", info.Commit)
+			fmt.Printf("Build Date: %s\n", info.BuildDate)
 		},
 	}
 


### PR DESCRIPTION
## Summary

Standardize command and format for printing version of components

- HYPERFLEET-819

## Test Plan

- [ ] Unit tests added/updated
- [x] `make test-all` passes
- [x] `make lint` passes
- [x] Helm chart changes validated with `make test-helm` (if applicable)
- [ ] Deployed to a development cluster and verified (if Helm/config changes)
- [ ] E2E tests passed (if cross-component or major changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Cleaned up version output: removed header/indentation and updated label text and spacing for clearer display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->