### PR TITLE
HYPERFLEET-1042 - test: add dry-run fixtures for 404 graceful handling

### DIFF
--- a/test/testdata/dryrun/dryrun-404-api-responses.json
+++ b/test/testdata/dryrun/dryrun-404-api-responses.json
@@ -1,0 +1,46 @@
+{
+  "responses": [
+    {
+      "match": {
+        "method": "GET",
+        "urlPattern": "/api/hyperfleet/v1/clusters/.*"
+      },
+      "responses": [
+        {
+          "statusCode": 404,
+          "headers": {
+            "Content-Type": "application/json"
+          },
+          "body": {
+            "kind": "Error",
+            "id": "404",
+            "href": "/api/hyperfleet/v1/errors/404",
+            "code": "HYPERFLEET-NTF-001",
+            "reason": "Cluster 'abc123' not found"
+          }
+        }
+      ]
+    },
+    {
+      "match": {
+        "method": "PUT",
+        "urlPattern": "/api/hyperfleet/v1/clusters/.*/statuses"
+      },
+      "responses": [
+        {
+          "statusCode": 404,
+          "headers": {
+            "Content-Type": "application/json"
+          },
+          "body": {
+            "kind": "Error",
+            "id": "404",
+            "href": "/api/hyperfleet/v1/errors/404",
+            "code": "HYPERFLEET-NTF-001",
+            "reason": "Cluster 'abc123' not found"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/testdata/dryrun/dryrun-post-action-404-api-responses.json
+++ b/test/testdata/dryrun/dryrun-post-action-404-api-responses.json
@@ -1,0 +1,61 @@
+{
+  "responses": [
+    {
+      "match": {
+        "method": "GET",
+        "urlPattern": "/api/hyperfleet/v1/clusters/.*"
+      },
+      "responses": [
+        {
+          "statusCode": 200,
+          "headers": {
+            "Content-Type": "application/json"
+          },
+          "body": {
+            "id": "abc-123",
+            "name": "abc123",
+            "kind": "Cluster",
+            "href": "/api/hyperfleet/v1/clusters/abc123",
+            "generation": "77",
+            "nodes": {
+              "compute": 3
+            },
+            "spec": {
+              "region": "us-east-1",
+              "provider": "aws"
+            },
+            "status": {
+              "conditions": [
+                {
+                  "type": "Reconciled",
+                  "status": "False"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "match": {
+        "method": "PUT",
+        "urlPattern": "/api/hyperfleet/v1/clusters/.*/statuses"
+      },
+      "responses": [
+        {
+          "statusCode": 404,
+          "headers": {
+            "Content-Type": "application/json"
+          },
+          "body": {
+            "kind": "Error",
+            "id": "404",
+            "href": "/api/hyperfleet/v1/errors/404",
+            "code": "HYPERFLEET-NTF-001",
+            "reason": "Cluster 'abc123' not found"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
[HYPERFLEET-1042](https://issues.redhat.com/browse/HYPERFLEET-1042)

## Test Plan

- [ ] Unit tests added/updated
- [ ] `make test-all` passes
- [ ] `make lint` passes
- [ ] Helm chart changes validated with `make test-helm` (if applicable)
- [ ] Deployed to a development cluster and verified (if Helm/config changes)
- [ ] E2E tests passed (if cross-component or major changes)


[HYPERFLEET-1042]: https://redhat.atlassian.net/browse/HYPERFLEET-1042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ