### PR TITLE
HYPERFLEET-978 - docs: Update docs to reflect missed PUT endpoints

### DIFF
--- a/charts/examples/kubernetes/adapter-task-config.yaml
+++ b/charts/examples/kubernetes/adapter-task-config.yaml
@@ -163,7 +163,7 @@ post:
   post_actions:
     - name: "reportClusterStatus"
       api_call:
-        method: "POST"
+        method: "PUT"
         url: "/clusters/{{ .clusterId }}/statuses"
         headers:
           - name: "Content-Type"

--- a/charts/examples/maestro/adapter-task-config.yaml
+++ b/charts/examples/maestro/adapter-task-config.yaml
@@ -260,5 +260,5 @@ post:
         headers:
           - name: Content-Type
             value: application/json
-        method: POST
+        method: PUT
         url: /clusters/{{ .clusterId }}/statuses

--- a/docs/adapter-authoring-guide.md
+++ b/docs/adapter-authoring-guide.md
@@ -1099,7 +1099,7 @@ post:
   post_actions:
     - name: "reportStatus"
       api_call:
-        method: "POST"
+        method: "PUT"
         url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}/statuses"
         body: "{{ .statusPayload }}"
 ```

--- a/test/integration/config-loader/testdata/adapter-config-template.yaml
+++ b/test/integration/config-loader/testdata/adapter-config-template.yaml
@@ -376,6 +376,6 @@ post:
     # Report cluster status to HyperFleet API (always executed)
     - name: "reportClusterStatus"
       api_call:
-        method: "POST"
+        method: "PUT"
         url: "/clusters/{{ .clusterId }}/statuses"
         body: "{{ .clusterStatusPayload }}"


### PR DESCRIPTION
## Summary

Found these missing changes last minute. Updates documentation and example configurations to correctly specify `PUT` method for cluster status reporting endpoints. The API spec uses PUT for idempotent status updates, but examples and documentation incorrectly showed POST. This aligns all example configs and the adapter authoring guide with the actual API implementation.

## Changes

- Updated `charts/examples/kubernetes/adapter-task-config.yaml` to use `PUT` for `/clusters/{id}/statuses` endpoint
- Updated `charts/examples/maestro/adapter-task-config.yaml` to use `PUT` for `/clusters/{id}/statuses` endpoint
- Updated `docs/adapter-authoring-guide.md` example to show `PUT` method in the reportStatus action
- Updated `test/integration/config-loader/testdata/adapter-config-template.yaml` to use `PUT` for cluster status reporting

## Test Plan

- [ ] `make test-all` passes
- [ ] `make lint` passes
- [ ] Verified examples match current API spec

## Jira Issue

[HYPERFLEET-978](https://redhat.atlassian.net/browse/HYPERFLEET-978)

[HYPERFLEET-978]: https://redhat.atlassian.net/browse/HYPERFLEET-978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ