### PR TITLE
HYPERFLEET-978 - docs: Update docs again to reflect missed PUT endpoints

### DIFF
--- a/charts/examples/maestro-two-resources/adapter-task-config.yaml
+++ b/charts/examples/maestro-two-resources/adapter-task-config.yaml
@@ -310,5 +310,5 @@ post:
         headers:
           - name: Content-Type
             value: application/json
-        method: POST
+        method: PUT
         url: /clusters/{{ .clusterId }}/statuses

--- a/internal/dryrun/dryrun_api_client_test.go
+++ b/internal/dryrun/dryrun_api_client_test.go
@@ -176,6 +176,7 @@ func TestDo_WildcardMethod(t *testing.T) {
 		{"POST matches wildcard", "POST"},
 		{"DELETE matches wildcard", "DELETE"},
 		{"PATCH matches wildcard", "PATCH"},
+		{"PUT matches wildcard", "PUT"},
 	}
 
 	for _, tc := range tests {

--- a/test/testdata/dryrun/cel-showcase/dryrun-cel-showcase-api-responses.json
+++ b/test/testdata/dryrun/cel-showcase/dryrun-cel-showcase-api-responses.json
@@ -75,7 +75,7 @@
     },
     {
       "match": {
-        "method": "PATCH",
+        "method": "PUT",
         "urlPattern": "/api/hyperfleet/v1/clusters/.*/statuses"
       },
       "responses": [

--- a/test/testdata/dryrun/cel-showcase/dryrun-cel-showcase-task-config.yaml
+++ b/test/testdata/dryrun/cel-showcase/dryrun-cel-showcase-task-config.yaml
@@ -363,6 +363,6 @@ post:
   post_actions:
     - name: "updateStatus"
       api_call:
-        method: "PATCH"
+        method: "PUT"
         url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}/statuses"
         body: "{{ .statusPayload }}"

--- a/test/testdata/dryrun/dryrun-api-responses.json
+++ b/test/testdata/dryrun/dryrun-api-responses.json
@@ -38,8 +38,8 @@
     },
     {
       "match": {
-        "method": "PATCH",
-        "urlPattern": "/api/hyperfleet/v1/clusters/.*/status"
+        "method": "PUT",
+        "urlPattern": "/api/hyperfleet/v1/clusters/.*/statuses"
       },
       "responses": [
         {

--- a/test/testdata/dryrun/dryrun-delete-api-responses.json
+++ b/test/testdata/dryrun/dryrun-delete-api-responses.json
@@ -35,7 +35,7 @@
     },
     {
       "match": {
-        "method": "POST",
+        "method": "PUT",
         "urlPattern": "/api/hyperfleet/v1/clusters/.*/statuses"
       },
       "responses": [

--- a/test/testdata/dryrun/kubernetes-delete/dryrun-kubernetes-delete-task-config.yaml
+++ b/test/testdata/dryrun/kubernetes-delete/dryrun-kubernetes-delete-task-config.yaml
@@ -185,6 +185,6 @@ post:
   post_actions:
     - name: updateStatus
       api_call:
-        method: POST
+        method: PUT
         url: /api/hyperfleet/v1/clusters/{{ .clusterId }}/statuses
         body: "{{ .statusPayload }}"

--- a/test/testdata/dryrun/kubernetes/dryrun-kubernetes-task-config.yaml
+++ b/test/testdata/dryrun/kubernetes/dryrun-kubernetes-task-config.yaml
@@ -205,6 +205,6 @@ post:
   post_actions:
     - name: "updateStatus"
       api_call:
-        method: "PATCH"
+        method: "PUT"
         url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}/statuses"
         body: "{{ .statusPayload }}"

--- a/test/testdata/dryrun/maestro-delete/dryrun-maestro-delete-task-config.yaml
+++ b/test/testdata/dryrun/maestro-delete/dryrun-maestro-delete-task-config.yaml
@@ -192,6 +192,6 @@ post:
   post_actions:
     - name: updateStatus
       api_call:
-        method: POST
+        method: PUT
         url: /api/hyperfleet/v1/clusters/{{ .clusterId }}/statuses
         body: "{{ .statusPayload }}"

--- a/test/testdata/dryrun/maestro/dryrun-maestro-adapter-task-config.yaml
+++ b/test/testdata/dryrun/maestro/dryrun-maestro-adapter-task-config.yaml
@@ -311,6 +311,6 @@ post:
   post_actions:
     - api_call:
         body: '{{ .statusPayload }}'
-        method: POST
+        method: PUT
         url: /api/hyperfleet/v1/clusters/{{ .clusterId }}/statuses
       name: updateStatus

--- a/test/testdata/task-config.yaml
+++ b/test/testdata/task-config.yaml
@@ -111,6 +111,6 @@ post:
   post_actions:
     - api_call:
         body: '{{ .clusterStatusPayload }}'
-        method: POST
+        method: PUT
         url: /clusters/{{ .clusterId }}/statuses
       name: updateStatus


### PR DESCRIPTION
## Summary

Updates all adapter task configurations and test fixtures to use PUT instead of POST/PATCH for the cluster status update endpoint. The API spec was previously updated to use PUT for idempotent status updates, but several adapter config examples and test data files were missed in that change. This ensures all examples and tests align with the current API specification.

[HYPERFLEET-978](https://redhat.atlassian.net/browse/HYPERFLEET-978)

## Changes

- Updated adapter task config example in `charts/examples/maestro-two-resources/` to use PUT for `/clusters/{id}/statuses` endpoint
- Changed all dryrun test configs to use PUT instead of POST/PATCH for status update calls across 6 test scenarios (CEL showcase, Kubernetes, Maestro, delete flows)
- Added PUT method test case to wildcard method match test in `dryrun_api_client_test.go`
- Updated dryrun mock API responses to expect PUT requests for status endpoints instead of POST

## Test Plan

- [x] Unit tests added/updated
- [x] `make test-all` passes
- [x] `make lint` passes


[HYPERFLEET-978]: https://redhat.atlassian.net/browse/HYPERFLEET-978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ