### PR TITLE
HYPERFLEET-978 - chore: update mock server to use http.MethodPut

### DIFF
--- a/test/integration/testutil/mock_api_server.go
+++ b/test/integration/testutil/mock_api_server.go
@@ -35,7 +35,7 @@ type MockAPIServer struct {
 	statusResponses  []map[string]interface{}
 	mu               sync.Mutex
 	failPrecondition bool
-	failPostAction   bool // If true, POST to /status endpoint returns 500
+	failPostAction   bool // If true, post action api call returns 500
 }
 
 // NewMockAPIServer creates a new MockAPIServer for testing.
@@ -45,7 +45,7 @@ type MockAPIServer struct {
 //
 // The server simulates common HyperFleet API endpoints:
 //   - GET /clusters/{id} - Returns cluster details
-//   - POST /clusters/{id}/status - Accepts status updates
+//   - PUT /clusters/{id}/statuses - Accepts status updates
 //   - GET /validation/availability - Returns availability status
 func NewMockAPIServer(t *testing.T) *MockAPIServer {
 	mock := &MockAPIServer{
@@ -102,9 +102,9 @@ func NewMockAPIServer(t *testing.T) *MockAPIServer {
 		// Route handling
 		switch {
 		case strings.Contains(r.URL.Path, "/clusters/") && strings.HasSuffix(r.URL.Path, "/statuses"):
-			// POST /clusters/{id}/statuses - Store status and return success (or fail if configured)
-			if r.Method == http.MethodPost {
-				// Check if we should fail the post action
+			// PUT /clusters/{id}/statuses - Store status and return success (or fail if configured)
+			if r.Method == http.MethodPut {
+				// Check if fail post action is set to true
 				if mock.failPostAction {
 					w.WriteHeader(http.StatusInternalServerError)
 					if encodeErr := json.NewEncoder(w).Encode(map[string]string{


### PR DESCRIPTION
  ## Summary

  This change updates the mock API server test utility to use PUT instead of POST
  for the cluster status endpoint, following the API change made in PR #113.

  **Changes made:**
  - Updated `mock_api_server.go` to check for `http.MethodPut` instead of
  `http.MethodPost` for status updates
  - This was a missed instance when the adapter was updated to use PUT for status
  endpoints

  **Related changes:**
  - Follows up on #113 - HYPERFLEET-978: Update adapter configs, docs, and tests to
   use PUT

  ## Test Plan

  - [x] Unit tests added/updated
  - [x] `make test-all` passes
  - [x] `make lint` passes
  - [x] Integration tests pass with updated mock server

  ## Jira Issue

  - [HYPERFLEET-978](https://redhat.atlassian.net/browse/HYPERFLEET-978)



[HYPERFLEET-978]: https://redhat.atlassian.net/browse/HYPERFLEET-978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ