### PR TITLE
GCP-676 - feat: register ext.Strings() in CEL environment

### DIFF
--- a/internal/criteria/cel_evaluator.go
+++ b/internal/criteria/cel_evaluator.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/ext"
 	apperrors "github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/errors"
 )
 
@@ -67,6 +68,7 @@ func buildCELOptions(ctx *EvaluationContext) []cel.EnvOption {
 
 	// Enable optional types for optional chaining syntax (e.g., a.?b.?c)
 	options = append(options, cel.OptionalTypes())
+	options = append(options, ext.Strings())
 	options = append(options, customCELFunctions()...)
 
 	// Get a snapshot of the data for thread safety

--- a/internal/criteria/cel_evaluator_test.go
+++ b/internal/criteria/cel_evaluator_test.go
@@ -368,6 +368,26 @@ func TestCELEvaluatorCustomFunctions(t *testing.T) {
 	})
 }
 
+func TestCELEvaluatorExtStrings(t *testing.T) {
+	ctx := NewEvaluationContext()
+	ctx.Set("channelGroup", "candidate")
+	ctx.Set("version", "4.22.0-ec.4")
+
+	evaluator, err := newCELEvaluator(ctx)
+	require.NoError(t, err)
+
+	// The version resolution adapter derives the Cincinnati channel name from channelGroup
+	// and the major.minor portion of version using CEL split(). This mirrors the Go logic
+	// in deriveChannel(): channelGroup + "-" + major + "." + minor
+	// e.g. channelGroup="candidate", version="4.22.0-ec.4" → "candidate-4.22"
+	t.Run("split derives cincinnati channel name from channelGroup and version", func(t *testing.T) {
+		result, err := evaluator.EvaluateSafe(`channelGroup + "-" + version.split(".")[0] + "." + version.split(".")[1]`)
+		require.NoError(t, err)
+		require.False(t, result.HasError())
+		assert.Equal(t, "candidate-4.22", result.Value)
+	})
+}
+
 // TestEvaluateSafeErrorHandling tests how EvaluateSafe handles various error scenarios
 // and how callers can use the result to make decisions at a higher level
 func TestEvaluateSafeErrorHandling(t *testing.T) {


### PR DESCRIPTION
## Summary

Registers `ext.Strings()` in the CEL evaluator environment, enabling string extension functions (`split()`, `join()`, `trim()`, etc.) in precondition capture expressions and post-payload CEL expressions.

Jira: https://redhat.atlassian.net/browse/GCP-676

## Changes

- `internal/criteria/cel_evaluator.go`: add `ext.Strings()` to `buildCELOptions()`
- `internal/criteria/cel_evaluator_test.go`: test coverage verifying `split()` works in expressions

## Test plan

- [ ] Unit tests pass (`go test ./...`)
- [ ] Adapter task configs using `split()` (e.g. channel derivation `version.split(".")[0]`) evaluate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)