### PR TITLE
HYPERFLEET-1094 - ci: add /licenses to container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -39,8 +39,7 @@ chart/
 charts/
 deployments/
 
-# License and owners
-LICENSE
+# Owners
 OWNERS
 CONTRIBUTING.md
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ WORKDIR /app
 # ubi9-micro doesn't include CA certificates; copy from builder for TLS (e.g. Google Pub/Sub)
 COPY --from=builder /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 COPY --from=builder /build/bin/hyperfleet-adapter /app/adapter
+COPY --from=builder /build/LICENSE /licenses/LICENSE
 
 USER 65532:65532
 


### PR DESCRIPTION
## Summary
- Copies LICENSE into `/licenses/` in the container image for Konflux preflight `HasLicense` certification check

## Test plan
- [ ] Konflux preflight `HasLicense` check passes
- [ ] No regression in other preflight checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)