### PR TITLE
HYPERFLEET-700 - refactor: extract WithMetrics and AlwaysAck wrappers

### DIFF
--- a/cmd/adapter/main.go
+++ b/cmd/adapter/main.go
@@ -383,14 +383,12 @@ func buildExecutor(
 	apiClient hyperfleetapi.Client,
 	tc transportclient.TransportClient,
 	log logger.Logger,
-	recorder *metrics.Recorder,
 ) (*executor.Executor, error) {
 	return executor.NewBuilder().
 		WithConfig(config).
 		WithAPIClient(apiClient).
 		WithTransportClient(tc).
 		WithLogger(log).
-		WithMetricsRecorder(recorder).
 		Build()
 }
 
@@ -521,7 +519,7 @@ func runServe(flags *pflag.FlagSet) error {
 
 	// Build executor
 	log.Info(ctx, "Creating event executor...")
-	exec, err := buildExecutor(config, apiClient, tc, log, metricsRecorder)
+	exec, err := buildExecutor(config, apiClient, tc, log)
 	if err != nil {
 		errCtx := logger.WithErrorField(ctx, err)
 		log.Errorf(errCtx, "Failed to create executor")
@@ -529,7 +527,7 @@ func runServe(flags *pflag.FlagSet) error {
 	}
 
 	// Create the event handler and subscribe to broker
-	handler := exec.CreateHandler()
+	handler := executor.AlwaysAck(executor.WithMetrics(exec.CreateHandler(), metricsRecorder, log))
 
 	// Handle signals for graceful shutdown
 	sigCh := make(chan os.Signal, 1)
@@ -708,7 +706,7 @@ func runDryRun(flags *pflag.FlagSet) error {
 	}
 
 	// Build executor with mock clients (same builder as serve, no metrics in dry-run)
-	exec, err := buildExecutor(config, dryrunAPI, dryrunClient, log, nil)
+	exec, err := buildExecutor(config, dryrunAPI, dryrunClient, log)
 	if err != nil {
 		return fmt.Errorf("failed to create executor: %w", err)
 	}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -7,14 +7,11 @@ import (
 	"reflect"
 	"strings"
 
-	"time"
-
 	"github.com/cloudevents/sdk-go/v2/event"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/configloader"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/hyperfleetapi"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/transportclient"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/logger"
-	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/metrics"
 	pkgotel "github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/otel"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
@@ -256,14 +253,9 @@ func (e *Executor) startTracedExecution(ctx context.Context) (context.Context, t
 	return ctx, span
 }
 
-// CreateHandler creates an event handler function that can be used with the broker subscriber
-// This is a convenience method for integrating with the broker_consumer package
-//
-// Error handling strategy:
-// - All failures are logged but the message is ACKed (return nil)
-// - This prevents infinite retry loops for non-recoverable errors (e.g., 400 Bad Request, invalid data)
-func (e *Executor) CreateHandler() func(ctx context.Context, evt *event.Event) error {
-	return func(ctx context.Context, evt *event.Event) error {
+// CreateHandler creates a HandlerFunc that executes the adapter task for a given CloudEvent
+func (e *Executor) CreateHandler() HandlerFunc {
+	return func(ctx context.Context, evt *event.Event) (*ExecutionResult, error) {
 		// Add event ID to context for logging correlation
 		ctx = logger.WithEventID(ctx, evt.ID())
 
@@ -276,38 +268,12 @@ func (e *Executor) CreateHandler() func(ctx context.Context, evt *event.Event) e
 		e.log.Infof(ctx, "Event received: id=%s type=%s source=%s time=%s",
 			evt.ID(), evt.Type(), evt.Source(), evt.Time())
 
-		start := time.Now()
 		result := e.Execute(ctx, evt.Data())
-		duration := time.Since(start)
-
-		e.recordMetrics(result, duration)
 
 		e.log.Infof(ctx, "Event processed: type=%s source=%s time=%s",
 			evt.Type(), evt.Source(), evt.Time())
 
-		return nil
-	}
-}
-
-// recordMetrics records Prometheus metrics based on the execution result.
-func (e *Executor) recordMetrics(result *ExecutionResult, duration time.Duration) {
-	recorder := e.config.MetricsRecorder
-	if recorder == nil {
-		return
-	}
-
-	recorder.ObserveProcessingDuration(duration)
-
-	switch {
-	case result.Status == StatusFailed:
-		recorder.RecordEventProcessed("failed")
-		for phase := range result.Errors {
-			recorder.RecordError(string(phase))
-		}
-	case result.ResourcesSkipped:
-		recorder.RecordEventProcessed("skipped")
-	default:
-		recorder.RecordEventProcessed("success")
+		return result, nil
 	}
 }
 
@@ -390,12 +356,6 @@ func (b *ExecutorBuilder) WithTransportClient(client transportclient.TransportCl
 // WithLogger sets the logger
 func (b *ExecutorBuilder) WithLogger(log logger.Logger) *ExecutorBuilder {
 	b.config.Logger = log
-	return b
-}
-
-// WithMetricsRecorder sets the Prometheus metrics recorder
-func (b *ExecutorBuilder) WithMetricsRecorder(recorder *metrics.Recorder) *ExecutorBuilder {
-	b.config.MetricsRecorder = recorder
 	return b
 }
 

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -814,7 +814,7 @@ func TestSequentialExecution_SkipReasonCapture(t *testing.T) {
 	}
 }
 
-// TestCreateHandler_MetricsRecording verifies that CreateHandler records Prometheus metrics
+// TestCreateHandler_MetricsRecording verifies that WithMetrics records Prometheus metrics
 func TestCreateHandler_MetricsRecording(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -851,11 +851,10 @@ func TestCreateHandler_MetricsRecording(t *testing.T) {
 				WithAPIClient(newMockAPIClient()).
 				WithTransportClient(k8sclient.NewMockK8sClient()).
 				WithLogger(logger.NewTestLogger()).
-				WithMetricsRecorder(recorder).
 				Build()
 			require.NoError(t, err)
 
-			handler := exec.CreateHandler()
+			handler := AlwaysAck(WithMetrics(exec.CreateHandler(), recorder, logger.NewTestLogger()))
 
 			evt := event.New()
 			evt.SetID("test-event-1")
@@ -901,11 +900,10 @@ func TestCreateHandler_MetricsRecording_Failed(t *testing.T) {
 		WithAPIClient(newMockAPIClient()).
 		WithTransportClient(k8sclient.NewMockK8sClient()).
 		WithLogger(logger.NewTestLogger()).
-		WithMetricsRecorder(recorder).
 		Build()
 	require.NoError(t, err)
 
-	handler := exec.CreateHandler()
+	handler := AlwaysAck(WithMetrics(exec.CreateHandler(), recorder, logger.NewTestLogger()))
 
 	evt := event.New()
 	evt.SetID("test-event-fail")
@@ -944,7 +942,7 @@ func TestCreateHandler_NilMetricsRecorder(t *testing.T) {
 		Build()
 	require.NoError(t, err)
 
-	handler := exec.CreateHandler()
+	handler := AlwaysAck(WithMetrics(exec.CreateHandler(), nil, logger.NewTestLogger()))
 
 	evt := event.New()
 	evt.SetID("test-event-nil")
@@ -955,6 +953,165 @@ func TestCreateHandler_NilMetricsRecorder(t *testing.T) {
 	assert.NotPanics(t, func() {
 		_ = handler(context.Background(), &evt)
 	}, "handler with nil MetricsRecorder should not panic")
+}
+
+// TestWithMetrics_RecordsMetrics verifies WithMetrics records the correct metric status
+// and passes the result through
+func TestWithMetrics_RecordsMetrics(t *testing.T) {
+	tests := []struct {
+		result          *ExecutionResult
+		name            string
+		expectedStatus  string
+		expectNoMetrics bool
+	}{
+		{
+			name:           "success",
+			result:         &ExecutionResult{Status: StatusSuccess},
+			expectedStatus: "success",
+		},
+		{
+			name:           "skipped",
+			result:         &ExecutionResult{Status: StatusSuccess, ResourcesSkipped: true},
+			expectedStatus: "skipped",
+		},
+		{
+			name: "failed",
+			result: &ExecutionResult{
+				Status: StatusFailed,
+				Errors: map[ExecutionPhase]error{PhaseParamExtraction: fmt.Errorf("error")},
+			},
+			expectedStatus: "failed",
+		},
+		{
+			name:            "nil result",
+			result:          nil,
+			expectNoMetrics: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := prometheus.NewRegistry()
+			recorder := metrics.NewRecorder("test-adapter", "v0.1.0", registry)
+
+			inner := HandlerFunc(func(_ context.Context, _ *event.Event) (*ExecutionResult, error) {
+				return tt.result, nil
+			})
+			handler := WithMetrics(inner, recorder, logger.NewTestLogger())
+
+			evt := event.New()
+			evt.SetID("test-metrics-" + tt.name)
+			evt.SetType("com.hyperfleet.test")
+			evt.SetSource("test")
+
+			got, err := handler(context.Background(), &evt)
+			require.NoError(t, err)
+			assert.Equal(t, tt.result, got, "result must be passed through unchanged")
+
+			families, err := registry.Gather()
+			require.NoError(t, err)
+
+			if tt.expectNoMetrics {
+				assert.Nil(t, findFamily(families, "hyperfleet_adapter_events_processed_total"),
+					"no status counter should be recorded for nil result")
+				durationFamily := findFamily(families, "hyperfleet_adapter_event_processing_duration_seconds")
+				require.NotNil(t, durationFamily, "duration must be recorded even for nil result")
+				assert.Equal(t, uint64(1), durationFamily.GetMetric()[0].GetHistogram().GetSampleCount())
+				return
+			}
+
+			count := getCounterValue(t, families, "hyperfleet_adapter_events_processed_total", "status", tt.expectedStatus)
+			assert.Equal(t, float64(1), count)
+
+			durationFamily := findFamily(families, "hyperfleet_adapter_event_processing_duration_seconds")
+			require.NotNil(t, durationFamily)
+			assert.Equal(t, uint64(1), durationFamily.GetMetric()[0].GetHistogram().GetSampleCount())
+		})
+	}
+}
+
+// TestWithMetrics_HandlerPanicPropagates verifies a panic in handler is not swallowed by WithMetrics
+func TestWithMetrics_HandlerPanicPropagates(t *testing.T) {
+	inner := HandlerFunc(func(_ context.Context, _ *event.Event) (*ExecutionResult, error) {
+		panic("handler panic")
+	})
+
+	registry := prometheus.NewRegistry()
+	recorder := metrics.NewRecorder("test-adapter", "v0.1.0", registry)
+	handler := WithMetrics(inner, recorder, logger.NewTestLogger())
+
+	evt := event.New()
+	evt.SetID("test-handler-panic")
+	evt.SetType("com.hyperfleet.test")
+	evt.SetSource("test")
+
+	assert.Panics(t, func() {
+		_, _ = handler(context.Background(), &evt)
+	}, "panic in inner handler must propagate through WithMetrics")
+}
+
+// TestWithMetrics_MetricsPanicRecovered verifies that a panic inside metrics recording
+// is recovered
+func TestWithMetrics_MetricsPanicRecovered(t *testing.T) {
+	inner := HandlerFunc(func(_ context.Context, _ *event.Event) (*ExecutionResult, error) {
+		return &ExecutionResult{Status: StatusSuccess}, nil
+	})
+
+	// new(metrics.Recorder) bypasses the nil receiver guard but has nil internal
+	// fields, causing panic inside recordMetrics
+	panicRecorder := new(metrics.Recorder)
+	handler := WithMetrics(inner, panicRecorder, logger.NewTestLogger())
+
+	evt := event.New()
+	evt.SetID("test-metrics-panic")
+	evt.SetType("com.hyperfleet.test")
+	evt.SetSource("test")
+
+	var got *ExecutionResult
+	assert.NotPanics(t, func() {
+		got, _ = handler(context.Background(), &evt)
+	}, "panic in metrics recording must be recovered by WithMetrics")
+	assert.NotNil(t, got, "result must still be returned after metrics panic")
+}
+
+// TestAlwaysAck_AlwaysReturnsNil verifies AlwaysAck always returns nil
+func TestAlwaysAck_AlwaysReturnsNil(t *testing.T) {
+	tests := []struct {
+		result *ExecutionResult
+		err    error
+		name   string
+	}{
+		{
+			name:   "success result",
+			result: &ExecutionResult{Status: StatusSuccess},
+		},
+		{
+			name:   "failed result",
+			result: &ExecutionResult{Status: StatusFailed},
+		},
+		{
+			name: "error from inner handler",
+			err:  fmt.Errorf("inner handler error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inner := HandlerFunc(func(_ context.Context, _ *event.Event) (*ExecutionResult, error) {
+				return tt.result, tt.err
+			})
+
+			handler := AlwaysAck(inner)
+
+			evt := event.New()
+			evt.SetID("test-ack")
+			evt.SetType("com.hyperfleet.test")
+			evt.SetSource("test")
+
+			err := handler(context.Background(), &evt)
+			assert.Nil(t, err, "AlwaysAck must always return nil")
+		})
+	}
 }
 
 // TestPreconditionAPIFailure_ExecutionStatusRemainsFailed verifies that when a precondition

--- a/internal/executor/handler.go
+++ b/internal/executor/handler.go
@@ -1,0 +1,80 @@
+package executor
+
+import (
+	"context"
+	"time"
+
+	"github.com/cloudevents/sdk-go/v2/event"
+	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/logger"
+	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/metrics"
+)
+
+// HandlerFunc is a composable event handler. Build a broker-compatible handler with:
+//
+//	handler := AlwaysAck(WithMetrics(exec.CreateHandler(), metricsRecorder, log))
+type HandlerFunc func(ctx context.Context, evt *event.Event) (*ExecutionResult, error)
+
+// WithMetrics wraps a HandlerFunc to record Prometheus metrics after execution.
+// A panic in metrics recording is recovered to prevent crashing the handler.
+// If recorder is nil, the handler is returned unwrapped.
+func WithMetrics(h HandlerFunc, recorder *metrics.Recorder, log logger.Logger) HandlerFunc {
+	if recorder == nil {
+		return h
+	}
+	return func(ctx context.Context, evt *event.Event) (*ExecutionResult, error) {
+		start := time.Now()
+		result, err := h(ctx, evt)
+		duration := time.Since(start)
+
+		resultForMetrics := result
+		if err != nil && (result == nil || result.Status == StatusSuccess) {
+			resultForMetrics = &ExecutionResult{Status: StatusFailed}
+		}
+
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					log.Errorf(ctx, "panic in metrics recording (recovered): %v", r)
+				}
+			}()
+			recordMetrics(recorder, resultForMetrics, duration)
+		}()
+
+		return result, err
+	}
+}
+
+// AlwaysAck wraps a HandlerFunc into a broker compatible handler that always returns nil,
+// preventing infinite retry loops for non-recoverable errors.
+// Any error returned by HandlerFunc is discarded, callers must log or record errors before this layer.
+func AlwaysAck(h HandlerFunc) func(ctx context.Context, evt *event.Event) error {
+	return func(ctx context.Context, evt *event.Event) error {
+		_, _ = h(ctx, evt) //nolint:errcheck // errors are handled by inner wrappers before this layer
+		return nil
+	}
+}
+
+// recordMetrics records Prometheus metrics based on the execution result.
+func recordMetrics(recorder *metrics.Recorder, result *ExecutionResult, duration time.Duration) {
+	if recorder == nil {
+		return
+	}
+
+	recorder.ObserveProcessingDuration(duration)
+
+	if result == nil {
+		return
+	}
+
+	switch {
+	case result.Status == StatusFailed:
+		recorder.RecordEventProcessed("failed")
+		for phase := range result.Errors {
+			recorder.RecordError(string(phase))
+		}
+	case result.ResourcesSkipped:
+		recorder.RecordEventProcessed("skipped")
+	default:
+		recorder.RecordEventProcessed("success")
+	}
+}

--- a/internal/executor/types.go
+++ b/internal/executor/types.go
@@ -11,7 +11,6 @@ import (
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/manifest"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/transportclient"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/logger"
-	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/metrics"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -65,8 +64,6 @@ type ExecutorConfig struct {
 	TransportClient transportclient.TransportClient
 	// Logger is the logger instance
 	Logger logger.Logger
-	// MetricsRecorder records adapter-level Prometheus metrics (nil disables recording)
-	MetricsRecorder *metrics.Recorder
 }
 
 // Executor processes CloudEvents according to the adapter configuration

--- a/test/integration/executor/executor_integration_test.go
+++ b/test/integration/executor/executor_integration_test.go
@@ -640,7 +640,7 @@ func TestExecutor_Handler_Integration(t *testing.T) {
 	}
 
 	// Get the handler function
-	handler := exec.CreateHandler()
+	handler := executor.AlwaysAck(exec.CreateHandler())
 
 	// Simulate broker calling the handler
 	evt := createTestEvent("cluster-handler-test")
@@ -691,7 +691,7 @@ func TestExecutor_Handler_PreconditionNotMet_ReturnsNil(t *testing.T) {
 		t.Fatalf("Failed to create executor: %v", err)
 	}
 
-	handler := exec.CreateHandler()
+	handler := executor.AlwaysAck(exec.CreateHandler())
 	evt := createTestEvent("cluster-skip")
 
 	// Handler should return nil even when precondition not met
@@ -794,7 +794,7 @@ func TestExecutor_MissingRequiredParam(t *testing.T) {
 	}
 
 	// Test handler behavior: should ACK (not NACK) invalid events
-	handler := exec.CreateHandler()
+	handler := executor.AlwaysAck(exec.CreateHandler())
 	err = handler(context.Background(), evt)
 	if err != nil {
 		t.Errorf("Handler should ACK (return nil) for param extraction failures, got error: %v", err)
@@ -850,7 +850,7 @@ func TestExecutor_InvalidEventJSON(t *testing.T) {
 	assert.Empty(t, result.ResourceResults, "Resources should not execute for invalid event")
 
 	// Test handler behavior: should ACK (not NACK) invalid events
-	handler := exec.CreateHandler()
+	handler := executor.AlwaysAck(exec.CreateHandler())
 	err = handler(context.Background(), &evt)
 	assert.Nil(t, err, "Handler should ACK (return nil) for invalid events, not NACK")
 
@@ -908,7 +908,7 @@ func TestExecutor_MissingEventFields(t *testing.T) {
 	assert.Empty(t, result.ResourceResults, "Resources should not execute for missing required field")
 
 	// Test handler behavior: should ACK (not NACK) events with missing required fields
-	handler := exec.CreateHandler()
+	handler := executor.AlwaysAck(exec.CreateHandler())
 	errPhase = handler(context.Background(), &evt)
 	assert.Nil(t, errPhase, "Handler should ACK (return nil) for missing required fields, not NACK")
 


### PR DESCRIPTION
## Summary
Replaces the `CreateHandler` callback pattern with composable decorator functions `WithMetrics` and `AlwaysAck`, extracting metrics recording and ACK logic out of the executor into wrappers.

- Ticket: [HYPERFLEET-700](https://redhat.atlassian.net/browse/HYPERFLEET-700)

## Test Plan

- [x] Unit tests added/updated
- [x] `make test-all` passes
- [x] `make lint` passes
- [ ] Helm chart changes validated with `make test-helm` (if applicable)
- [ ] Deployed to a development cluster and verified (if Helm/config changes)
- [ ] E2E tests passed (if cross-component or major changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Metrics collection and event acknowledgement are now separate, composable handler wrappers; core execution no longer directly performs instrumentation or forces ACK behavior.
  * Handler abstraction was reworked so metrics and ACKs are applied externally for clearer separation and safer instrumentation.

* **Tests**
  * Added tests for metrics across outcomes, always-ACK behavior, and panic/edge-case handling in the wrapper utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->