### PR TITLE
HYPERFLEET-1097 - fix: update vendor label to "Red Hat, Inc."

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ CMD ["serve"]
 
 ARG APP_VERSION="0.0.0-dev"
 LABEL name="hyperfleet-adapter" \
-      vendor="Red Hat" \
+      vendor="Red Hat, Inc." \
       version="${APP_VERSION}" \
       summary="HyperFleet Adapter - Event-driven adapter services for HyperFleet cluster provisioning" \
       description="Handles CloudEvents consumption, AdapterConfig CRD integration, precondition evaluation, Kubernetes Job creation/monitoring, and status reporting via API"

--- a/test/Dockerfile.integration
+++ b/test/Dockerfile.integration
@@ -48,7 +48,7 @@ EXPOSE 6443
 
 # Label the image
 LABEL name="hyperfleet-integration-test" \
-      vendor="Red Hat" \
+      vendor="Red Hat, Inc." \
       summary="Integration test image with Kubernetes envtest binaries" \
       description="Pre-built envtest environment for HyperFleet adapter integration tests" \
       kubernetes.version="1.30.x"


### PR DESCRIPTION
## Summary
- Fix Dockerfile vendor label from `"Red Hat"` to `"Red Hat, Inc."` for Enterprise Contract `labels.required_labels` compliance

## Test plan
- [ ] EC `labels.required_labels` check passes on next release pipeline run

🤖 Generated with [Claude Code](https://claude.com/claude-code)