### PR TITLE
HYPERFLEET-1104 - feat: adapt chart to expose rabbitmq

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,11 +107,14 @@ test-helm: ## Test Helm charts (lint, template, validate)
 		--set image.repository=openshift-hyperfleet/hyperfleet-adapter \
 		--set image.tag=test \
 		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
-		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" > /dev/null
+		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
+		--set broker.type=googlepubsub \
+		--set broker.googlepubsub.subscriptionId=test-sub \
+		--set broker.googlepubsub.topic=test-topic > /dev/null
 	@echo "Minimal required values template OK"
 	@echo ""
 	@echo "Testing template with broker enabled..."
-	helm template test-release charts/ \
+	@output=$$(helm template test-release charts/ \
 		--set image.registry=quay.io \
 		--set image.repository=openshift-hyperfleet/hyperfleet-adapter \
 		--set image.tag=test \
@@ -120,7 +123,9 @@ test-helm: ## Test Helm charts (lint, template, validate)
 		--set broker.create=true \
 		--set broker.googlepubsub.subscriptionId=test-sub \
 		--set broker.googlepubsub.topic=test-topic \
-		--set broker.type=googlepubsub > /dev/null
+		--set broker.type=googlepubsub) \
+		&& echo "$$output" | grep -q 'type: googlepubsub' \
+		|| { echo "ERROR: expected googlepubsub broker type in rendered output"; exit 1; }
 	@echo "Broker config template OK"
 	@echo ""
 	@echo "Testing template with HyperFleet API config..."
@@ -130,6 +135,9 @@ test-helm: ## Test Helm charts (lint, template, validate)
 		--set image.tag=test \
 		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
+		--set broker.type=googlepubsub \
+		--set broker.googlepubsub.subscriptionId=test-sub \
+		--set broker.googlepubsub.topic=test-topic \
 		--set adapterConfig.hyperfleetApi.baseUrl=http://localhost:8000 \
 		--set adapterConfig.hyperfleetApi.version=v1 > /dev/null
 	@echo "HyperFleet API config template OK"
@@ -141,6 +149,9 @@ test-helm: ## Test Helm charts (lint, template, validate)
 		--set image.tag=test \
 		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
+		--set broker.type=googlepubsub \
+		--set broker.googlepubsub.subscriptionId=test-sub \
+		--set broker.googlepubsub.topic=test-topic \
 		--set podDisruptionBudget.enabled=true \
 		--set podDisruptionBudget.minAvailable=1 \
 		--set podDisruptionBudget.maxUnavailable=null > /dev/null
@@ -153,6 +164,9 @@ test-helm: ## Test Helm charts (lint, template, validate)
 		--set image.tag=test \
 		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
+		--set broker.type=googlepubsub \
+		--set broker.googlepubsub.subscriptionId=test-sub \
+		--set broker.googlepubsub.topic=test-topic \
 		--set autoscaling.enabled=true \
 		--set autoscaling.minReplicas=2 \
 		--set autoscaling.maxReplicas=5 > /dev/null
@@ -165,6 +179,9 @@ test-helm: ## Test Helm charts (lint, template, validate)
 		--set image.tag=test \
 		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
+		--set broker.type=googlepubsub \
+		--set broker.googlepubsub.subscriptionId=test-sub \
+		--set broker.googlepubsub.topic=test-topic \
 		--set livenessProbe.enabled=true \
 		--set readinessProbe.enabled=true \
 		--set startupProbe.enabled=true > /dev/null
@@ -177,6 +194,9 @@ test-helm: ## Test Helm charts (lint, template, validate)
 		--set image.tag=test \
 		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
+		--set broker.type=googlepubsub \
+		--set broker.googlepubsub.subscriptionId=test-sub \
+		--set broker.googlepubsub.topic=test-topic \
 		--set serviceMonitor.enabled=true \
 		--api-versions monitoring.coreos.com/v1/ServiceMonitor | grep -q 'kind: ServiceMonitor' \
 		|| { echo "ERROR: ServiceMonitor not rendered"; exit 1; }
@@ -189,6 +209,9 @@ test-helm: ## Test Helm charts (lint, template, validate)
 		--set image.tag=test \
 		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
+		--set broker.type=googlepubsub \
+		--set broker.googlepubsub.subscriptionId=test-sub \
+		--set broker.googlepubsub.topic=test-topic \
 		--set serviceMonitor.enabled=true) \
 		&& ! echo "$$output" | grep -q 'kind: ServiceMonitor' \
 		|| { echo "ERROR: ServiceMonitor rendered without CRD"; exit 1; }
@@ -201,11 +224,96 @@ test-helm: ## Test Helm charts (lint, template, validate)
 		--set image.tag=test \
 		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
+		--set broker.type=googlepubsub \
+		--set broker.googlepubsub.subscriptionId=test-sub \
+		--set broker.googlepubsub.topic=test-topic \
 		--set serviceMonitor.enabled=false \
 		--api-versions monitoring.coreos.com/v1/ServiceMonitor) \
 		&& ! echo "$$output" | grep -q 'kind: ServiceMonitor' \
 		|| { echo "ERROR: ServiceMonitor rendered while disabled"; exit 1; }
 	@echo "ServiceMonitor disabled template OK"
+	@echo ""
+	@echo "Testing template with RabbitMQ broker..."
+	@output=$$(helm template test-release charts/ \
+		--set image.registry=quay.io \
+		--set image.repository=openshift-hyperfleet/hyperfleet-adapter \
+		--set image.tag=test \
+		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
+		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
+		--set broker.create=true \
+		--set broker.type=rabbitmq \
+		--set broker.rabbitmq.url=amqp://guest:guest@rabbitmq:5672/ \
+		--set broker.rabbitmq.queue=test-queue \
+		--set broker.rabbitmq.exchange=test-exchange \
+		--set broker.rabbitmq.routingKey=test-key) \
+		&& echo "$$output" | grep -q 'type: rabbitmq' \
+		|| { echo "ERROR: expected rabbitmq broker type in rendered output"; exit 1; }
+	@echo "RabbitMQ broker template OK"
+	@echo ""
+	@echo "Testing that rabbitmq broker.type with both sections set selects rabbitmq..."
+	@output=$$(helm template test-release charts/ \
+		--set image.registry=quay.io \
+		--set image.repository=openshift-hyperfleet/hyperfleet-adapter \
+		--set image.tag=test \
+		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
+		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
+		--set broker.create=true \
+		--set broker.type=rabbitmq \
+		--set broker.rabbitmq.url=amqp://guest:guest@rabbitmq:5672/ \
+		--set broker.rabbitmq.queue=test-queue \
+		--set broker.rabbitmq.exchange=test-exchange \
+		--set broker.rabbitmq.routingKey=test-key \
+		--set broker.googlepubsub.projectId=my-project \
+		--set broker.googlepubsub.topic=my-topic \
+		--set broker.googlepubsub.subscriptionId=my-sub) \
+		&& echo "$$output" | grep -q 'type: rabbitmq' \
+		|| { echo "ERROR: expected rabbitmq broker type in output"; exit 1; }
+	@echo "RabbitMQ broker type selection OK"
+	@echo ""
+	@echo "Testing that rabbitmq without queue fails validation..."
+	@if helm template test-release charts/ \
+		--set image.registry=quay.io \
+		--set image.repository=openshift-hyperfleet/hyperfleet-adapter \
+		--set image.tag=test \
+		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
+		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
+		--set broker.create=true \
+		--set broker.type=rabbitmq \
+		--set broker.rabbitmq.url=amqp://guest:guest@rabbitmq:5672/ > /dev/null 2>&1; then \
+		echo "ERROR: expected helm template to fail when broker.rabbitmq.queue is missing"; exit 1; \
+	fi
+	@echo "RabbitMQ missing queue validation OK"
+	@echo ""
+	@echo "Testing that rabbitmq without exchange fails validation..."
+	@if helm template test-release charts/ \
+		--set image.registry=quay.io \
+		--set image.repository=openshift-hyperfleet/hyperfleet-adapter \
+		--set image.tag=test \
+		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
+		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
+		--set broker.create=true \
+		--set broker.type=rabbitmq \
+		--set broker.rabbitmq.url=amqp://guest:guest@rabbitmq:5672/ \
+		--set broker.rabbitmq.queue=test-queue > /dev/null 2>&1; then \
+		echo "ERROR: expected helm template to fail when broker.rabbitmq.exchange is missing"; exit 1; \
+	fi
+	@echo "RabbitMQ missing exchange validation OK"
+	@echo ""
+	@echo "Testing that rabbitmq without routingKey fails validation..."
+	@if helm template test-release charts/ \
+		--set image.registry=quay.io \
+		--set image.repository=openshift-hyperfleet/hyperfleet-adapter \
+		--set image.tag=test \
+		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
+		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
+		--set broker.create=true \
+		--set broker.type=rabbitmq \
+		--set broker.rabbitmq.url=amqp://guest:guest@rabbitmq:5672/ \
+		--set broker.rabbitmq.queue=test-queue \
+		--set broker.rabbitmq.exchange=test-exchange > /dev/null 2>&1; then \
+		echo "ERROR: expected helm template to fail when broker.rabbitmq.routingKey is missing"; exit 1; \
+	fi
+	@echo "RabbitMQ missing routingKey validation OK"
 
 ##@ Code Quality
 

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -285,14 +285,29 @@ different namespaces never collide on the same cluster-scoped resource name.
 
 {{/*
 Determine the broker type.
-Returns broker.type if explicitly set, otherwise infers from broker config objects.
+broker.type must be set explicitly — inference from sub-keys is not supported.
 */}}
 {{- define "hyperfleet-adapter.brokerType" -}}
-{{- if .Values.broker.type -}}
-{{- .Values.broker.type -}}
-{{- else if .Values.broker.googlepubsub -}}
-googlepubsub
-{{- else if .Values.broker.rabbitmq -}}
-rabbitmq
+{{- required "broker.type must be set to one of: googlepubsub, rabbitmq" .Values.broker.type -}}
+{{- end }}
+
+{{/*
+Validate that required fields are set for the resolved broker type.
+*/}}
+{{- define "hyperfleet-adapter.validateBrokerConfig" -}}
+{{- $brokerType := include "hyperfleet-adapter.brokerType" . -}}
+{{- if eq $brokerType "rabbitmq" -}}
+  {{- if not .Values.broker.rabbitmq.url -}}
+    {{- fail "broker.rabbitmq.url is required when broker type is rabbitmq" -}}
+  {{- end -}}
+  {{- if not .Values.broker.rabbitmq.queue -}}
+    {{- fail "broker.rabbitmq.queue is required when broker type is rabbitmq" -}}
+  {{- end -}}
+  {{- if not .Values.broker.rabbitmq.exchange -}}
+    {{- fail "broker.rabbitmq.exchange is required when broker type is rabbitmq" -}}
+  {{- end -}}
+  {{- if not .Values.broker.rabbitmq.routingKey -}}
+    {{- fail "broker.rabbitmq.routingKey is required when broker type is rabbitmq" -}}
+  {{- end -}}
 {{- end -}}
 {{- end }}

--- a/charts/templates/configmap-broker.yaml
+++ b/charts/templates/configmap-broker.yaml
@@ -4,6 +4,9 @@
 {{- if and $brokerType (not (has $brokerType $allowedTypes)) }}
   {{- fail (printf "broker.type must be one of %s (got %q)" (join ", " $allowedTypes) $brokerType) }}
 {{- end }}
+{{- if not .Values.broker.yaml }}
+{{- include "hyperfleet-adapter.validateBrokerConfig" . }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -73,8 +73,8 @@ broker:
   # option2
   # yaml: ""
 
-  # option3: Broker type identifier (googlepubsub, rabbitmq, etc.) - used as label
-  # Subscription/topic are used to set adapter broker config overrides
+  # option3: required broker type — must be set to "googlepubsub" or "rabbitmq".
+  type: ""
   googlepubsub:
     projectId: ""
     topic: ""
@@ -84,13 +84,12 @@ broker:
     # Set to true for development/testing; use false in production with pre-provisioned resources
     createTopicIfMissing: false
     createSubscriptionIfMissing: false
-  # option3: for rabbitmq
-  #rabbitmq:
-  #  url: ""
-  #  queue: ""
-  #  exchange: ""
-  #  exchangeType: "topic"
-  #  routingKey: ""
+  rabbitmq:
+    url: ""
+    queue: ""
+    exchange: ""
+    exchangeType: "topic"
+    routingKey: ""
 # Override default command
 command:
   - /app/adapter


### PR DESCRIPTION
## Summary

Allows to set rabbitmq as broker for adapters using helm.

Without this changes, the E2E  environment can not be deployed with rabbitmq support and make use of completely local environments

With this in place you can deploy a completely local environment :

```
 ADAPTER_CHART_REPO=https://github.com/rh-amarin/hyperfleet-adapter.git \
 ADAPTER_CHART_REF=adapt-to-rabbit \
SENTINEL_BROKER_RABBITMQ_URL="amqp://guest:guest@rabbitmq.rabbitmq:5672" \
  ADAPTER_BROKER_RABBITMQ_URL="amqp://guest:guest@rabbitmq.rabbitmq:5672" \
  ADAPTER_BROKER_TYPE=rabbitmq \
  API_SERVICE_TYPE=ClusterIP \
  SENTINEL_BROKER_TYPE=rabbitmq \
IMAGE_REGISTRY=quay.io/amarin \
  ./deploy-scripts/deploy-clm.sh --action install \
  --namespace hyperfleet-e2e-amarin \
  --image-registry quay.io/amarin \
  --api-image-repo hyperfleet-api \
  --api-image-tag dev-1f6fd98 \
  --sentinel-image-repo hyperfleet-sentinel \
  --sentinel-image-tag dev-720f676 \
  --adapter-image-repo hyperfleet-adapter \
  --adapter-image-tag dev-f6fad60 \
  --api-base-url http://hyperfleet-api:8000 \
  --api-adapters-cluster cl-namespace,cl-maestro,cl-deployment,cl-job \
  --api-adapters-nodepool np-configmap \
  --cluster-tier0-adapters cl-namespace,cl-maestro,cl-deployment,cl-job,cl-invalid-resource,cl-precondition-error \
  --nodepool-tier0-adapters np-configmap
````

This:
- sets the url for rabbit, which can be installed using the hyperfleet-infra `make install-rabbitmq NAMESPACE=rabbitmq`
- uses custom registry images for the components
- uses ClusterIP for the API instead of a LoadBalancer 
