### PR TITLE
HYPERFLEET-852 - feat: add resource deletion metrics

### DIFF
--- a/cmd/adapter/main.go
+++ b/cmd/adapter/main.go
@@ -385,12 +385,14 @@ func buildExecutor(
 	apiClient hyperfleetapi.Client,
 	tc transportclient.TransportClient,
 	log logger.Logger,
+	metricsRecorder *metrics.Recorder,
 ) (*executor.Executor, error) {
 	return executor.NewBuilder().
 		WithConfig(config).
 		WithAPIClient(apiClient).
 		WithTransportClient(tc).
 		WithLogger(log).
+		WithMetricsRecorder(metricsRecorder).
 		Build()
 }
 
@@ -524,7 +526,8 @@ func runServe(flags *pflag.FlagSet) error {
 	}()
 
 	// Create adapter metrics recorder
-	metricsRecorder := metrics.NewRecorder(config.Adapter.Name, version.Version, nil)
+	adapterName := metrics.ExtractAdapterName(config.Adapter.Name)
+	metricsRecorder := metrics.NewRecorder(config.Adapter.Name, version.Version, adapterName, nil)
 
 	// Create real clients
 	log.Info(ctx, "Creating HyperFleet API client...")
@@ -544,7 +547,7 @@ func runServe(flags *pflag.FlagSet) error {
 
 	// Build executor
 	log.Info(ctx, "Creating event executor...")
-	exec, err := buildExecutor(config, apiClient, tc, log)
+	exec, err := buildExecutor(config, apiClient, tc, log, metricsRecorder)
 	if err != nil {
 		errCtx := logger.WithErrorField(ctx, err)
 		log.Errorf(errCtx, "Failed to create executor")
@@ -731,7 +734,7 @@ func runDryRun(flags *pflag.FlagSet) error {
 	}
 
 	// Build executor with mock clients (same builder as serve, no metrics in dry-run)
-	exec, err := buildExecutor(config, dryrunAPI, dryrunClient, log)
+	exec, err := buildExecutor(config, dryrunAPI, dryrunClient, log, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create executor: %w", err)
 	}

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -46,6 +46,25 @@ The `error_type` label on `hyperfleet_adapter_errors_total` corresponds to the e
 | `resources` | Failed to apply Kubernetes resources |
 | `post_actions` | Failed to execute post-actions (e.g., status reporting) |
 
+### Resource Deletion Metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `hyperfleet_adapter_resources_deleted_total` | Counter | `component`, `version`, `adapter_name`, `resource_type`, `status` | Total resource deletion operations by Kubernetes kind |
+| `hyperfleet_adapter_resource_deletion_duration_seconds` | Histogram | `component`, `version`, `adapter_name`, `resource_type` | Duration of resource deletion operations by Kubernetes kind |
+| `hyperfleet_adapter_resource_deletions_in_progress` | Gauge | `component`, `version`, `adapter_name`, `resource_type` | Number of resource deletions currently in progress by Kubernetes kind |
+
+**ConstLabels**: `component`, `version`, and `adapter_name` are set at metric registration and remain constant for the adapter instance.
+
+**Label `resource_type`**: Kubernetes resource kind (e.g., `Namespace`, `ServiceAccount`, `Deployment`). Individual resource instances are tracked via logs/traces, not metrics, per HyperFleet observability architecture.
+
+#### Deletion Status Values
+
+| Status | Description |
+|--------|-------------|
+| `success` | Resource deleted successfully, or already deleted/not found (desired state achieved) |
+| `error` | Deletion operation failed |
+
 #### Histogram Buckets
 
 The `event_processing_duration_seconds` histogram uses the following buckets (in seconds), as recommended by the [adapter metrics standard](https://github.com/openshift-hyperfleet/architecture/blob/main/hyperfleet/components/adapter/framework/adapter-metrics.md):

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -4,28 +4,28 @@
 
 All metrics are exposed on the `/metrics` endpoint (port 9090) in Prometheus format. No additional configuration is needed.
 
-The Helm chart includes a **ServiceMonitor** template for automatic discovery by the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator). It is enabled by default (`serviceMonitor.enabled: true`) and scrapes the `/metrics` endpoint every 30s with `honorLabels: true` to preserve the adapter's `component` and `version` labels. The template is only rendered when the Prometheus Operator CRDs (`monitoring.coreos.com/v1/ServiceMonitor`) are available on the cluster; otherwise it is silently skipped. See the Helm `values.yaml` for configuration options (interval, scrapeTimeout, labels, namespaceSelector).
+The Helm chart includes a **ServiceMonitor** template for automatic discovery by the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator). It is enabled by default (`serviceMonitor.enabled: true`) and scrapes the `/metrics` endpoint every 30s with `honorLabels: true` to preserve the adapter's `component`, `version`, and `adapter_name` labels. The template is only rendered when the Prometheus Operator CRDs (`monitoring.coreos.com/v1/ServiceMonitor`) are available on the cluster; otherwise it is silently skipped. See the Helm `values.yaml` for configuration options (interval, scrapeTimeout, labels, namespaceSelector).
 
 ## Adapter Metrics
 
 The adapter exposes Prometheus metrics following the [HyperFleet Metrics Standard](https://github.com/openshift-hyperfleet/architecture/blob/main/hyperfleet/standards/metrics.md) with the `hyperfleet_adapter_` prefix.
 
-All adapter metrics include `component` and `version` as constant labels.
+All adapter metrics include `component`, `version`, and `adapter_name` as constant labels.
 
 ### Baseline Metrics
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `hyperfleet_adapter_build_info` | Gauge | `component`, `version`, `commit` | Build information (always 1) |
-| `hyperfleet_adapter_up` | Gauge | `component`, `version` | Whether the adapter is up and running (1=up, 0=shutting down) |
+| `hyperfleet_adapter_build_info` | Gauge | `component`, `version`, `adapter_name`, `commit` | Build information (always 1) |
+| `hyperfleet_adapter_up` | Gauge | `component`, `version`, `adapter_name` | Whether the adapter is up and running (1=up, 0=shutting down) |
 
 ### Event Processing Metrics
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `hyperfleet_adapter_events_processed_total` | Counter | `component`, `version`, `status` | Total CloudEvents processed. Status: `success`, `failed`, `skipped` |
-| `hyperfleet_adapter_event_processing_duration_seconds` | Histogram | `component`, `version` | End-to-end event processing duration |
-| `hyperfleet_adapter_errors_total` | Counter | `component`, `version`, `error_type` | Total errors by execution phase |
+| `hyperfleet_adapter_events_processed_total` | Counter | `component`, `version`, `adapter_name`, `status` | Total CloudEvents processed. Status: `success`, `failed`, `skipped` |
+| `hyperfleet_adapter_event_processing_duration_seconds` | Histogram | `component`, `version`, `adapter_name` | End-to-end event processing duration |
+| `hyperfleet_adapter_errors_total` | Counter | `component`, `version`, `adapter_name`, `error_type` | Total errors by execution phase |
 
 #### Status Values
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -67,11 +67,13 @@ The `error_type` label on `hyperfleet_adapter_errors_total` corresponds to the e
 
 #### Histogram Buckets
 
-The `event_processing_duration_seconds` histogram uses the following buckets (in seconds), as recommended by the [adapter metrics standard](https://github.com/openshift-hyperfleet/architecture/blob/main/hyperfleet/components/adapter/framework/adapter-metrics.md):
+Both duration histograms (`event_processing_duration_seconds` and `resource_deletion_duration_seconds`) use the following buckets (in seconds), as recommended by the [adapter metrics standard](https://github.com/openshift-hyperfleet/architecture/blob/main/hyperfleet/components/adapter/framework/adapter-metrics.md):
 
 ```text
 0.1, 0.5, 1, 2, 5, 10, 30, 60, 120
 ```
+
+This shared bucket configuration enables consistent histogram_quantile queries across both metrics.
 
 ### Example PromQL Queries
 

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/hyperfleetapi"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/transportclient"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/logger"
+	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/metrics"
 	pkgotel "github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/telemetry"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
@@ -356,6 +357,12 @@ func (b *ExecutorBuilder) WithTransportClient(client transportclient.TransportCl
 // WithLogger sets the logger
 func (b *ExecutorBuilder) WithLogger(log logger.Logger) *ExecutorBuilder {
 	b.config.Logger = log
+	return b
+}
+
+// WithMetricsRecorder sets the optional Prometheus metrics recorder
+func (b *ExecutorBuilder) WithMetricsRecorder(recorder *metrics.Recorder) *ExecutorBuilder {
+	b.config.MetricsRecorder = recorder
 	return b
 }
 

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -839,7 +839,7 @@ func TestCreateHandler_MetricsRecording(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			registry := prometheus.NewRegistry()
-			recorder := metrics.NewRecorder("test-adapter", "v0.1.0", registry)
+			recorder := metrics.NewRecorder("test-adapter", "v0.1.0", "test", registry)
 
 			config := &configloader.Config{
 				Adapter:       configloader.AdapterInfo{Name: "test-adapter", Version: "v0.1.0"},
@@ -886,7 +886,7 @@ func TestCreateHandler_MetricsRecording(t *testing.T) {
 // TestCreateHandler_MetricsRecording_Failed verifies error metrics are recorded on failure
 func TestCreateHandler_MetricsRecording_Failed(t *testing.T) {
 	registry := prometheus.NewRegistry()
-	recorder := metrics.NewRecorder("test-adapter", "v0.1.0", registry)
+	recorder := metrics.NewRecorder("test-adapter", "v0.1.0", "test", registry)
 
 	config := &configloader.Config{
 		Adapter: configloader.AdapterInfo{Name: "test-adapter", Version: "v0.1.0"},
@@ -992,7 +992,7 @@ func TestWithMetrics_RecordsMetrics(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			registry := prometheus.NewRegistry()
-			recorder := metrics.NewRecorder("test-adapter", "v0.1.0", registry)
+			recorder := metrics.NewRecorder("test-adapter", "v0.1.0", "test", registry)
 
 			inner := HandlerFunc(func(_ context.Context, _ *event.Event) (*ExecutionResult, error) {
 				return tt.result, nil
@@ -1037,7 +1037,7 @@ func TestWithMetrics_HandlerPanicPropagates(t *testing.T) {
 	})
 
 	registry := prometheus.NewRegistry()
-	recorder := metrics.NewRecorder("test-adapter", "v0.1.0", registry)
+	recorder := metrics.NewRecorder("test-adapter", "v0.1.0", "test", registry)
 	handler := WithMetrics(inner, recorder, logger.NewTestLogger())
 
 	evt := event.New()

--- a/internal/executor/resource_executor.go
+++ b/internal/executor/resource_executor.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/configloader"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/criteria"
@@ -12,6 +13,7 @@ import (
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/manifest"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/transportclient"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/logger"
+	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/metrics"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/utils"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -20,16 +22,18 @@ import (
 
 // ResourceExecutor creates and updates Kubernetes resources
 type ResourceExecutor struct {
-	client transportclient.TransportClient
-	log    logger.Logger
+	client  transportclient.TransportClient
+	log     logger.Logger
+	metrics *metrics.Recorder
 }
 
 // newResourceExecutor creates a new resource executor
 // NOTE: Caller (NewExecutor) is responsible for config validation
 func newResourceExecutor(config *ExecutorConfig) *ResourceExecutor {
 	return &ResourceExecutor{
-		client: config.TransportClient,
-		log:    config.Logger,
+		client:  config.TransportClient,
+		log:     config.Logger,
+		metrics: config.MetricsRecorder,
 	}
 }
 
@@ -589,6 +593,19 @@ func (re *ResourceExecutor) executeResourceDelete(
 	execCtx *ExecutionContext,
 	transportTarget transportclient.TransportContext,
 ) (ResourceResult, error) {
+	// Extract resource type (Kubernetes kind) from manifest for metrics labeling.
+	// This is done early so it's available for all metric recording paths (success/failure).
+	gvk := re.resolveGVK(resource)
+	resourceType := gvk.Kind
+	if resourceType == "" {
+		resourceType = metrics.ResourceTypeUnknown
+	}
+
+	// Metrics: track deletion in-progress and duration
+	startTime := time.Now()
+	re.metrics.IncDeletionInProgress(resourceType)
+	defer re.metrics.DecDeletionInProgress(resourceType)
+
 	result := ResourceResult{
 		Name:      resource.Name,
 		Status:    StatusSuccess,
@@ -603,6 +620,8 @@ func (re *ResourceExecutor) executeResourceDelete(
 		result.Status = StatusFailed
 		result.Error = discoverErr
 		re.recordResourceError(execCtx, resource, discoverErr)
+		re.metrics.RecordDeletion(resourceType, metrics.DeletionStatusError)
+		re.metrics.ObserveDeletionDuration(resourceType, time.Since(startTime))
 		return result, NewExecutorError(
 			PhaseResources, resource.Name, "failed to discover resource for deletion", discoverErr)
 	}
@@ -612,17 +631,26 @@ func (re *ResourceExecutor) executeResourceDelete(
 		// Store nil — the key is removed from the CEL resources map, so
 		// !resources.?X.hasValue() evaluates to true in this reconciliation.
 		execCtx.Resources[resource.Name] = nil
-		result.OperationReason = "resource not found, already deleted"
-		re.log.Infof(ctx, "Resource[%s] delete: already gone (not found)", resource.Name)
+		result.OperationReason = "resource already deleted or never existed"
+		re.log.Infof(ctx, "Resource[%s] delete: already deleted or never existed", resource.Name)
+		re.metrics.RecordDeletion(resourceType, metrics.DeletionStatusSuccess)
+		re.metrics.ObserveDeletionDuration(resourceType, time.Since(startTime))
 		return result, nil
 	}
 
 	// Step 3: Extract identity from discovered resource for result reporting
-	gvk := discovered.GroupVersionKind()
+	gvk = discovered.GroupVersionKind()
 	result.Kind = gvk.Kind
 	result.Namespace = discovered.GetNamespace()
 	result.ResourceName = discovered.GetName()
 	result.DiscoveredState = discovered
+
+	// Update resourceType with authoritative kind from discovered resource.
+	// If manifest-based GVK resolution initially failed (resourceType was set to "Unknown"),
+	// we now have the correct kind from the actual K8s resource.
+	if gvk.Kind != "" {
+		resourceType = gvk.Kind
+	}
 
 	// Step 4: Build delete options
 	propagationPolicy := "Background"
@@ -641,6 +669,8 @@ func (re *ResourceExecutor) executeResourceDelete(
 		errCtx := logger.WithK8sResult(ctx, "FAILED")
 		errCtx = logger.WithErrorField(errCtx, err)
 		re.log.Errorf(errCtx, "Resource[%s] delete: FAILED", resource.Name)
+		re.metrics.RecordDeletion(resourceType, metrics.DeletionStatusError)
+		re.metrics.ObserveDeletionDuration(resourceType, time.Since(startTime))
 		return result, NewExecutorError(PhaseResources, resource.Name, "failed to delete resource", err)
 	}
 
@@ -671,6 +701,9 @@ func (re *ResourceExecutor) executeResourceDelete(
 	re.log.Infof(logger.WithK8sResult(ctx, "SUCCESS"),
 		"Resource[%s] delete: operation=delete propagationPolicy=%s",
 		resource.Name, propagationPolicy)
+
+	re.metrics.RecordDeletion(resourceType, metrics.DeletionStatusSuccess)
+	re.metrics.ObserveDeletionDuration(resourceType, time.Since(startTime))
 
 	return result, nil
 }

--- a/internal/executor/types.go
+++ b/internal/executor/types.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/manifest"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/transportclient"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/logger"
+	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/metrics"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -64,6 +65,8 @@ type ExecutorConfig struct {
 	TransportClient transportclient.TransportClient
 	// Logger is the logger instance
 	Logger logger.Logger
+	// MetricsRecorder is the optional Prometheus metrics recorder
+	MetricsRecorder *metrics.Recorder
 }
 
 // Executor processes CloudEvents according to the adapter configuration

--- a/pkg/health/metrics_test.go
+++ b/pkg/health/metrics_test.go
@@ -105,7 +105,7 @@ func TestAdapterMetricsExposedOnMetricsEndpoint(t *testing.T) {
 	upGauge.Set(1)
 
 	// Register adapter event metrics using the same registry
-	recorder := metrics.NewRecorder("test-adapter", "v0.1.0-test", registry)
+	recorder := metrics.NewRecorder("test-adapter", "v0.1.0-test", "test", registry)
 
 	// Simulate adapter activity
 	recorder.RecordEventProcessed("success")

--- a/pkg/metrics/recorder.go
+++ b/pkg/metrics/recorder.go
@@ -20,13 +20,16 @@ const (
 	ResourceTypeUnknown = "Unknown"
 )
 
-// Propagation policy constants
-const (
-	PropagationPolicyUnknown = "unknown"
-)
-
 // ExtractAdapterName derives a short adapter name from the component name.
-// Examples: "hyperfleet-adapter-gcp" → "gcp", "adapter-validation" → "validation", "test-adapter" → "test"
+// It strips common prefixes ("hyperfleet-adapter-", "adapter-") and suffixes ("-adapter")
+// to produce a short identifier suitable for the adapter_name metric label.
+// If no pattern matches, it returns the component name unchanged.
+//
+// Examples:
+//   - "hyperfleet-adapter-gcp" → "gcp"
+//   - "adapter-validation" → "validation"
+//   - "test-adapter" → "test"
+//   - "standalone" → "standalone"
 func ExtractAdapterName(component string) string {
 	switch {
 	case strings.HasPrefix(component, "hyperfleet-adapter-"):

--- a/pkg/metrics/recorder.go
+++ b/pkg/metrics/recorder.go
@@ -3,10 +3,42 @@
 package metrics
 
 import (
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
+
+// Deletion status constants per HyperFleet adapter-metrics.md standard
+const (
+	DeletionStatusSuccess = "success"
+	DeletionStatusError   = "error"
+)
+
+// Resource type constants
+const (
+	ResourceTypeUnknown = "Unknown"
+)
+
+// Propagation policy constants
+const (
+	PropagationPolicyUnknown = "unknown"
+)
+
+// ExtractAdapterName derives a short adapter name from the component name.
+// Examples: "hyperfleet-adapter-gcp" → "gcp", "adapter-validation" → "validation", "test-adapter" → "test"
+func ExtractAdapterName(component string) string {
+	switch {
+	case strings.HasPrefix(component, "hyperfleet-adapter-"):
+		return strings.TrimPrefix(component, "hyperfleet-adapter-")
+	case strings.HasPrefix(component, "adapter-"):
+		return strings.TrimPrefix(component, "adapter-")
+	case strings.HasSuffix(component, "-adapter"):
+		return strings.TrimSuffix(component, "-adapter")
+	default:
+		return component
+	}
+}
 
 // Recorder registers and records adapter-level Prometheus metrics.
 // All methods are nil-safe: calling methods on a nil *Recorder is a no-op,
@@ -15,11 +47,15 @@ type Recorder struct {
 	eventsProcessed    *prometheus.CounterVec
 	processingDuration prometheus.Observer
 	errorsTotal        *prometheus.CounterVec
+	deletionTotal      *prometheus.CounterVec
+	deletionDuration   *prometheus.HistogramVec
+	deletionInProgress *prometheus.GaugeVec
 }
 
 // NewRecorder creates a new Recorder and registers metrics with the given registerer.
 // If reg is nil, prometheus.DefaultRegisterer is used.
-func NewRecorder(component, version string, reg prometheus.Registerer) *Recorder {
+// The adapterName should be a short identifier (e.g., "gcp", "validation") derived from component.
+func NewRecorder(component, version, adapterName string, reg prometheus.Registerer) *Recorder {
 	if reg == nil {
 		reg = prometheus.DefaultRegisterer
 	}
@@ -29,8 +65,9 @@ func NewRecorder(component, version string, reg prometheus.Registerer) *Recorder
 			Name: "hyperfleet_adapter_events_processed_total",
 			Help: "Total number of CloudEvents processed by the adapter",
 			ConstLabels: prometheus.Labels{
-				"component": component,
-				"version":   version,
+				"component":    component,
+				"version":      version,
+				"adapter_name": adapterName,
 			},
 		},
 		[]string{"status"},
@@ -42,8 +79,9 @@ func NewRecorder(component, version string, reg prometheus.Registerer) *Recorder
 			Help:    "Duration of event processing in seconds",
 			Buckets: []float64{0.1, 0.5, 1, 2, 5, 10, 30, 60, 120},
 			ConstLabels: prometheus.Labels{
-				"component": component,
-				"version":   version,
+				"component":    component,
+				"version":      version,
+				"adapter_name": adapterName,
 			},
 		},
 	)
@@ -53,21 +91,68 @@ func NewRecorder(component, version string, reg prometheus.Registerer) *Recorder
 			Name: "hyperfleet_adapter_errors_total",
 			Help: "Total number of errors encountered by the adapter",
 			ConstLabels: prometheus.Labels{
-				"component": component,
-				"version":   version,
+				"component":    component,
+				"version":      version,
+				"adapter_name": adapterName,
 			},
 		},
 		[]string{"error_type"},
 	)
 
+	deletionTotal := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "hyperfleet_adapter_resources_deleted_total",
+			Help: "Total number of adapter resource deletion operations",
+			ConstLabels: prometheus.Labels{
+				"component":    component,
+				"version":      version,
+				"adapter_name": adapterName,
+			},
+		},
+		[]string{"resource_type", "status"},
+	)
+
+	deletionDuration := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "hyperfleet_adapter_resource_deletion_duration_seconds",
+			Help:    "Duration of resource deletion operations in seconds",
+			Buckets: []float64{0.1, 0.5, 1, 2, 5, 10, 30, 60, 120},
+			ConstLabels: prometheus.Labels{
+				"component":    component,
+				"version":      version,
+				"adapter_name": adapterName,
+			},
+		},
+		[]string{"resource_type"},
+	)
+
+	deletionInProgress := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "hyperfleet_adapter_resource_deletions_in_progress",
+			Help: "Number of resource deletions currently in progress",
+			ConstLabels: prometheus.Labels{
+				"component":    component,
+				"version":      version,
+				"adapter_name": adapterName,
+			},
+		},
+		[]string{"resource_type"},
+	)
+
 	reg.MustRegister(eventsProcessed)
 	reg.MustRegister(processingDuration)
 	reg.MustRegister(errorsTotal)
+	reg.MustRegister(deletionTotal)
+	reg.MustRegister(deletionDuration)
+	reg.MustRegister(deletionInProgress)
 
 	return &Recorder{
 		eventsProcessed:    eventsProcessed,
 		processingDuration: processingDuration,
 		errorsTotal:        errorsTotal,
+		deletionTotal:      deletionTotal,
+		deletionDuration:   deletionDuration,
+		deletionInProgress: deletionInProgress,
 	}
 }
 
@@ -96,4 +181,41 @@ func (r *Recorder) RecordError(errorType string) {
 		return
 	}
 	r.errorsTotal.WithLabelValues(errorType).Inc()
+}
+
+// RecordDeletion increments the resources_deleted_total counter for the given resource type.
+// resourceType should be the Kubernetes kind (e.g., "Namespace", "ServiceAccount").
+// Valid status values: DeletionStatusSuccess ("success"), DeletionStatusError ("error").
+func (r *Recorder) RecordDeletion(resourceType, status string) {
+	if r == nil {
+		return
+	}
+	r.deletionTotal.WithLabelValues(resourceType, status).Inc()
+}
+
+// ObserveDeletionDuration records the deletion duration for a resource type in seconds.
+// resourceType should be the Kubernetes kind (e.g., "Namespace", "ServiceAccount").
+func (r *Recorder) ObserveDeletionDuration(resourceType string, d time.Duration) {
+	if r == nil {
+		return
+	}
+	r.deletionDuration.WithLabelValues(resourceType).Observe(d.Seconds())
+}
+
+// IncDeletionInProgress increments the in-progress deletion gauge for a resource type.
+// resourceType should be the Kubernetes kind (e.g., "Namespace", "ServiceAccount").
+func (r *Recorder) IncDeletionInProgress(resourceType string) {
+	if r == nil {
+		return
+	}
+	r.deletionInProgress.WithLabelValues(resourceType).Inc()
+}
+
+// DecDeletionInProgress decrements the in-progress deletion gauge for a resource type.
+// resourceType should be the Kubernetes kind (e.g., "Namespace", "ServiceAccount").
+func (r *Recorder) DecDeletionInProgress(resourceType string) {
+	if r == nil {
+		return
+	}
+	r.deletionInProgress.WithLabelValues(resourceType).Dec()
 }

--- a/pkg/metrics/recorder.go
+++ b/pkg/metrics/recorder.go
@@ -40,6 +40,30 @@ func ExtractAdapterName(component string) string {
 	}
 }
 
+// normalizeResourceType normalizes resource type labels to prevent cardinality issues.
+// Empty or whitespace-only values are replaced with ResourceTypeUnknown.
+func normalizeResourceType(resourceType string) string {
+	resourceType = strings.TrimSpace(resourceType)
+	if resourceType == "" {
+		return ResourceTypeUnknown
+	}
+	return resourceType
+}
+
+// normalizeDeletionStatus validates and normalizes deletion status labels.
+// Only DeletionStatusSuccess and DeletionStatusError are valid.
+// Invalid values are replaced with DeletionStatusError to prevent bad time series.
+func normalizeDeletionStatus(status string) string {
+	status = strings.TrimSpace(status)
+	switch status {
+	case DeletionStatusSuccess, DeletionStatusError:
+		return status
+	default:
+		// Invalid status values default to "error" as a safe fallback
+		return DeletionStatusError
+	}
+}
+
 // Recorder registers and records adapter-level Prometheus metrics.
 // All methods are nil-safe: calling methods on a nil *Recorder is a no-op,
 // which allows dry-run mode to skip metrics without nil checks at every call site.
@@ -186,36 +210,45 @@ func (r *Recorder) RecordError(errorType string) {
 // RecordDeletion increments the resources_deleted_total counter for the given resource type.
 // resourceType should be the Kubernetes kind (e.g., "Namespace", "ServiceAccount").
 // Valid status values: DeletionStatusSuccess ("success"), DeletionStatusError ("error").
+// Invalid inputs are normalized to prevent bad time series.
 func (r *Recorder) RecordDeletion(resourceType, status string) {
 	if r == nil {
 		return
 	}
+	resourceType = normalizeResourceType(resourceType)
+	status = normalizeDeletionStatus(status)
 	r.deletionTotal.WithLabelValues(resourceType, status).Inc()
 }
 
 // ObserveDeletionDuration records the deletion duration for a resource type in seconds.
 // resourceType should be the Kubernetes kind (e.g., "Namespace", "ServiceAccount").
+// Empty or invalid resourceType is normalized to prevent bad time series.
 func (r *Recorder) ObserveDeletionDuration(resourceType string, d time.Duration) {
 	if r == nil {
 		return
 	}
+	resourceType = normalizeResourceType(resourceType)
 	r.deletionDuration.WithLabelValues(resourceType).Observe(d.Seconds())
 }
 
 // IncDeletionInProgress increments the in-progress deletion gauge for a resource type.
 // resourceType should be the Kubernetes kind (e.g., "Namespace", "ServiceAccount").
+// Empty or invalid resourceType is normalized to prevent bad time series.
 func (r *Recorder) IncDeletionInProgress(resourceType string) {
 	if r == nil {
 		return
 	}
+	resourceType = normalizeResourceType(resourceType)
 	r.deletionInProgress.WithLabelValues(resourceType).Inc()
 }
 
 // DecDeletionInProgress decrements the in-progress deletion gauge for a resource type.
 // resourceType should be the Kubernetes kind (e.g., "Namespace", "ServiceAccount").
+// Empty or invalid resourceType is normalized to prevent bad time series.
 func (r *Recorder) DecDeletionInProgress(resourceType string) {
 	if r == nil {
 		return
 	}
+	resourceType = normalizeResourceType(resourceType)
 	r.deletionInProgress.WithLabelValues(resourceType).Dec()
 }

--- a/pkg/metrics/recorder_test.go
+++ b/pkg/metrics/recorder_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestNewRecorder(t *testing.T) {
 	registry := prometheus.NewRegistry()
-	recorder := NewRecorder("test-adapter", "v0.1.0", registry)
+	recorder := NewRecorder("test-adapter", "v0.1.0", "test", registry)
 	require.NotNil(t, recorder)
 
 	// Trigger all metrics so they appear in Gather()
@@ -38,7 +38,7 @@ func TestNewRecorder(t *testing.T) {
 
 func TestRecordEventProcessed(t *testing.T) {
 	registry := prometheus.NewRegistry()
-	recorder := NewRecorder("test-adapter", "v0.1.0", registry)
+	recorder := NewRecorder("test-adapter", "v0.1.0", "test", registry)
 
 	recorder.RecordEventProcessed("success")
 	recorder.RecordEventProcessed("success")
@@ -75,7 +75,7 @@ func TestRecordEventProcessed(t *testing.T) {
 
 func TestRecordEventProcessed_ConstLabels(t *testing.T) {
 	registry := prometheus.NewRegistry()
-	recorder := NewRecorder("my-adapter", "v1.2.3", registry)
+	recorder := NewRecorder("my-adapter", "v1.2.3", "my", registry)
 
 	recorder.RecordEventProcessed("success")
 
@@ -104,7 +104,7 @@ func TestRecordEventProcessed_ConstLabels(t *testing.T) {
 
 func TestObserveProcessingDuration(t *testing.T) {
 	registry := prometheus.NewRegistry()
-	recorder := NewRecorder("test-adapter", "v0.1.0", registry)
+	recorder := NewRecorder("test-adapter", "v0.1.0", "test", registry)
 
 	recorder.ObserveProcessingDuration(500 * time.Millisecond)
 	recorder.ObserveProcessingDuration(2 * time.Second)
@@ -139,7 +139,7 @@ func TestObserveProcessingDuration(t *testing.T) {
 
 func TestRecordError(t *testing.T) {
 	registry := prometheus.NewRegistry()
-	recorder := NewRecorder("test-adapter", "v0.1.0", registry)
+	recorder := NewRecorder("test-adapter", "v0.1.0", "test", registry)
 
 	recorder.RecordError("param_extraction")
 	recorder.RecordError("preconditions")
@@ -172,6 +172,138 @@ func TestRecordError(t *testing.T) {
 	assert.Equal(t, float64(1), counts["resources"], "resources error count")
 }
 
+func TestRecordDeletion(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	recorder := NewRecorder("test-adapter", "v0.1.0", "test", registry)
+
+	recorder.RecordDeletion("Namespace", DeletionStatusSuccess)
+	recorder.RecordDeletion("Namespace", DeletionStatusSuccess)
+	recorder.RecordDeletion("ServiceAccount", DeletionStatusError)
+	recorder.RecordDeletion("ConfigMap", DeletionStatusSuccess)
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+
+	var deletionFamily *dto.MetricFamily
+	for _, f := range families {
+		if f.GetName() == "hyperfleet_adapter_resources_deleted_total" {
+			deletionFamily = f
+			break
+		}
+	}
+	require.NotNil(t, deletionFamily, "resources_deleted_total metric family should exist")
+
+	counts := make(map[string]float64)
+	for _, m := range deletionFamily.GetMetric() {
+		labels := make(map[string]string)
+		for _, l := range m.GetLabel() {
+			labels[l.GetName()] = l.GetValue()
+		}
+		key := labels["resource_type"] + "/" + labels["status"]
+		counts[key] = m.GetCounter().GetValue()
+	}
+
+	assert.Equal(t, float64(2), counts["Namespace/success"], "Namespace success count")
+	assert.Equal(t, float64(1), counts["ServiceAccount/error"], "ServiceAccount error count")
+	assert.Equal(t, float64(1), counts["ConfigMap/success"], "ConfigMap success count")
+}
+
+func TestObserveDeletionDuration(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	recorder := NewRecorder("test-adapter", "v0.1.0", "test", registry)
+
+	recorder.ObserveDeletionDuration("Namespace", 500*time.Millisecond)
+	recorder.ObserveDeletionDuration("Namespace", 2*time.Second)
+	recorder.ObserveDeletionDuration("ServiceAccount", 100*time.Millisecond)
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+
+	var durationFamily *dto.MetricFamily
+	for _, f := range families {
+		if f.GetName() == "hyperfleet_adapter_resource_deletion_duration_seconds" {
+			durationFamily = f
+			break
+		}
+	}
+	require.NotNil(t, durationFamily, "resource_deletion_duration_seconds metric family should exist")
+
+	// Find Namespace histogram
+	var namespaceHistogram *dto.Histogram
+	for _, m := range durationFamily.GetMetric() {
+		for _, l := range m.GetLabel() {
+			if l.GetName() == "resource_type" && l.GetValue() == "Namespace" {
+				namespaceHistogram = m.GetHistogram()
+				break
+			}
+		}
+	}
+	require.NotNil(t, namespaceHistogram, "Namespace histogram should exist")
+
+	assert.Equal(t, uint64(2), namespaceHistogram.GetSampleCount(), "Namespace sample count")
+	assert.InDelta(t, 2.5, namespaceHistogram.GetSampleSum(), 0.01, "Namespace sample sum")
+}
+
+func TestDeletionInProgress(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	recorder := NewRecorder("test-adapter", "v0.1.0", "test", registry)
+
+	recorder.IncDeletionInProgress("Namespace")
+	recorder.IncDeletionInProgress("Namespace")
+	recorder.IncDeletionInProgress("ServiceAccount")
+	recorder.DecDeletionInProgress("Namespace")
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+
+	var gaugeFamily *dto.MetricFamily
+	for _, f := range families {
+		if f.GetName() == "hyperfleet_adapter_resource_deletions_in_progress" {
+			gaugeFamily = f
+			break
+		}
+	}
+	require.NotNil(t, gaugeFamily, "resource_deletions_in_progress metric family should exist")
+
+	gauges := make(map[string]float64)
+	for _, m := range gaugeFamily.GetMetric() {
+		for _, l := range m.GetLabel() {
+			if l.GetName() == "resource_type" {
+				gauges[l.GetValue()] = m.GetGauge().GetValue()
+			}
+		}
+	}
+
+	assert.Equal(t, float64(1), gauges["Namespace"], "Namespace gauge value")
+	assert.Equal(t, float64(1), gauges["ServiceAccount"], "ServiceAccount gauge value")
+}
+
+func TestNewRecorder_DeletionMetrics(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	recorder := NewRecorder("test-adapter", "v0.1.0", "test", registry)
+	require.NotNil(t, recorder)
+
+	// Trigger deletion metrics so they appear in Gather()
+	recorder.RecordDeletion("Namespace", DeletionStatusSuccess)
+	recorder.ObserveDeletionDuration("Namespace", 1*time.Millisecond)
+	recorder.IncDeletionInProgress("Namespace")
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+
+	names := make(map[string]bool)
+	for _, f := range families {
+		names[f.GetName()] = true
+	}
+
+	assert.True(t, names["hyperfleet_adapter_resources_deleted_total"],
+		"resources_deleted_total should be registered")
+	assert.True(t, names["hyperfleet_adapter_resource_deletion_duration_seconds"],
+		"resource_deletion_duration_seconds should be registered")
+	assert.True(t, names["hyperfleet_adapter_resource_deletions_in_progress"],
+		"resource_deletions_in_progress should be registered")
+}
+
 func TestNilRecorderNoPanic(t *testing.T) {
 	var recorder *Recorder
 
@@ -187,4 +319,41 @@ func TestNilRecorderNoPanic(t *testing.T) {
 	assert.NotPanics(t, func() {
 		recorder.RecordError("test_error")
 	}, "RecordError on nil recorder")
+
+	assert.NotPanics(t, func() {
+		recorder.RecordDeletion("Namespace", DeletionStatusSuccess)
+	}, "RecordDeletion on nil recorder")
+
+	assert.NotPanics(t, func() {
+		recorder.ObserveDeletionDuration("Namespace", 1*time.Second)
+	}, "ObserveDeletionDuration on nil recorder")
+
+	assert.NotPanics(t, func() {
+		recorder.IncDeletionInProgress("Namespace")
+	}, "IncDeletionInProgress on nil recorder")
+
+	assert.NotPanics(t, func() {
+		recorder.DecDeletionInProgress("Namespace")
+	}, "DecDeletionInProgress on nil recorder")
+}
+
+func TestExtractAdapterName(t *testing.T) {
+	tests := []struct {
+		component string
+		want      string
+	}{
+		{"hyperfleet-adapter-gcp", "gcp"},
+		{"hyperfleet-adapter-aws", "aws"},
+		{"adapter-validation", "validation"},
+		{"test-adapter", "test"},
+		{"my-adapter", "my"},
+		{"standalone", "standalone"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.component, func(t *testing.T) {
+			got := ExtractAdapterName(tt.component)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }

--- a/pkg/metrics/recorder_test.go
+++ b/pkg/metrics/recorder_test.go
@@ -357,3 +357,90 @@ func TestExtractAdapterName(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeResourceType(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"valid kind", "Namespace", "Namespace"},
+		{"empty string", "", "Unknown"},
+		{"whitespace only", "   ", "Unknown"},
+		{"with leading/trailing spaces", "  Deployment  ", "Deployment"},
+		{"lowercase (no change)", "pod", "pod"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeResourceType(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestNormalizeDeletionStatus(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"valid success", "success", "success"},
+		{"valid error", "error", "error"},
+		{"invalid failed", "failed", "error"},
+		{"invalid skipped", "skipped", "error"},
+		{"empty string", "", "error"},
+		{"whitespace only", "   ", "error"},
+		{"typo in status", "sucess", "error"}, //nolint:misspell // intentional typo for testing
+		{"uppercase SUCCESS", "SUCCESS", "error"},
+		{"with spaces", " success ", "success"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeDeletionStatus(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRecordDeletion_Normalization(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	recorder := NewRecorder("test-adapter", "v0.1.0", "test", registry)
+
+	// Record with invalid status - should normalize to "error"
+	recorder.RecordDeletion("Namespace", "invalid-status")
+	// Record with empty resourceType - should normalize to "Unknown"
+	recorder.RecordDeletion("", "success")
+	// Record with valid values
+	recorder.RecordDeletion("ServiceAccount", "success")
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+
+	var deletionFamily *dto.MetricFamily
+	for _, f := range families {
+		if f.GetName() == "hyperfleet_adapter_resources_deleted_total" {
+			deletionFamily = f
+			break
+		}
+	}
+	require.NotNil(t, deletionFamily)
+
+	counts := make(map[string]float64)
+	for _, m := range deletionFamily.GetMetric() {
+		labels := make(map[string]string)
+		for _, l := range m.GetLabel() {
+			labels[l.GetName()] = l.GetValue()
+		}
+		key := labels["resource_type"] + "/" + labels["status"]
+		counts[key] = m.GetCounter().GetValue()
+	}
+
+	// invalid-status normalized to error
+	assert.Equal(t, float64(1), counts["Namespace/error"], "Invalid status should normalize to error")
+	// empty resourceType normalized to Unknown
+	assert.Equal(t, float64(1), counts["Unknown/success"], "Empty resourceType should normalize to Unknown")
+	// valid values unchanged
+	assert.Equal(t, float64(1), counts["ServiceAccount/success"], "Valid values should be preserved")
+}


### PR DESCRIPTION
## Summary                                                                                                                                                                                                       
                                                                                                                                                                                                                   
  - Added Prometheus metrics for resource deletion operations: counter (by status), duration histogram, and in-progress gauge                                                                                      
  - Integrated metrics recorder into executor builder pattern and resource deletion flow                                                                                                                           
  - Added `adapter_name` label to all adapter metrics per [HyperFleet adapter-metrics.md                                                                                                                           
  standard](https://github.com/openshift-hyperfleet/architecture/blob/main/hyperfleet/components/adapter/framework/adapter-metrics.md)                                                                             
                                                                                                                                                                                                                   
  ## Changes                                                                                                                                                                                                       
                  
  ### New Metrics

  All metrics include `component`, `version`, and `adapter_name` as ConstLabels:                                                                                                                                   
   
  - **`hyperfleet_adapter_resources_deleted_total`** (Counter)                                                                                                                                                     
    - Labels: `resource_type` (Kubernetes kind), `status` (`success`/`error`)
    - Tracks total deletion operations by resource kind and outcome                                                                                                                                                
                                                                                                                                                                                                                   
  - **`hyperfleet_adapter_resource_deletion_duration_seconds`** (Histogram)                                                                                                                                        
    - Labels: `resource_type`                                                                                                                                                                                      
    - Buckets: `0.1, 0.5, 1, 2, 5, 10, 30, 60, 120` seconds                                                                                                                                                        
    - Tracks deletion operation latency                                                                                                                                                                            
                                                                                                                                                                                                                   
  - **`hyperfleet_adapter_resource_deletions_in_progress`** (Gauge)                                                                                                                                                
    - Labels: `resource_type`                                                                                                                                                                                      
    - Tracks concurrent deletion operations
                                                                                                                                                                                                                   
  ### Implementation Details
                                                                                                                                                                                                                   
  - Metrics recorder passed through executor builder pattern (`WithMetricsRecorder`)
  - Deletion metrics recorded on all code paths (success, error, not-found)                                                                                                                                        
  - Resource type uses authoritative kind from discovered K8s resource when available, falls back to manifest-based GVK resolution                                                                                 
  - Added `ExtractAdapterName()` helper to derive short adapter names from component names                                                                                                                         
  - All metrics methods are nil-safe for dry-run mode compatibility                                                                                                                                                
                                                                                                                                                                                                                   
  ### Breaking Changes                                                                                                                                                                                             
                                                                                                                                                                                                                   
  - `metrics.NewRecorder()` signature changed: added `adapterName string` parameter
  - All existing call sites updated (main.go, tests)                                                                                                                                                               
                                                                                                                                                                                                                   
  ## Test Plan                                                                                                                                                                                                     
                                                                                                                                                                                                                   
  - [ ] Unit tests pass: `make test`
  - [ ] Integration tests pass: `make test-integration`                                                                                                                                                            
  - [ ] Metrics endpoint exposes new deletion metrics at `/metrics`
  - [ ] Deletion metrics increment correctly on resource deletion success                                                                                                                                          
  - [ ] Deletion metrics increment correctly on resource deletion error                                                                                                                                            
  - [ ] Duration histogram records timing for deletion operations                                                                                                                                                  
  - [ ] In-progress gauge increments/decrements correctly with defer pattern                                                                                                                                       
  - [ ] Resource type label uses correct Kubernetes kind from discovered resource                                                                                                                                  
  - [ ] Resource type falls back to "Unknown" when GVK resolution fails                                                                                                                                            
  - [ ] Nil recorder (dry-run mode) doesn't panic on any metric method call                                                                                                                                        
  - [ ] All metrics include `adapter_name` label with correct value                                                                                                                                                
                                                                                                                                                                                                                   
  ## Documentation                                                                                                                                                                                                 
                                                                                                                                                                                                                   
  - Updated `docs/metrics.md` with deletion metrics specification
  - Added metric descriptions, labels, and status value definitions                                                                                                                                                
  - Documented ConstLabels behavior and resource_type label semantics                                                                                                                                              
                                                                                                                                                                                                                   


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added resource-deletion metrics: per-resource-type deletion counts (success/error), in-progress gauges, and deletion-duration histograms; adapter name, component, and version are included as metric labels.

* **Documentation**
  * Documented deletion metrics, label semantics (resource_type, status, adapter_name) and shared histogram bucket configuration.

* **Tests**
  * Expanded tests to cover deletion metrics, label normalization, adapter-name extraction, and nil-safe metric behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->