### PR TITLE
HYPERFLEET-114 - fix: disable tracing by default

### DIFF
--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -281,7 +281,7 @@ serviceMonitor:
   namespace: ""
 
 tracing:
-  enabled: true
+  enabled: false
   serviceName: "hyperfleet-adapter"
   # OTLP exporter endpoint (traces go to stdout if not set)
   otlpEndpoint: ""


### PR DESCRIPTION
## Summary

Let's save some trees (and $$)  disabling verbose tracing