### PR TITLE
Hyperfleet 888 - fix integration test instability caused by unpinned setup-envtest and stale image cache

### DIFF
--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -38,18 +38,12 @@ echo "   Checking integration image configuration..."
 
 # Check and set integration image
 if [ -z "$INTEGRATION_ENVTEST_IMAGE" ]; then
-    echo "   INTEGRATION_ENVTEST_IMAGE not set, using local image"
-    
-    if ! $CONTAINER_RUNTIME images | grep -q "hyperfleet-integration-test"; then
-        echo "   ⚠️  Local integration image not found. Building it..."
-        echo ""
-        cd "$PROJECT_ROOT"
-        make image-integration-test
-        echo ""
-    else
-        echo "   ✅ Local integration image found"
-    fi
-    
+    echo "   INTEGRATION_ENVTEST_IMAGE not set, building local image"
+    echo ""
+    cd "$PROJECT_ROOT"
+    make image-integration-test
+    echo ""
+
     INTEGRATION_ENVTEST_IMAGE="localhost/hyperfleet-integration-test:latest"
 fi
 

--- a/test/Dockerfile.integration
+++ b/test/Dockerfile.integration
@@ -8,7 +8,7 @@ FROM golang:1.25-alpine
 RUN apk add --no-cache curl tar openssl bash
 
 # Install setup-envtest
-RUN go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+RUN go install sigs.k8s.io/controller-runtime/tools/setup-envtest@f9589b9
 
 # Download and extract Kubernetes binaries (etcd, kube-apiserver, kubectl)
 # Using 1.30.x for stability and active support


### PR DESCRIPTION
## Summary

fix integration test instability caused by unpinned setup-envtest and stale image cache

- HYPERFLEET-888

## Test Plan

- [ ] Unit tests added/updated
- [x] `make test-all` passes
- [x] `make lint` passes
- [ ] Helm chart changes validated with `make test-helm` (if applicable)
- [ ] Deployed to a development cluster and verified (if Helm/config changes)
- [ ] E2E tests passed (if cross-component or major changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Integration test build script now always rebuilds the integration test image when the image variable is unset, ensuring consistent test environments.
  * Integration test image setup now pins the envtest tooling to a fixed version for reproducible and stable image builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->