### PR TITLE
HYPERFLEET-1040 - fix: Namespace-qualify ClusterRole names 

### DIFF
--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -275,6 +275,15 @@ Per Helm Chart Conventions Standard section 9 (Deprecation and Migration Pattern
 {{- end }}
 
 {{/*
+Name for cluster-scoped resources (ClusterRole, ClusterRoleBinding).
+Appends the release namespace to the fullname so that two installations in
+different namespaces never collide on the same cluster-scoped resource name.
+*/}}
+{{- define "hyperfleet-adapter.clusterScopedName" -}}
+{{- printf "%s-%s" (include "hyperfleet-adapter.fullname" .) .Release.Namespace | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
 Determine the broker type.
 Returns broker.type if explicitly set, otherwise infers from broker config objects.
 */}}

--- a/charts/templates/rbac.yaml
+++ b/charts/templates/rbac.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "hyperfleet-adapter.fullname" . }}
+  name: {{ include "hyperfleet-adapter.clusterScopedName" . }}
   labels:
     {{- include "hyperfleet-adapter.labels" . | nindent 4 }}
 rules:
@@ -19,13 +19,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "hyperfleet-adapter.fullname" . }}
+  name: {{ include "hyperfleet-adapter.clusterScopedName" . }}
   labels:
     {{- include "hyperfleet-adapter.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "hyperfleet-adapter.fullname" . }}
+  name: {{ include "hyperfleet-adapter.clusterScopedName" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "hyperfleet-adapter.serviceAccountName" . }}


### PR DESCRIPTION

ClusterRole and ClusterRoleBinding were named after the Helm release name (fullnameOverride), which is deterministic per adapter type. Two parallel e2e runs deploying the same adapter produced identical cluster-scoped resource names and conflicted.

Add a `hyperfleet-adapter.clusterScopedName` helper that appends the release namespace to the fullname, making cluster-scoped resource names unique per namespace while preserving upgrade-in-place semantics for single-run deployments.

This can be tested by deploying two e2e instances to the same cluster in different namespaces.
For that you need to run a command like this to provide a custom ADAPTER_CHART_REPO pointing to the branch

```
ADAPTER_CHART_REPO=https://github.com/rh-amarin/hyperfleet-adapter.git \
  ADAPTER_CHART_REF=HYPERFLEET-1040 \
SENTINEL_BROKER_RABBITMQ_URL="amqp://guest:guest@rabbitmq.rabbitmq:5672" \
  ADAPTER_BROKER_RABBITMQ_URL="amqp://guest:guest@rabbitmq.rabbitmq:5672" \
  ADAPTER_BROKER_TYPE=rabbitmq \
  SENTINEL_BROKER_TYPE=rabbitmq \
  ./deploy-scripts/deploy-clm.sh --action install \
  --namespace fix1 \
  --image-registry quay.io/amarin \
  --api-image-repo hyperfleet-api \
  --api-image-tag dev-79b8af6 \
  --sentinel-image-repo hyperfleet-sentinel \
  --sentinel-image-tag dev-56a2bdd \
  --adapter-image-repo hyperfleet-adapter \
  --adapter-image-tag dev-d61faa5 \
  --api-base-url http://hyperfleet-api:8000 \
  --api-adapters-cluster cl-namespace,cl-maestro,cl-deployment,cl-job \
  --api-adapters-nodepool np-configmap \
  --cluster-tier0-adapters cl-namespace,cl-maestro,cl-deployment,cl-job,cl-invalid-resource,cl-precondition-error \
  --nodepool-tier0-adapters np-configmap

``` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated naming scheme for cluster-scoped Kubernetes resources: names now include the release namespace, are truncated to meet length limits, and sanitized to avoid trailing separators. ClusterRole and ClusterRoleBinding names were updated to follow this scheme for consistent, valid cluster-scoped resource naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->