### PR TITLE
HYPERFLEET-1036 - fix: use APP_VERSION build-arg in tag pipeline

### DIFF
--- a/.tekton/hyperfleet-adapter-push.yaml
+++ b/.tekton/hyperfleet-adapter-push.yaml
@@ -207,6 +207,7 @@ spec:
       - name: BUILD_ARGS
         value:
         - $(params.build-args[*])
+        - APP_VERSION=dev
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
       - name: PRIVILEGED_NESTED

--- a/.tekton/hyperfleet-adapter-tag.yaml
+++ b/.tekton/hyperfleet-adapter-tag.yaml
@@ -237,7 +237,7 @@ spec:
       - name: BUILD_ARGS
         value:
         - $(params.build-args[*])
-        - VERSION=$(tasks.extract-version.results.VERSION)
+        - APP_VERSION=$(tasks.extract-version.results.VERSION)
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
       - name: PRIVILEGED_NESTED


### PR DESCRIPTION
## Summary
- Fix tag pipeline to pass `APP_VERSION` instead of `VERSION` as the build-arg
- `VERSION` is silently ignored because the Dockerfile uses `ARG APP_VERSION`
- Without this fix, tag builds produce `version=0.0.0-dev` instead of the actual tag version

## Test plan
- [ ] After merge: push test tag `v0.0.1-rc1`, confirm image has `version=0.0.1-rc1` label
- [ ] Nightly builds unaffected (no build-arg, uses Dockerfile default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)