### PR TITLE
HYPERFLEET-908 - feat: change default log format to JSON and add format constants

### DIFF
--- a/configs/adapter-config-template.yaml
+++ b/configs/adapter-config-template.yaml
@@ -40,7 +40,7 @@ log:
   # Flag: --log-level
   level: "info"
 
-  # Log format: text, json (default: text)
+  # Log format: text, json (default: json)
   # Environment variable: LOG_FORMAT
   # Flag: --log-format
   format: "json"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,7 +81,7 @@ clients:
 ### Logging (`log`)
 
 - `log.level` (string, optional): Log level (`debug`, `info`, `warn`, `error`). Default: `info`.
-- `log.format` (string, optional): Log format (`text`, `json`). Default: `text`.
+- `log.format` (string, optional): Log format (`text`, `json`). Default: `json`.
 - `log.output` (string, optional): Log output destination (`stdout`, `stderr`). Default: `stdout`.
 
 ### Maestro client (`clients.maestro`)

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -9,6 +9,11 @@ import (
 	"strings"
 )
 
+const (
+	FormatJSON = "json"
+	FormatText = "text"
+)
+
 // Logger is the interface for structured logging.
 // Context is passed as a parameter to each method (aligned with sentinel pattern).
 type Logger interface {
@@ -54,7 +59,7 @@ type logger struct {
 type Config struct {
 	// Level is the minimum log level: "debug", "info", "warn", "error"
 	Level string
-	// Format is the output format: "text" or "json"
+	// Format is the output format: FormatText ("text") or FormatJSON ("json")
 	Format string
 	// Output is the output destination: "stdout", "stderr", or empty (defaults to stdout)
 	// Ignored if Writer is set.
@@ -72,7 +77,7 @@ type Config struct {
 func DefaultConfig() Config {
 	return Config{
 		Level:     "info",
-		Format:    "text",
+		Format:    FormatJSON,
 		Output:    "stdout",
 		Component: "adapter",
 		Version:   "unknown",
@@ -128,10 +133,13 @@ func NewLogger(cfg Config) (Logger, error) {
 
 	// Create handler based on format
 	var handler slog.Handler
-	if cfg.Format == "json" {
+	switch strings.ToLower(cfg.Format) {
+	case FormatJSON:
 		handler = slog.NewJSONHandler(writer, opts)
-	} else {
+	case FormatText:
 		handler = slog.NewTextHandler(writer, opts)
+	default:
+		return nil, fmt.Errorf("invalid log format %q: must be %q or %q", cfg.Format, FormatJSON, FormatText)
 	}
 
 	// Get hostname

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -18,7 +18,7 @@ func TestNewLogger(t *testing.T) {
 			name: "create_logger_with_json_format",
 			config: Config{
 				Level:     "debug",
-				Format:    "json",
+				Format:    FormatJSON,
 				Output:    "stdout",
 				Component: "test-adapter",
 				Version:   "v1.0.0",
@@ -28,7 +28,7 @@ func TestNewLogger(t *testing.T) {
 			name: "create_logger_with_text_format",
 			config: Config{
 				Level:     "info",
-				Format:    "text",
+				Format:    FormatText,
 				Output:    "stderr",
 				Component: "test-adapter",
 				Version:   "v1.0.0",
@@ -57,13 +57,26 @@ func TestNewLogger(t *testing.T) {
 func TestNewLoggerInvalidOutput(t *testing.T) {
 	_, err := NewLogger(Config{
 		Level:     "info",
-		Format:    "text",
+		Format:    FormatText,
 		Output:    "invalid_output",
 		Component: "test",
 		Version:   "v1.0.0",
 	})
 	if err == nil {
 		t.Fatal("Expected error for invalid output, got nil")
+	}
+}
+
+func TestNewLoggerInvalidFormat(t *testing.T) {
+	_, err := NewLogger(Config{
+		Level:     "info",
+		Format:    "yaml",
+		Output:    "stdout",
+		Component: "test",
+		Version:   "v1.0.0",
+	})
+	if err == nil {
+		t.Fatal("Expected error for invalid format, got nil")
 	}
 }
 
@@ -157,7 +170,7 @@ func TestLoggerMethods(t *testing.T) {
 	// These tests verify the methods don't panic
 	log, err := NewLogger(Config{
 		Level:     "debug", // Enable all levels
-		Format:    "text",
+		Format:    FormatText,
 		Output:    "stdout",
 		Component: "test",
 		Version:   "v1.0.0",
@@ -353,8 +366,8 @@ func TestConfigFromEnv(t *testing.T) {
 		if cfg.Level != "info" {
 			t.Errorf("Expected default level 'info', got %s", cfg.Level)
 		}
-		if cfg.Format != "text" {
-			t.Errorf("Expected default format 'text', got %s", cfg.Format)
+		if cfg.Format != FormatJSON {
+			t.Errorf("Expected default format %q, got %s", FormatJSON, cfg.Format)
 		}
 		if cfg.Output != "stdout" {
 			t.Errorf("Expected default output 'stdout', got %s", cfg.Output)
@@ -372,8 +385,8 @@ func TestConfigFromEnv(t *testing.T) {
 	t.Run("reads_LOG_FORMAT_env_var", func(t *testing.T) {
 		t.Setenv("LOG_FORMAT", "JSON")
 		cfg := ConfigFromEnv()
-		if cfg.Format != "json" {
-			t.Errorf("Expected format 'json', got %s", cfg.Format)
+		if cfg.Format != FormatJSON {
+			t.Errorf("Expected format %q, got %s", FormatJSON, cfg.Format)
 		}
 	})
 
@@ -416,7 +429,7 @@ func TestParseLevel(t *testing.T) {
 func TestLoggerContextExtraction(t *testing.T) {
 	log, err := NewLogger(Config{
 		Level:     "debug",
-		Format:    "text",
+		Format:    FormatText,
 		Output:    "stdout",
 		Component: "test",
 		Version:   "v1.0.0",


### PR DESCRIPTION
Switch default logging format from text to JSON for structured log output in production environments.

- Add FormatJSON and FormatText constants to replace string literals
- Change default config format from "text" to "json"
- Update format comparison to use FormatJSON constant
- Update tests to reflect the new default format

## Summary

<!-- Brief description of the changes. Reference the Jira ticket. -->

- HYPERFLEET-908

## Test Plan

- [ ] Unit tests added/updated
- [ ] `make test-all` passes
- [ ] `make lint` passes
- [ ] Helm chart changes validated with `make test-helm` (if applicable)
- [ ] Deployed to a development cluster and verified (if Helm/config changes)
- [ ] E2E tests passed (if cross-component or major changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Logger output now defaults to JSON for improved machine readability and structured logging.

* **Refactor**
  * Configuration uses explicit, named format options for clearer selection and documentation.

* **Bug Fixes**
  * Unsupported log format values now return an error instead of silently falling back.

* **Tests**
  * Tests updated to use the new format options and include a case for invalid formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->