### PR TITLE
HYPERFLEET-1056 - fix: Allow external files in adapter task configmap

### DIFF
--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -137,10 +137,14 @@ true
 {{- if .Values.adapterTaskConfig.create -}}
   {{- $hasYaml := not (empty .Values.adapterTaskConfig.yaml) -}}
   {{- $hasFiles := not (empty .Values.adapterTaskConfig.files) -}}
-  {{- if or $hasYaml $hasFiles -}}
+  {{- $hasExternal := not (empty .Values.adapterTaskConfig.external) -}}
+  {{- if and $hasYaml (or $hasFiles $hasExternal) -}}
+{{- fail "Cannot set .Values.adapterTaskConfig.yaml with .Values.adapterTaskConfig.files or .Values.adapterTaskConfig.external - these modes are mutually exclusive." -}}
+  {{- end -}}
+  {{- if or $hasYaml $hasFiles $hasExternal -}}
 true
   {{- else -}}
-{{- fail "When .Values.adapterTaskConfig.create is true, either .Values.adapterTaskConfig.yaml or .Values.adapterTaskConfig.files must be provided." -}}
+{{- fail "When .Values.adapterTaskConfig.create is true, at least one of .Values.adapterTaskConfig.yaml, .Values.adapterTaskConfig.files, or .Values.adapterTaskConfig.external must be provided." -}}
   {{- end -}}
 {{- else if (hasKey .Values.adapterTaskConfig "configMapName") -}}
   {{- if and .Values.adapterTaskConfig.configMapName (ne .Values.adapterTaskConfig.configMapName "") -}}
@@ -295,4 +299,28 @@ googlepubsub
 {{- else if .Values.broker.rabbitmq -}}
 rabbitmq
 {{- end -}}
+{{- end }}
+
+
+{{/*
+Validate no key collisions between adapterTaskConfig.external and adapterTaskConfig.files
+Also validate that all file paths in adapterTaskConfig.files actually exist
+*/}}
+{{- define "hyperfleet-adapter.validateTaskConfigKeys" -}}
+{{- if and .Values.adapterTaskConfig.external .Values.adapterTaskConfig.files }}
+  {{- range $name, $value := .Values.adapterTaskConfig.external }}
+    {{- $externalKey := printf "%s.yaml" $name }}
+    {{- if hasKey $.Values.adapterTaskConfig.files $externalKey }}
+      {{- fail (printf "ConfigMap key collision: '%s' exists in both adapterTaskConfig.external and adapterTaskConfig.files" $externalKey) }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- if .Values.adapterTaskConfig.files }}
+  {{- range $key, $path := .Values.adapterTaskConfig.files }}
+    {{- $content := $.Files.Get $path }}
+    {{- if not $content }}
+      {{- fail (printf "adapterTaskConfig.files.%s: file not found or empty at path '%s'" $key $path) }}
+    {{- end }}
+  {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/templates/configmap-adapter-task.yaml
+++ b/charts/templates/configmap-adapter-task.yaml
@@ -1,4 +1,7 @@
+
+
 {{- if .Values.adapterTaskConfig.create }}
+{{- include "hyperfleet-adapter.validateTaskConfigKeys" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -16,9 +19,17 @@ data:
 {{ toYaml .Values.adapterTaskConfig.yaml | nindent 4 }}
     {{- end }}
   {{- else }}
-    {{- range $key, $path := .Values.adapterTaskConfig.files }}
+  {{- if .Values.adapterTaskConfig.external }}
+  {{- range $name, $value := .Values.adapterTaskConfig.external }}
+  {{ $name }}.yaml: |
+{{ $value | nindent 4 }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.adapterTaskConfig.files }}
+  {{- range $key, $path := .Values.adapterTaskConfig.files }}
   {{ $key }}: |
-    {{ $.Files.Get $path | nindent 4 }}
-    {{- end }}
+{{ $.Files.Get $path | nindent 4 }}
+  {{- end }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -32,21 +32,34 @@ adapterConfig:
     level: info
 # AdapterTaskConfig (business logic) can be created:
 # - option1: from an existing ConfigMap by setting configMapName
-# - option2: from a YAML file by setting yaml
-# - option3: from a set of files by setting files
+# - option2: from inline YAML by setting yaml (mutually exclusive with files/external)
+# - option3: from chart-packaged files by setting files (can be combined with external)
+# - option4: from external content by setting external (can be combined with files)
 adapterTaskConfig:
   create: true
   # option1: ConfigMap name (if different from default, and set create: false)
   #configMapName: ""
 
   # option2: AdapterTaskConfig YAML (creates task-config.yaml key in ConfigMap)
+  # Mutually exclusive with files and external
   # yaml:
-  #  params: []
-  #  resources: []
+  #   params: []
+  #   resources: []
 
   # option3: AdapterTaskConfig YAML files packaged with the chart
+  # Files are loaded from the chart directory via $.Files.Get
+  # Can be combined with external for site-specific overrides
   # files:
-  # task-config.yaml: examples/kubernetes/adapter-task-config.yaml
+  #   task-config.yaml: examples/kubernetes/adapter-task-config.yaml
+
+  # option4: External content passed in (e.g., via --set-file)
+  # Creates ConfigMap keys as <name>.yaml with the provided content
+  # Can be combined with files (collision detection enforced)
+  # external:
+  #   myconfig: |
+  #     params: []
+  #     resources: []
+  # Or use: --set-file adapterTaskConfig.external.myconfig=/path/to/config.yaml
 affinity: {}
 # Override default args
 args:


### PR DESCRIPTION
## Summary

Adds support for external configuration files in the adapter task ConfigMap to enable site-specific overrides without modifying the chart. Previously, adapter task configs could only be provided via inline YAML or chart-bundled files, making it difficult to inject environment-specific configurations at deployment time. This change introduces a new `adapterTaskConfig.external` field that accepts external content via `--set-file`, allowing operators to combine chart-bundled templates with site-specific configs while preventing key collisions through validation.

## Jira Issue
[HYPERFLEET-1056](https://redhat.atlassian.net/browse/HYPERFLEET-1056)

## Changes
- Added `adapterTaskConfig.external` field to values.yaml as a sibling to `files` (not nested under it)
- External configs are rendered as `<name>.yaml` keys in the ConfigMap and can be passed via `--set-file adapterTaskConfig.external.myconfig=/path/to/file.yaml`
- `adapterTaskConfig.yaml` is now mutually exclusive with both `files` and `external` (enforced via validation)
- `adapterTaskConfig.files` and `adapterTaskConfig.external` can be used together for combining chart-bundled and site-specific configs
- Added `hyperfleet-adapter.validateTaskConfigKeys` helper template that validates:
  - No ConfigMap key collisions between `external` (rendered as `<name>.yaml`) and `files` keys
  - All file paths in `adapterTaskConfig.files` actually exist in the chart (prevents silent failures from typos)
- Updated `helmValidateAdapterTaskIsConfigured` to include external in validation logic
- Updated values.yaml documentation to explain all four configuration modes and their compatibility rules

## Notes

This change is fully backward compatible. Existing Helm values that reference chart-local files (e.g., `adapterTaskConfig.files.config: "configs/my-config.yaml"`) will continue to work exactly as before.
[HYPERFLEET-1056]: https://redhat.atlassian.net/browse/HYPERFLEET-1056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Test Plan
- [x] Helm chart changes validated with `make test-helm`
- [x] Manually tested collision detection with overlapping keys
- [x] Manually tested `--set-file adapterTaskConfig.external.myconfig=<path>` rendering