### PR TITLE
HYPERFLEET-1042 - feat: gracefully handle 404 when resource is force-deleted

### DIFF
--- a/internal/dryrun/trace.go
+++ b/internal/dryrun/trace.go
@@ -118,11 +118,16 @@ func (t *ExecutionTrace) FormatText() string {
 	// Phase 2: Preconditions
 	precondStatus := statusSuccess
 	precondDetail := ""
-	if _, ok := result.Errors[executor.PhasePreconditions]; ok {
+	_, hasPrecondErr := result.Errors[executor.PhasePreconditions]
+	switch {
+	case hasPrecondErr:
 		precondStatus = statusFailed
-	} else if result.ResourcesSkipped && result.SkipReason != "" {
+	case result.ResourcesSkipped && result.SkipReason == executor.ResourceGoneReason &&
+		len(result.PostActionResults) == 0:
+		precondDetail = " (RESOURCE GONE)"
+	case result.ResourcesSkipped && result.SkipReason != "" && result.SkipReason != executor.ResourceGoneReason:
 		precondDetail = " (NOT MET)"
-	} else if len(result.PreconditionResults) > 0 {
+	case len(result.PreconditionResults) > 0:
 		precondDetail = " (MET)"
 	}
 	fmt.Fprintf(&b, "Phase 2: Preconditions ..................... %s%s\n", precondStatus, precondDetail)
@@ -235,10 +240,14 @@ func (t *ExecutionTrace) FormatText() string {
 
 	// Phase 4: Post Actions
 	postStatus := statusSuccess
+	postDetail := ""
 	if _, ok := result.Errors[executor.PhasePostActions]; ok {
 		postStatus = statusFailed
+	} else if result.ResourcesSkipped && result.SkipReason == executor.ResourceGoneReason &&
+		len(result.PostActionResults) > 0 {
+		postDetail = " (RESOURCE GONE)"
 	}
-	fmt.Fprintf(&b, "Phase 4: Post Actions ..................... %s\n", postStatus)
+	fmt.Fprintf(&b, "Phase 4: Post Actions ..................... %s%s\n", postStatus, postDetail)
 
 	for i, pa := range result.PostActionResults {
 		status := "EXECUTED"

--- a/internal/dryrun/trace_test.go
+++ b/internal/dryrun/trace_test.go
@@ -96,6 +96,32 @@ func TestFormatText_ResourcesSkipped(t *testing.T) {
 		assert.Contains(t, output, "SKIPPED")
 		assert.Contains(t, output, "preconditions not met")
 	})
+
+	t.Run("resource gone shows RESOURCE GONE instead of NOT MET", func(t *testing.T) {
+		trace := makeTestTrace(executor.StatusSuccess, false)
+		trace.Result.ResourcesSkipped = true
+		trace.Result.SkipReason = executor.ResourceGoneReason
+
+		output := trace.FormatText()
+
+		assert.Contains(t, output, "(RESOURCE GONE)")
+		assert.NotContains(t, output, "(NOT MET)")
+	})
+
+	t.Run("post-action resource gone shows RESOURCE GONE in phase 4", func(t *testing.T) {
+		trace := makeTestTrace(executor.StatusSuccess, false)
+		trace.Result.ResourcesSkipped = true
+		trace.Result.SkipReason = executor.ResourceGoneReason
+		trace.Result.PostActionResults = []executor.PostActionResult{
+			{Name: "reportStatus", Status: executor.StatusSkipped, Skipped: true, SkipReason: executor.ResourceGoneReason},
+		}
+
+		output := trace.FormatText()
+
+		assert.Contains(t, output, "Phase 4: Post Actions")
+		assert.Contains(t, output, "(RESOURCE GONE)")
+		assert.Contains(t, output, "SKIPPED")
+	})
 }
 
 func TestFormatText_VerboseShowsBodies(t *testing.T) {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -11,12 +11,16 @@ import (
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/configloader"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/hyperfleetapi"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/transportclient"
+	apierrors "github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/errors"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/logger"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/metrics"
 	pkgotel "github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/telemetry"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 )
+
+// ResourceGoneReason indicates the target resource was force-deleted (API returned 404).
+const ResourceGoneReason = "ResourceGone"
 
 // NewExecutor creates a new Executor with the given configuration
 func NewExecutor(config *ExecutorConfig) (*Executor, error) {
@@ -125,6 +129,18 @@ func (e *Executor) Execute(ctx context.Context, data interface{}) *ExecutionResu
 	result.PreconditionResults = precondOutcome.Results
 
 	switch {
+	case precondOutcome.Error != nil && apierrors.IsNotFoundError(precondOutcome.Error):
+		// Resource was force-deleted: API returned 404. Log and stop processing gracefully.
+		// No point running resources or post-actions for a resource that no longer exists.
+		e.log.Infof(ctx, "Phase %s: resource not found, stopping processing gracefully",
+			result.CurrentPhase)
+		result.ResourcesSkipped = true
+		result.SkipReason = ResourceGoneReason
+		execCtx.SetSkipped(ResourceGoneReason, "")
+		execCtx.Adapter.ExecutionError = nil
+		result.ExecutionContext = execCtx
+		result.Params = execCtx.Params
+		return result
 	case precondOutcome.Error != nil:
 		// Process execution error: precondition evaluation failed
 		result.Status = StatusFailed
@@ -187,11 +203,35 @@ func (e *Executor) Execute(ctx context.Context, data interface{}) *ExecutionResu
 	result.PostActionResults = postResults
 
 	if err != nil {
-		result.Status = StatusFailed
-		postErr := fmt.Errorf("post action execution failed: %w", err)
-		result.Errors[result.CurrentPhase] = postErr
-		errCtx := logger.WithErrorField(ctx, err)
-		e.log.Errorf(errCtx, "Phase %s: FAILED", result.CurrentPhase)
+		if apierrors.IsNotFoundError(err) {
+			// Resource was force-deleted mid-execution. Log and continue, don't fail.
+			e.log.Infof(ctx, "Phase %s: resource not found, skipping remaining post-actions",
+				result.CurrentPhase)
+			result.ResourcesSkipped = true
+			// ResourceGone takes precedence: the resource no longer exists,
+			// making the original skip reason moot.
+			result.SkipReason = ResourceGoneReason
+			// The PostActionExecutor set the step to StatusFailed before the error
+			// reached us. Now that we've decided this 404 is a graceful stop (not a
+			// real failure), correct the step to match that decision.
+			if len(result.PostActionResults) > 0 {
+				last := &result.PostActionResults[len(result.PostActionResults)-1]
+				last.Status = StatusSkipped
+				last.Skipped = true
+				last.SkipReason = ResourceGoneReason
+				last.Error = nil
+			}
+			if result.Status == StatusSuccess {
+				execCtx.SetSkipped(ResourceGoneReason, "")
+				execCtx.Adapter.ExecutionError = nil
+			}
+		} else {
+			result.Status = StatusFailed
+			postErr := fmt.Errorf("post action execution failed: %w", err)
+			result.Errors[result.CurrentPhase] = postErr
+			errCtx := logger.WithErrorField(ctx, err)
+			e.log.Errorf(errCtx, "Phase %s: FAILED", result.CurrentPhase)
+		}
 	} else {
 		e.log.Infof(ctx, "Phase %s: SUCCESS - %d executed", result.CurrentPhase, len(postResults))
 	}

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -4,24 +4,67 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/cloudevents/sdk-go/v2/event"
-	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/configloader"
-	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/criteria"
-	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/hyperfleetapi"
-	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/k8sclient"
-	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/logger"
-	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/configloader"
+	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/criteria"
+	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/hyperfleetapi"
+	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/k8sclient"
+	apierrors "github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/errors"
+	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/logger"
+	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/metrics"
 )
 
 // newMockAPIClient creates a new mock API client for convenience
 func newMockAPIClient() *hyperfleetapi.MockClient {
 	return hyperfleetapi.NewMockClient()
+}
+
+func mockErrorResponse(statusCode int) (*hyperfleetapi.Response, error) {
+	status := fmt.Sprintf("%d %s", statusCode, http.StatusText(statusCode))
+	body := []byte(fmt.Sprintf(`{"error":"%d"}`, statusCode))
+	resp := &hyperfleetapi.Response{
+		StatusCode: statusCode,
+		Status:     status,
+		Body:       body,
+		Attempts:   1,
+	}
+	apiErr := apierrors.NewAPIError("MOCK", "/mock", statusCode, status, body, 1, 0,
+		fmt.Errorf("HTTP %d", statusCode))
+	return resp, apiErr
+}
+
+// mock404Response returns a 404 response without an error. The MockClient only
+// returns (nil, error) when an error is set, so using mockErrorResponse for 404
+// tests causes ExecuteAPICall to wrap the error in a new APIError with StatusCode=0,
+// which breaks IsNotFoundError detection. Setting only the response lets
+// ValidateAPIResponse create the correct APIError{StatusCode:404}.
+func mock404Response() *hyperfleetapi.Response {
+	return &hyperfleetapi.Response{
+		StatusCode: 404,
+		Status:     "404 Not Found",
+		Body:       []byte(`{"error":"not found"}`),
+		Attempts:   1,
+	}
+}
+
+func build404TestExecutor(t *testing.T, config *configloader.Config, mockClient *hyperfleetapi.MockClient) *Executor {
+	t.Helper()
+	exec, err := NewBuilder().
+		WithConfig(config).
+		WithAPIClient(mockClient).
+		WithTransportClient(k8sclient.NewMockK8sClient()).
+		WithLogger(logger.NewTestLogger()).
+		Build()
+	require.NoError(t, err)
+	return exec
 }
 
 // TestNewExecutor tests the NewExecutor function
@@ -1408,6 +1451,181 @@ func findFamily(families []*dto.MetricFamily, name string) *dto.MetricFamily {
 		}
 	}
 	return nil
+}
+
+// TestPrecondition404_GracefulStop verifies that when a precondition API call returns 404
+// (resource force-deleted), the executor stops gracefully: status remains "success",
+// resources are skipped, and no error state is set.
+func new404PreconditionConfig() *configloader.Config {
+	return &configloader.Config{
+		Adapter: configloader.AdapterInfo{
+			Name:    "test-adapter",
+			Version: "1.0.0",
+		},
+		Clients: configloader.ClientsConfig{
+			HyperfleetAPI: configloader.HyperfleetAPIConfig{
+				BaseURL: "http://mock-api:8000",
+				Version: "v1",
+			},
+		},
+		Params: []configloader.Parameter{
+			{Name: "clusterId", Source: "event.id", Required: true},
+		},
+		Preconditions: []configloader.Precondition{
+			{
+				ActionBase: configloader.ActionBase{
+					Name: "clusterStatus",
+					APICall: &configloader.APICall{
+						Method:  "GET",
+						URL:     "/clusters/{{ .clusterId }}",
+						Timeout: "2s",
+					},
+				},
+			},
+		},
+	}
+}
+
+func new404PostActionConfig() *configloader.Config {
+	cfg := new404PreconditionConfig()
+	cfg.Post = &configloader.PostConfig{
+		PostActions: []configloader.PostAction{
+			{
+				ActionBase: configloader.ActionBase{
+					Name: "reportStatus",
+					APICall: &configloader.APICall{
+						Method:  "PUT",
+						URL:     "/clusters/{{ .clusterId }}/statuses",
+						Body:    `{"status":"done"}`,
+						Timeout: "2s",
+					},
+				},
+			},
+		},
+	}
+	return cfg
+}
+
+func TestPrecondition404_GracefulStop(t *testing.T) {
+	mockClient := newMockAPIClient()
+	mockClient.GetResponse = mock404Response()
+
+	config := new404PreconditionConfig()
+	exec := build404TestExecutor(t, config, mockClient)
+
+	ctx := logger.WithEventID(context.Background(), "test-precond-404")
+	result := exec.Execute(ctx, map[string]interface{}{"id": "cluster-gone"})
+
+	assert.Equal(t, StatusSuccess, result.Status,
+		"404 on resource should not mark execution as failed")
+
+	assert.True(t, result.ResourcesSkipped, "resources should be skipped")
+	assert.Equal(t, ResourceGoneReason, result.SkipReason,
+		"skip reason should be ResourceGoneReason")
+
+	assert.Empty(t, result.Errors, "no errors should be recorded for a 404")
+	assert.Equal(t, "", result.ExecutionContext.Adapter.ErrorReason,
+		"adapter.errorReason should be empty for a 404")
+	assert.Equal(t, "", result.ExecutionContext.Adapter.ErrorMessage,
+		"adapter.errorMessage should be empty for a 404")
+	assert.Nil(t, result.ExecutionContext.Adapter.ExecutionError,
+		"adapter.executionError should be nil for a 404")
+}
+
+// TestPostAction404_GracefulHandling verifies that when a post-action API call returns 404
+// (resource force-deleted), the executor does not mark the execution as failed.
+func TestPostAction404_GracefulHandling(t *testing.T) {
+	mockClient := newMockAPIClient()
+	mockClient.GetResponse = &hyperfleetapi.Response{
+		StatusCode: 200,
+		Body:       []byte(`{"id":"cluster-456","status":{"conditions":[{"type":"Reconciled","status":"False"}]}}`),
+	}
+	mockClient.PutResponse = mock404Response()
+
+	config := new404PostActionConfig()
+	exec := build404TestExecutor(t, config, mockClient)
+
+	ctx := logger.WithEventID(context.Background(), "test-postaction-404")
+	result := exec.Execute(ctx, map[string]interface{}{"id": "cluster-gone"})
+
+	// Status should be success; 404 in post-actions is gracefully handled
+	assert.Equal(t, StatusSuccess, result.Status,
+		"404 in post-actions should result in success, not failure")
+
+	// No post-action errors should be recorded
+	assert.Nil(t, result.Errors[PhasePostActions],
+		"no post_actions error should be recorded for a 404")
+
+	// Verify adapter metadata is consistent
+	require.NotNil(t, result.ExecutionContext)
+	assert.Equal(t, string(StatusSuccess), result.ExecutionContext.Adapter.ExecutionStatus,
+		"adapter.executionStatus should be success for a post-action 404")
+	assert.True(t, result.ExecutionContext.Adapter.ResourcesSkipped,
+		"adapter.resourcesSkipped should be true")
+	assert.Equal(t, ResourceGoneReason, result.SkipReason,
+		"skip reason should be ResourceGone")
+	assert.Nil(t, result.ExecutionContext.Adapter.ExecutionError,
+		"adapter.executionError should be nil for a post-action 404")
+}
+
+// TestPrecondition404_SkipsPostActions verifies that when a precondition returns 404,
+// post-actions are never attempted (no PUT/POST requests after the 404 GET).
+func TestPrecondition404_SkipsPostActions(t *testing.T) {
+	mockClient := newMockAPIClient()
+	mockClient.GetResponse = mock404Response()
+
+	config := new404PostActionConfig()
+	exec := build404TestExecutor(t, config, mockClient)
+
+	ctx := logger.WithEventID(context.Background(), "test-precond-404-skips-post")
+	_ = exec.Execute(ctx, map[string]interface{}{"id": "cluster-gone"})
+
+	// Only the precondition GET should have been made; no PUT for post-actions
+	var getCalls, putCalls int
+	for _, req := range mockClient.Requests {
+		switch req.Method {
+		case "GET":
+			getCalls++
+		case "PUT":
+			putCalls++
+		}
+	}
+	assert.Equal(t, 1, getCalls,
+		"expected exactly 1 GET call (precondition)")
+	assert.Equal(t, 0, putCalls,
+		"expected 0 PUT calls (post-actions should not run after precondition 404)")
+}
+
+// TestPreconditionFail_PostAction404 verifies that when preconditions fail with a non-404 error
+// and post-actions also return 404, the execution status remains failed (not masked by ResourceGone)
+// and the original error context is preserved.
+func TestPreconditionFail_PostAction404(t *testing.T) {
+	mockClient := newMockAPIClient()
+	mockClient.GetResponse, mockClient.GetError = mockErrorResponse(500)
+	mockClient.PutResponse = mock404Response()
+
+	config := new404PostActionConfig()
+	exec := build404TestExecutor(t, config, mockClient)
+
+	ctx := logger.WithEventID(context.Background(), "test-precond-fail-post-404")
+	result := exec.Execute(ctx, map[string]interface{}{"id": "cluster-gone"})
+
+	// Status stays failed (precondition error is the primary failure)
+	assert.Equal(t, StatusFailed, result.Status,
+		"status should remain failed from precondition error")
+
+	// SkipReason gets overwritten to ResourceGone (resource is gone, overrides PreconditionFailed)
+	assert.Equal(t, ResourceGoneReason, result.SkipReason,
+		"skip reason should be ResourceGone when post-action 404 overwrites it")
+	assert.True(t, result.ResourcesSkipped, "resources should be skipped")
+
+	// The precondition error should still be recorded
+	assert.NotNil(t, result.Errors[PhasePreconditions],
+		"precondition error should still be recorded")
+
+	// No post-action error recorded (404 is handled gracefully)
+	assert.Nil(t, result.Errors[PhasePostActions],
+		"post-action 404 should not add an error")
 }
 
 func getCounterValue(t *testing.T, families []*dto.MetricFamily, metricName, labelName, labelValue string) float64 {

--- a/pkg/errors/api_error.go
+++ b/pkg/errors/api_error.go
@@ -156,3 +156,10 @@ func IsAPIError(err error) (*APIError, bool) {
 	}
 	return nil, false
 }
+
+// IsNotFoundError checks whether err (or any error in its chain) is
+// an APIError with a 404 status code.
+func IsNotFoundError(err error) bool {
+	apiErr, ok := IsAPIError(err)
+	return ok && apiErr.IsNotFound()
+}

--- a/pkg/errors/api_error_test.go
+++ b/pkg/errors/api_error_test.go
@@ -1,0 +1,77 @@
+package errors
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsNotFoundError(t *testing.T) {
+	tests := []struct {
+		err  error
+		name string
+		want bool
+	}{
+		// Non-API errors
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "plain error",
+			err:  fmt.Errorf("something went wrong"),
+			want: false,
+		},
+
+		// 404 errors: should return true regardless of wrapping depth
+		{
+			name: "404 direct",
+			err:  NewAPIError("GET", "/clusters/123", 404, "404 Not Found", nil, 1, 0, fmt.Errorf("not found")),
+			want: true,
+		},
+		{
+			name: "404 single-wrapped",
+			err: fmt.Errorf("precondition failed: %w",
+				NewAPIError("GET", "/clusters/123", 404, "404 Not Found", nil, 1, 0, fmt.Errorf("not found"))),
+			want: true,
+		},
+		{
+			name: "404 double-wrapped (ExecutorError -> APIError chain)",
+			err: fmt.Errorf("[preconditions] checkCluster: API call failed: %w",
+				NewAPIError("GET", "/clusters/123", 404, "404 Not Found", nil, 1, 0, fmt.Errorf("not found"))),
+			want: true,
+		},
+
+		// Non-404 API errors: should return false
+		{
+			name: "500 direct",
+			err:  NewAPIError("GET", "/clusters/123", 500, "500 Internal Server Error", nil, 1, 0, fmt.Errorf("server error")),
+			want: false,
+		},
+		{
+			name: "500 single-wrapped",
+			err: fmt.Errorf("precondition failed: %w",
+				NewAPIError("GET", "/clusters/123", 500, "500 Internal Server Error", nil, 1, 0, fmt.Errorf("server error"))),
+			want: false,
+		},
+		{
+			name: "500 double-wrapped (ExecutorError -> APIError chain)",
+			err: fmt.Errorf("[preconditions] checkCluster: API call failed: %w",
+				NewAPIError("GET", "/clusters/123", 500, "500 Internal Server Error", nil, 1, 0, fmt.Errorf("server error"))),
+			want: false,
+		},
+		{
+			name: "0 status (no response)",
+			err:  NewAPIError("GET", "/clusters/123", 0, "", nil, 1, 0, fmt.Errorf("connection refused")),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsNotFoundError(tt.err))
+		})
+	}
+}

--- a/test/integration/executor/executor_integration_test.go
+++ b/test/integration/executor/executor_integration_test.go
@@ -395,7 +395,7 @@ func TestExecutor_PreconditionAPIFailure(t *testing.T) {
 	// Setup mock API server that fails precondition API call
 	mockAPI := testutil.NewMockAPIServer(t)
 	defer mockAPI.Close()
-	mockAPI.SetFailPrecondition(true) // API will return 404
+	mockAPI.SetFailPrecondition(true)
 
 	// Set environment variables
 	t.Setenv("HYPERFLEET_API_BASE_URL", mockAPI.URL())
@@ -487,6 +487,74 @@ func TestExecutor_PreconditionAPIFailure(t *testing.T) {
 	}
 
 	t.Logf("Execution failed as expected: errors=%v", result.Errors)
+}
+
+func setup404IntegrationTest(t *testing.T) (*testutil.MockAPIServer, *executor.Executor) {
+	t.Helper()
+	mockAPI := testutil.NewMockAPIServer(t)
+	t.Cleanup(func() { mockAPI.Close() })
+
+	t.Setenv("HYPERFLEET_API_BASE_URL", mockAPI.URL())
+	t.Setenv("HYPERFLEET_API_VERSION", "v1")
+
+	k8sEnv := getK8sEnvForTest(t)
+
+	config := createTestConfig(mockAPI.URL())
+	apiClient, err := hyperfleetapi.NewClient(testLog(),
+		hyperfleetapi.WithRetryAttempts(1),
+	)
+	require.NoError(t, err)
+
+	exec, err := executor.NewBuilder().
+		WithConfig(config).
+		WithAPIClient(apiClient).
+		WithLogger(k8sEnv.Log).
+		WithTransportClient(k8sEnv.Client).
+		Build()
+	require.NoError(t, err)
+
+	return mockAPI, exec
+}
+
+func TestExecutor_PreconditionNotFound_GracefulStop(t *testing.T) {
+	mockAPI, exec := setup404IntegrationTest(t)
+	mockAPI.SetPreconditionNotFound(true)
+
+	evt := createTestEvent("cluster-force-deleted")
+	ctx := context.Background()
+	result := exec.Execute(ctx, evt)
+
+	assert.Equal(t, executor.StatusSuccess, result.Status,
+		"404 on force-deleted resource should not mark execution as failed")
+	assert.True(t, result.ResourcesSkipped, "resources should be skipped")
+	assert.Equal(t, executor.ResourceGoneReason, result.SkipReason,
+		"skip reason should be ResourceGone")
+	assert.Empty(t, result.Errors, "no errors should be recorded for a 404")
+	assert.Empty(t, result.ResourceResults, "no resources should be processed")
+	assert.Empty(t, result.PostActionResults, "no post-actions should be attempted")
+
+	statusResponses := mockAPI.GetStatusResponses()
+	assert.Empty(t, statusResponses, "no status should be reported to the API")
+
+	t.Logf("Execution stopped gracefully: skipReason=%s", result.SkipReason)
+}
+
+func TestExecutor_PostActionNotFound_GracefulHandling(t *testing.T) {
+	mockAPI, exec := setup404IntegrationTest(t)
+	mockAPI.SetPostActionNotFound(true)
+
+	evt := createTestEvent("cluster-force-deleted-during-post")
+	ctx := context.Background()
+	result := exec.Execute(ctx, evt)
+
+	assert.Equal(t, executor.StatusSuccess, result.Status,
+		"404 on post-action should not mark execution as failed")
+	assert.True(t, result.ResourcesSkipped, "resources should be skipped")
+	assert.Equal(t, executor.ResourceGoneReason, result.SkipReason,
+		"skip reason should be ResourceGone")
+	assert.Empty(t, result.Errors, "no errors should be recorded for a post-action 404")
+
+	t.Logf("Post-action 404 handled gracefully: skipReason=%s", result.SkipReason)
 }
 
 func TestExecutor_CELExpressionEvaluation(t *testing.T) {
@@ -1168,7 +1236,7 @@ func TestExecutor_ExecutionError_CELAccess(t *testing.T) {
 	// Setup mock API server that fails precondition to trigger an error
 	mockAPI := testutil.NewMockAPIServer(t)
 	defer mockAPI.Close()
-	mockAPI.SetFailPrecondition(true) // Will return 404 for cluster lookup
+	mockAPI.SetFailPrecondition(true) // Will return 500 for cluster lookup
 
 	// Set environment variables
 	t.Setenv("HYPERFLEET_API_BASE_URL", mockAPI.URL())

--- a/test/integration/testutil/mock_api_server.go
+++ b/test/integration/testutil/mock_api_server.go
@@ -28,14 +28,17 @@ type MockRequest struct {
 //
 // TODO: Replace with testcontainers using hyperfleet-api image when available.
 type MockAPIServer struct {
-	server           *httptest.Server
-	t                *testing.T
-	clusterResponse  map[string]interface{}
-	requests         []MockRequest
-	statusResponses  []map[string]interface{}
-	mu               sync.Mutex
-	failPrecondition bool
-	failPostAction   bool // If true, post action api call returns 500
+	server          *httptest.Server
+	t               *testing.T
+	clusterResponse map[string]interface{}
+	requests        []MockRequest
+	statusResponses []map[string]interface{}
+	mu              sync.Mutex
+
+	failPrecondition     bool // If true, precondition GET returns 500 (ignored if preconditionNotFound is set)
+	preconditionNotFound bool // If true, precondition GET returns 404 (takes precedence over failPrecondition)
+	failPostAction       bool // If true, post-action PUT returns 500
+	postActionNotFound   bool // If true, post-action PUT returns 404 (takes precedence over failPostAction)
 }
 
 // NewMockAPIServer creates a new MockAPIServer for testing.
@@ -104,7 +107,16 @@ func NewMockAPIServer(t *testing.T) *MockAPIServer {
 		case strings.Contains(r.URL.Path, "/clusters/") && strings.HasSuffix(r.URL.Path, "/statuses"):
 			// PUT /clusters/{id}/statuses - Store status and return success (or fail if configured)
 			if r.Method == http.MethodPut {
-				// Check if fail post action is set to true
+				if mock.postActionNotFound {
+					w.WriteHeader(http.StatusNotFound)
+					if encodeErr := json.NewEncoder(w).Encode(map[string]string{
+						"error":   "not found",
+						"message": "cluster not found",
+					}); encodeErr != nil {
+						t.Logf("Warning: failed to encode error response: %v", encodeErr)
+					}
+					return
+				}
 				if mock.failPostAction {
 					w.WriteHeader(http.StatusInternalServerError)
 					if encodeErr := json.NewEncoder(w).Encode(map[string]string{
@@ -130,9 +142,16 @@ func NewMockAPIServer(t *testing.T) *MockAPIServer {
 		case strings.Contains(r.URL.Path, "/clusters/"):
 			// GET /clusters/{id} - Return cluster details
 			if r.Method == http.MethodGet {
-				if mock.failPrecondition {
+				if mock.preconditionNotFound {
 					w.WriteHeader(http.StatusNotFound)
 					if encodeErr := json.NewEncoder(w).Encode(map[string]string{"error": "cluster not found"}); encodeErr != nil {
+						t.Logf("Warning: failed to encode error response: %v", encodeErr)
+					}
+					return
+				}
+				if mock.failPrecondition {
+					w.WriteHeader(http.StatusInternalServerError)
+					if encodeErr := json.NewEncoder(w).Encode(map[string]string{"error": "internal server error"}); encodeErr != nil {
 						t.Logf("Warning: failed to encode error response: %v", encodeErr)
 					}
 					return
@@ -194,11 +213,25 @@ func (m *MockAPIServer) SetClusterResponse(resp map[string]interface{}) {
 	m.clusterResponse = resp
 }
 
-// SetFailPrecondition configures whether precondition API calls should fail
+// SetFailPrecondition configures whether precondition API calls should fail with 500
 func (m *MockAPIServer) SetFailPrecondition(fail bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.failPrecondition = fail
+}
+
+// SetPreconditionNotFound configures whether precondition API calls should return 404
+func (m *MockAPIServer) SetPreconditionNotFound(notFound bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.preconditionNotFound = notFound
+}
+
+// SetPostActionNotFound configures whether post-action API calls should return 404
+func (m *MockAPIServer) SetPostActionNotFound(notFound bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.postActionNotFound = notFound
 }
 
 // SetFailPostAction configures whether post-action API calls should fail
@@ -229,7 +262,9 @@ func (m *MockAPIServer) Reset() {
 	m.requests = make([]MockRequest, 0)
 	m.statusResponses = make([]map[string]interface{}, 0)
 	m.failPrecondition = false
+	m.preconditionNotFound = false
 	m.failPostAction = false
+	m.postActionNotFound = false
 	m.clusterResponse = map[string]interface{}{
 		"id":   "test-cluster-id",
 		"name": "test-cluster",


### PR DESCRIPTION

## Summary

When a resource is force-deleted, in-flight events may still reach adapters. Previously, if the adapter tried to GET the resource or PUT its status and received a 404, it would treat this as a failure. This PR adds graceful 404 handling so the adapter logs the situation and moves on without retrying or entering an error state.

[HYPERFLEET-1042](https://issues.redhat.com/browse/HYPERFLEET-1042)

## Changes

- When a precondition API call returns 404, the executor stops processing gracefully (status remains "success", resources are marked as skipped with a `ResourceGone` reason) instead of failing
- When a post-action API call returns 404, the executor logs and continues without marking the execution as failed, while preserving any prior failure state from earlier phases
- Added `IsNotFoundError` helper in `pkg/errors` to detect 404 errors through wrapped error chains
- Dryrun trace output now shows "(RESOURCE GONE)" instead of "(NOT MET)" when a precondition 404 triggers the skip
- Updated mock client to return both response and error (matching real `httpClient` behavior), enabling status-code inspection on error paths

## Test Plan

- [x] Unit tests added/updated
- [x] `make test-all` passes (envtest integration failures are pre-existing, not from this PR)
- [x] `make lint` passes
- [ ] Helm chart changes validated with `make test-helm` (if applicable)
- [ ] Deployed to a development cluster and verified (if Helm/config changes)
- [ ] E2E tests passed (if cross-component or major changes)


[HYPERFLEET-1042]: https://redhat.atlassian.net/browse/HYPERFLEET-1042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ