### PR TITLE
HYPERFLEET-1042 - refactor: rename ResourceGone to ResourceNotFound

### DIFF
--- a/internal/dryrun/trace.go
+++ b/internal/dryrun/trace.go
@@ -122,10 +122,10 @@ func (t *ExecutionTrace) FormatText() string {
 	switch {
 	case hasPrecondErr:
 		precondStatus = statusFailed
-	case result.ResourcesSkipped && result.SkipReason == executor.ResourceGoneReason &&
+	case result.ResourcesSkipped && result.SkipReason == executor.ResourceNotFoundReason &&
 		len(result.PostActionResults) == 0:
-		precondDetail = " (RESOURCE GONE)"
-	case result.ResourcesSkipped && result.SkipReason != "" && result.SkipReason != executor.ResourceGoneReason:
+		precondDetail = " (RESOURCE NOT FOUND)"
+	case result.ResourcesSkipped && result.SkipReason != "" && result.SkipReason != executor.ResourceNotFoundReason:
 		precondDetail = " (NOT MET)"
 	case len(result.PreconditionResults) > 0:
 		precondDetail = " (MET)"
@@ -243,9 +243,9 @@ func (t *ExecutionTrace) FormatText() string {
 	postDetail := ""
 	if _, ok := result.Errors[executor.PhasePostActions]; ok {
 		postStatus = statusFailed
-	} else if result.ResourcesSkipped && result.SkipReason == executor.ResourceGoneReason &&
+	} else if result.ResourcesSkipped && result.SkipReason == executor.ResourceNotFoundReason &&
 		len(result.PostActionResults) > 0 {
-		postDetail = " (RESOURCE GONE)"
+		postDetail = " (RESOURCE NOT FOUND)"
 	}
 	fmt.Fprintf(&b, "Phase 4: Post Actions ..................... %s%s\n", postStatus, postDetail)
 

--- a/internal/dryrun/trace_test.go
+++ b/internal/dryrun/trace_test.go
@@ -97,29 +97,29 @@ func TestFormatText_ResourcesSkipped(t *testing.T) {
 		assert.Contains(t, output, "preconditions not met")
 	})
 
-	t.Run("resource gone shows RESOURCE GONE instead of NOT MET", func(t *testing.T) {
+	t.Run("resource not found shows RESOURCE NOT FOUND instead of NOT MET", func(t *testing.T) {
 		trace := makeTestTrace(executor.StatusSuccess, false)
 		trace.Result.ResourcesSkipped = true
-		trace.Result.SkipReason = executor.ResourceGoneReason
+		trace.Result.SkipReason = executor.ResourceNotFoundReason
 
 		output := trace.FormatText()
 
-		assert.Contains(t, output, "(RESOURCE GONE)")
+		assert.Contains(t, output, "(RESOURCE NOT FOUND)")
 		assert.NotContains(t, output, "(NOT MET)")
 	})
 
-	t.Run("post-action resource gone shows RESOURCE GONE in phase 4", func(t *testing.T) {
+	t.Run("post-action resource not found shows RESOURCE NOT FOUND in phase 4", func(t *testing.T) {
 		trace := makeTestTrace(executor.StatusSuccess, false)
 		trace.Result.ResourcesSkipped = true
-		trace.Result.SkipReason = executor.ResourceGoneReason
+		trace.Result.SkipReason = executor.ResourceNotFoundReason
 		trace.Result.PostActionResults = []executor.PostActionResult{
-			{Name: "reportStatus", Status: executor.StatusSkipped, Skipped: true, SkipReason: executor.ResourceGoneReason},
+			{Name: "reportStatus", Status: executor.StatusSkipped, Skipped: true, SkipReason: executor.ResourceNotFoundReason},
 		}
 
 		output := trace.FormatText()
 
 		assert.Contains(t, output, "Phase 4: Post Actions")
-		assert.Contains(t, output, "(RESOURCE GONE)")
+		assert.Contains(t, output, "(RESOURCE NOT FOUND)")
 		assert.Contains(t, output, "SKIPPED")
 	})
 }

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -19,8 +19,8 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// ResourceGoneReason indicates the target resource was force-deleted (API returned 404).
-const ResourceGoneReason = "ResourceGone"
+// ResourceNotFoundReason indicates the API returned 404 for the target resource.
+const ResourceNotFoundReason = "ResourceNotFound"
 
 // NewExecutor creates a new Executor with the given configuration
 func NewExecutor(config *ExecutorConfig) (*Executor, error) {
@@ -135,8 +135,8 @@ func (e *Executor) Execute(ctx context.Context, data interface{}) *ExecutionResu
 		e.log.Infof(ctx, "Phase %s: resource not found, stopping processing gracefully",
 			result.CurrentPhase)
 		result.ResourcesSkipped = true
-		result.SkipReason = ResourceGoneReason
-		execCtx.SetSkipped(ResourceGoneReason, "")
+		result.SkipReason = ResourceNotFoundReason
+		execCtx.SetSkipped(ResourceNotFoundReason, "")
 		execCtx.Adapter.ExecutionError = nil
 		result.ExecutionContext = execCtx
 		result.Params = execCtx.Params
@@ -208,9 +208,9 @@ func (e *Executor) Execute(ctx context.Context, data interface{}) *ExecutionResu
 			e.log.Infof(ctx, "Phase %s: resource not found, skipping remaining post-actions",
 				result.CurrentPhase)
 			result.ResourcesSkipped = true
-			// ResourceGone takes precedence: the resource no longer exists,
+			// ResourceNotFound takes precedence: the resource no longer exists,
 			// making the original skip reason moot.
-			result.SkipReason = ResourceGoneReason
+			result.SkipReason = ResourceNotFoundReason
 			// The PostActionExecutor set the step to StatusFailed before the error
 			// reached us. Now that we've decided this 404 is a graceful stop (not a
 			// real failure), correct the step to match that decision.
@@ -218,11 +218,11 @@ func (e *Executor) Execute(ctx context.Context, data interface{}) *ExecutionResu
 				last := &result.PostActionResults[len(result.PostActionResults)-1]
 				last.Status = StatusSkipped
 				last.Skipped = true
-				last.SkipReason = ResourceGoneReason
+				last.SkipReason = ResourceNotFoundReason
 				last.Error = nil
 			}
 			if result.Status == StatusSuccess {
-				execCtx.SetSkipped(ResourceGoneReason, "")
+				execCtx.SetSkipped(ResourceNotFoundReason, "")
 				execCtx.Adapter.ExecutionError = nil
 			}
 		} else {

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -1520,8 +1520,8 @@ func TestPrecondition404_GracefulStop(t *testing.T) {
 		"404 on resource should not mark execution as failed")
 
 	assert.True(t, result.ResourcesSkipped, "resources should be skipped")
-	assert.Equal(t, ResourceGoneReason, result.SkipReason,
-		"skip reason should be ResourceGoneReason")
+	assert.Equal(t, ResourceNotFoundReason, result.SkipReason,
+		"skip reason should be ResourceNotFoundReason")
 
 	assert.Empty(t, result.Errors, "no errors should be recorded for a 404")
 	assert.Equal(t, "", result.ExecutionContext.Adapter.ErrorReason,
@@ -1562,8 +1562,8 @@ func TestPostAction404_GracefulHandling(t *testing.T) {
 		"adapter.executionStatus should be success for a post-action 404")
 	assert.True(t, result.ExecutionContext.Adapter.ResourcesSkipped,
 		"adapter.resourcesSkipped should be true")
-	assert.Equal(t, ResourceGoneReason, result.SkipReason,
-		"skip reason should be ResourceGone")
+	assert.Equal(t, ResourceNotFoundReason, result.SkipReason,
+		"skip reason should be ResourceNotFound")
 	assert.Nil(t, result.ExecutionContext.Adapter.ExecutionError,
 		"adapter.executionError should be nil for a post-action 404")
 }
@@ -1597,7 +1597,7 @@ func TestPrecondition404_SkipsPostActions(t *testing.T) {
 }
 
 // TestPreconditionFail_PostAction404 verifies that when preconditions fail with a non-404 error
-// and post-actions also return 404, the execution status remains failed (not masked by ResourceGone)
+// and post-actions also return 404, the execution status remains failed (not masked by ResourceNotFound)
 // and the original error context is preserved.
 func TestPreconditionFail_PostAction404(t *testing.T) {
 	mockClient := newMockAPIClient()
@@ -1614,9 +1614,9 @@ func TestPreconditionFail_PostAction404(t *testing.T) {
 	assert.Equal(t, StatusFailed, result.Status,
 		"status should remain failed from precondition error")
 
-	// SkipReason gets overwritten to ResourceGone (resource is gone, overrides PreconditionFailed)
-	assert.Equal(t, ResourceGoneReason, result.SkipReason,
-		"skip reason should be ResourceGone when post-action 404 overwrites it")
+	// SkipReason gets overwritten to ResourceNotFound (resource no longer exists, overrides PreconditionFailed)
+	assert.Equal(t, ResourceNotFoundReason, result.SkipReason,
+		"skip reason should be ResourceNotFound when post-action 404 overwrites it")
 	assert.True(t, result.ResourcesSkipped, "resources should be skipped")
 
 	// The precondition error should still be recorded

--- a/test/integration/executor/executor_integration_test.go
+++ b/test/integration/executor/executor_integration_test.go
@@ -527,8 +527,8 @@ func TestExecutor_PreconditionNotFound_GracefulStop(t *testing.T) {
 	assert.Equal(t, executor.StatusSuccess, result.Status,
 		"404 on force-deleted resource should not mark execution as failed")
 	assert.True(t, result.ResourcesSkipped, "resources should be skipped")
-	assert.Equal(t, executor.ResourceGoneReason, result.SkipReason,
-		"skip reason should be ResourceGone")
+	assert.Equal(t, executor.ResourceNotFoundReason, result.SkipReason,
+		"skip reason should be ResourceNotFound")
 	assert.Empty(t, result.Errors, "no errors should be recorded for a 404")
 	assert.Empty(t, result.ResourceResults, "no resources should be processed")
 	assert.Empty(t, result.PostActionResults, "no post-actions should be attempted")
@@ -550,8 +550,8 @@ func TestExecutor_PostActionNotFound_GracefulHandling(t *testing.T) {
 	assert.Equal(t, executor.StatusSuccess, result.Status,
 		"404 on post-action should not mark execution as failed")
 	assert.True(t, result.ResourcesSkipped, "resources should be skipped")
-	assert.Equal(t, executor.ResourceGoneReason, result.SkipReason,
-		"skip reason should be ResourceGone")
+	assert.Equal(t, executor.ResourceNotFoundReason, result.SkipReason,
+		"skip reason should be ResourceNotFound")
 	assert.Empty(t, result.Errors, "no errors should be recorded for a post-action 404")
 
 	t.Logf("Post-action 404 handled gracefully: skipReason=%s", result.SkipReason)


### PR DESCRIPTION
## Summary

Follow-up to the initial 404 graceful handling implementation ([HYPERFLEET-1042](https://issues.redhat.com/browse/HYPERFLEET-1042)). Renames the internal `ResourceGoneReason` constant to `ResourceNotFoundReason` to align with HTTP 404 ("Not Found") semantics rather than HTTP 410 ("Gone"), since the API returns 404 for force-deleted resources.

## Changes

- Renamed `ResourceGoneReason` constant to `ResourceNotFoundReason` and updated the string value from `"ResourceGone"` to `"ResourceNotFound"` across the executor and dry-run packages
- Updated display text from `"RESOURCE GONE"` to `"RESOURCE NOT FOUND"` in trace output formatting
- Updated all unit and integration test assertions to match the renamed constant and display text


## Test Plan

- [x] Unit tests added/updated
- [x] `make test-all` passes (envtest integration failures are pre-existing, not from this PR)
- [x] `make lint` passes
- [ ] Helm chart changes validated with `make test-helm` (if applicable)
- [ ] Deployed to a development cluster and verified (if Helm/config changes)
- [ ] E2E tests passed (if cross-component or major changes)


[HYPERFLEET-1042]: https://redhat.atlassian.net/browse/HYPERFLEET-1042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ