### PR TITLE
HYPERFLEET-1095 - chore: add renovate.json to fix broken MintMaker PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "schedule": ["every monday"],
+  "packageRules": [
+    {
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["digest"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "go module minor/patch updates"
+    },
+    {
+      "matchManagers": ["dockerfile"],
+      "groupName": "docker image updates"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `renovate.json` to disable broken Go module digest updates (known Renovate bug that writes invalid pseudo-versions to `go.mod`)
- Disables indirect Go dependency updates (they float naturally via `go mod tidy`)
- Groups Go minor/patch updates into a single PR instead of one per dependency
- Groups Docker image updates into a single PR
- Schedules all updates to run weekly on Mondays

## Context

MintMaker (Konflux Renovate) is running with defaults, producing many individual PRs including broken digest updates. This config reduces noise to ~2-3 grouped PRs per week.

See [HYPERFLEET-1095](https://redhat.atlassian.net/browse/HYPERFLEET-1095) for full details.

## Test plan
- [ ] Verify MintMaker picks up the new config on next run
- [ ] Confirm grouped PRs appear on the next Monday cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[HYPERFLEET-1095]: https://redhat.atlassian.net/browse/HYPERFLEET-1095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ