### PR TITLE
HYPERFLEET-876 - feat: add when condition to post-actions

### DIFF
--- a/charts/examples/maestro-two-resources/adapter-task-config.yaml
+++ b/charts/examples/maestro-two-resources/adapter-task-config.yaml
@@ -302,11 +302,13 @@ post:
       name: clusterStatusPayload
 
   post_actions:
-    - api_call:
+    - name: reportClusterStatus
+      when:
+        expression: "!adapter.resourcesSkipped"
+      api_call:
         body: '{{ .clusterStatusPayload }}'
         headers:
           - name: Content-Type
             value: application/json
         method: POST
         url: /clusters/{{ .clusterId }}/statuses
-      name: reportClusterStatus

--- a/charts/examples/maestro/adapter-task-config.yaml
+++ b/charts/examples/maestro/adapter-task-config.yaml
@@ -252,11 +252,13 @@ post:
         observed_time: '{{ now | date "2006-01-02T15:04:05Z07:00" }}'
       name: clusterStatusPayload
   post_actions:
-    - api_call:
+    - name: reportClusterStatus
+      when:
+        expression: "!adapter.resourcesSkipped"
+      api_call:
         body: '{{ .clusterStatusPayload }}'
         headers:
           - name: Content-Type
             value: application/json
         method: POST
         url: /clusters/{{ .clusterId }}/statuses
-      name: reportClusterStatus

--- a/configs/adapter-task-config-template.yaml
+++ b/configs/adapter-task-config-template.yaml
@@ -348,8 +348,12 @@ post:
   # ============================================================================
   # Post actions are executed after resources are created/updated
   post_actions:
-    # Report cluster status to HyperFleet API (always executed)
+    # Report cluster status to HyperFleet API.
+    # Skipped when the adapter did no work (preconditions not met / resources skipped)
+    # to avoid overwriting a previously reported status with stale data.
     - name: "reportClusterStatus"
+      when:
+        expression: "!adapter.resourcesSkipped"
       api_call:
         method: "POST"
         # NOTE: API path includes /api/hyperfleet/ prefix and ends with /statuses

--- a/internal/configloader/types.go
+++ b/internal/configloader/types.go
@@ -393,8 +393,22 @@ type PostConfig struct {
 }
 
 // PostAction represents a post-processing action
+//
+//nolint:govet // fieldalignment: padding is insignificant for a config struct loaded once at startup; keeping ActionBase first maintains consistency with Precondition
 type PostAction struct {
 	ActionBase `yaml:",inline"`
+	// When defines a CEL expression that gates execution of this post-action.
+	// If the expression evaluates to false, the action is skipped (not failed).
+	// Follows the same nested pattern as lifecycle.delete.when for consistency.
+	When *PostActionWhen `yaml:"when,omitempty"`
+}
+
+// PostActionWhen defines the condition for when a post-action should execute.
+type PostActionWhen struct {
+	// Expression is a CEL expression evaluated against the execution context.
+	// The post-action executes only when the expression evaluates to true.
+	// Available variables: adapter.resourcesSkipped, adapter.skipReason, params, resources.
+	Expression string `yaml:"expression" validate:"required"`
 }
 
 // LogAction represents a logging action that can be configured in the adapter config

--- a/internal/configloader/types.go
+++ b/internal/configloader/types.go
@@ -392,9 +392,11 @@ type PostConfig struct {
 	PostActions []PostAction `yaml:"post_actions,omitempty" validate:"dive"`
 }
 
-// PostAction represents a post-processing action
+// PostAction represents a post-processing action.
+// Note: field order is intentional — ActionBase is kept first for consistency with Precondition.
+// Padding from fieldalignment is insignificant for a config struct loaded once at startup.
 //
-//nolint:govet // fieldalignment: padding is insignificant for a config struct loaded once at startup; keeping ActionBase first maintains consistency with Precondition
+//nolint:govet // fieldalignment: see doc comment above
 type PostAction struct {
 	ActionBase `yaml:",inline"`
 	// When defines a CEL expression that gates execution of this post-action.

--- a/internal/executor/post_action_executor.go
+++ b/internal/executor/post_action_executor.go
@@ -77,7 +77,11 @@ func (pae *PostActionExecutor) ExecuteAll(
 			// Stop execution - don't run remaining post actions
 			return results, err
 		}
-		pae.log.Infof(ctx, "PostAction[%s] processed: SUCCESS - status=%s", action.Name, result.Status)
+		if result.Skipped {
+			pae.log.Infof(ctx, "PostAction[%s] processed: SKIPPED - reason=%s", action.Name, result.SkipReason)
+		} else {
+			pae.log.Infof(ctx, "PostAction[%s] processed: SUCCESS - status=%s", action.Name, result.Status)
+		}
 	}
 
 	return results, nil
@@ -240,6 +244,30 @@ func (pae *PostActionExecutor) executePostAction(
 	result := PostActionResult{
 		Name:   action.Name,
 		Status: StatusSuccess,
+	}
+
+	// Evaluate when condition if configured
+	if action.When != nil {
+		evalCtx := criteria.NewEvaluationContext()
+		evalCtx.SetVariablesFromMap(execCtx.GetCELVariables())
+		evaluator, err := criteria.NewEvaluator(ctx, evalCtx, pae.log)
+		if err != nil {
+			return result, NewExecutorError(PhasePostActions, action.Name, "failed to create evaluator for when condition", err)
+		}
+		celResult, err := evaluator.EvaluateCEL(action.When.Expression)
+		if err != nil {
+			return result, NewExecutorError(PhasePostActions, action.Name, "failed to evaluate when condition", err)
+		}
+		if celResult.HasError() {
+			return result, NewExecutorError(PhasePostActions, action.Name, "failed to evaluate when condition", celResult.Error)
+		}
+		if !celResult.Matched {
+			result.Skipped = true
+			result.Status = StatusSkipped
+			result.SkipReason = fmt.Sprintf("when condition evaluated to false: %s", action.When.Expression)
+			pae.log.Infof(ctx, "PostAction[%s] skipped: when condition is false", action.Name)
+			return result, nil
+		}
 	}
 
 	// Execute log action if configured

--- a/internal/executor/post_action_executor.go
+++ b/internal/executor/post_action_executor.go
@@ -252,14 +252,23 @@ func (pae *PostActionExecutor) executePostAction(
 		evalCtx.SetVariablesFromMap(execCtx.GetCELVariables())
 		evaluator, err := criteria.NewEvaluator(ctx, evalCtx, pae.log)
 		if err != nil {
-			return result, NewExecutorError(PhasePostActions, action.Name, "failed to create evaluator for when condition", err)
+			execErr := NewExecutorError(PhasePostActions, action.Name, "failed to create evaluator for when condition", err)
+			result.Status = StatusFailed
+			result.Error = execErr
+			return result, execErr
 		}
 		celResult, err := evaluator.EvaluateCEL(action.When.Expression)
 		if err != nil {
-			return result, NewExecutorError(PhasePostActions, action.Name, "failed to evaluate when condition", err)
+			execErr := NewExecutorError(PhasePostActions, action.Name, "failed to evaluate when condition", err)
+			result.Status = StatusFailed
+			result.Error = execErr
+			return result, execErr
 		}
 		if celResult.HasError() {
-			return result, NewExecutorError(PhasePostActions, action.Name, "failed to evaluate when condition", celResult.Error)
+			execErr := NewExecutorError(PhasePostActions, action.Name, "failed to evaluate when condition", celResult.Error)
+			result.Status = StatusFailed
+			result.Error = execErr
+			return result, execErr
 		}
 		if !celResult.Matched {
 			result.Skipped = true

--- a/internal/executor/post_action_executor_test.go
+++ b/internal/executor/post_action_executor_test.go
@@ -661,6 +661,90 @@ func TestExecuteAPICall(t *testing.T) {
 	}
 }
 
+func TestPostActionWhenCondition(t *testing.T) {
+	tests := []struct {
+		name             string
+		when             *configloader.PostActionWhen
+		wantAPICall      bool
+		wantSkipped      bool
+		wantErr          bool
+		resourcesSkipped bool
+	}{
+		{
+			name:        "no when condition — action always executes",
+			when:        nil,
+			wantAPICall: true,
+		},
+		{
+			name:        "when expression true — action executes",
+			when:        &configloader.PostActionWhen{Expression: "!adapter.resourcesSkipped"},
+			wantAPICall: true,
+		},
+		{
+			name:             "when expression false — action skipped",
+			when:             &configloader.PostActionWhen{Expression: "!adapter.resourcesSkipped"},
+			resourcesSkipped: true,
+			wantAPICall:      false,
+			wantSkipped:      true,
+		},
+		{
+			name:        "when expression literal false — action skipped",
+			when:        &configloader.PostActionWhen{Expression: "false"},
+			wantAPICall: false,
+			wantSkipped: true,
+		},
+		{
+			name:    "when expression parse error — returns error",
+			when:    &configloader.PostActionWhen{Expression: "=== invalid ==="},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := hyperfleetapi.NewMockClient()
+			mockClient.DoResponse = &hyperfleetapi.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Body:       []byte(`{}`),
+			}
+
+			pae := newPostActionExecutor(&ExecutorConfig{
+				APIClient: mockClient,
+				Logger:    logger.NewTestLogger(),
+			})
+
+			action := configloader.PostAction{
+				ActionBase: configloader.ActionBase{
+					Name: "testAction",
+					APICall: &configloader.APICall{
+						Method: "POST",
+						URL:    "http://api.example.com/statuses",
+					},
+				},
+				When: tt.when,
+			}
+
+			execCtx := NewExecutionContext(context.Background(), map[string]interface{}{}, nil)
+			execCtx.Adapter.ResourcesSkipped = tt.resourcesSkipped
+
+			result, err := pae.executePostAction(context.Background(), action, execCtx)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantAPICall, result.APICallMade)
+			assert.Equal(t, tt.wantSkipped, result.Skipped)
+			if tt.wantSkipped {
+				assert.Equal(t, StatusSkipped, result.Status)
+			}
+		})
+	}
+}
+
 func TestBuildPostPayloads_WithResourceDiscoveryCELHelpers(t *testing.T) {
 	pae := testPAE()
 	execCtx := NewExecutionContext(context.Background(), map[string]interface{}{}, nil)

--- a/internal/executor/post_action_executor_test.go
+++ b/internal/executor/post_action_executor_test.go
@@ -663,8 +663,8 @@ func TestExecuteAPICall(t *testing.T) {
 
 func TestPostActionWhenCondition(t *testing.T) {
 	tests := []struct {
-		name             string
 		when             *configloader.PostActionWhen
+		name             string
 		wantAPICall      bool
 		wantSkipped      bool
 		wantErr          bool

--- a/internal/executor/types.go
+++ b/internal/executor/types.go
@@ -36,6 +36,8 @@ const (
 	StatusSuccess ExecutionStatus = "success"
 	// StatusFailed indicates failed execution (process execution error: API timeout, parse error, K8s error, etc.)
 	StatusFailed ExecutionStatus = "failed"
+	// StatusSkipped indicates the action was intentionally skipped (e.g. when condition evaluated to false)
+	StatusSkipped ExecutionStatus = "skipped"
 )
 
 // ResourceRef represents a reference to a HyperFleet resource


### PR DESCRIPTION
## Summary

Extends the adapter framework to support a `when` condition on post-actions. If the `when` expression evaluates to `false`, the post-action is skipped. This allows adapters to conditionally skip status reporting or other post-actions based on execution state (e.g. skip reporting when resources were skipped).

Jira: https://redhat.atlassian.net/browse/HYPERFLEET-876

## Changes

- `internal/configloader/types.go`: add `When` field to `PostActionConfig`
- `internal/executor/post_action_executor.go`: evaluate `when` CEL expression before executing; skip if false
- `internal/executor/post_action_executor_test.go`: test coverage for when-gated post-actions (skip/execute branches)

## Test plan

- [ ] Unit tests pass (`go test ./...`)
- [ ] Post-action with `when: expression: "!adapter.resourcesSkipped"` skips correctly when resources are skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)