### PR TITLE
HYPERFLEET-1203 - fix: skip version validation for non-semver versions

### DIFF
--- a/cmd/adapter/main.go
+++ b/cmd/adapter/main.go
@@ -234,6 +234,8 @@ func loadConfig(ctx context.Context, log logger.Logger, flags *pflag.FlagSet) (*
 		configloader.WithTaskConfigPath(taskConfigPath),
 		configloader.WithAdapterVersion(version.Version),
 		configloader.WithFlags(flags),
+		configloader.WithContext(ctx),
+		configloader.WithLogger(log),
 	)
 	if err != nil {
 		errCtx := logger.WithErrorField(ctx, err)

--- a/internal/configloader/loader.go
+++ b/internal/configloader/loader.go
@@ -1,10 +1,12 @@
 package configloader
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/logger"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/utils"
 	"gopkg.in/yaml.v3"
 )
@@ -30,9 +32,11 @@ var ValidHTTPMethods = []string{"GET", "POST", "PUT", "PATCH", "DELETE"}
 type LoadOption func(*loadOptions)
 
 type loadOptions struct {
+	flags                  interface{} // *pflag.FlagSet
+	ctx                    context.Context
+	logger                 logger.Logger
 	adapterConfigPath      string
 	taskConfigPath         string
-	flags                  interface{} // *pflag.FlagSet
 	adapterVersion         string
 	skipSemanticValidation bool
 }
@@ -72,6 +76,20 @@ func WithSkipSemanticValidation() LoadOption {
 	}
 }
 
+// WithContext sets the context for logging during config loading
+func WithContext(ctx context.Context) LoadOption {
+	return func(o *loadOptions) {
+		o.ctx = ctx
+	}
+}
+
+// WithLogger sets the logger for config loading
+func WithLogger(l logger.Logger) LoadOption {
+	return func(o *loadOptions) {
+		o.logger = l
+	}
+}
+
 // -----------------------------------------------------------------------------
 // Public API
 // -----------------------------------------------------------------------------
@@ -83,6 +101,16 @@ func LoadConfig(opts ...LoadOption) (*Config, error) {
 	o := &loadOptions{}
 	for _, opt := range opts {
 		opt(o)
+	}
+	if o.ctx == nil {
+		o.ctx = context.Background()
+	}
+	if o.logger == nil {
+		var logErr error
+		o.logger, logErr = logger.NewLogger(logger.DefaultConfig())
+		if logErr != nil {
+			return nil, fmt.Errorf("failed to create logger: %w", logErr)
+		}
 	}
 
 	// 1. Load AdapterConfig with Viper (env/CLI overrides)
@@ -106,7 +134,7 @@ func LoadConfig(opts ...LoadOption) (*Config, error) {
 
 	// Validate adapter version if specified
 	if o.adapterVersion != "" {
-		if err = ValidateAdapterVersion(adapterCfg, o.adapterVersion); err != nil {
+		if err = ValidateAdapterVersion(o.ctx, o.logger, adapterCfg, o.adapterVersion); err != nil {
 			return nil, fmt.Errorf("adapter version validation failed: %w", err)
 		}
 	}

--- a/internal/configloader/loader_test.go
+++ b/internal/configloader/loader_test.go
@@ -1,6 +1,8 @@
 package configloader
 
 import (
+	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,6 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
+
+	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/logger"
 )
 
 const testAdapterConfigYAML = `
@@ -521,6 +525,9 @@ func TestGetPreconditionByName(t *testing.T) {
 }
 
 func TestValidateAdapterVersion(t *testing.T) {
+	ctx := context.Background()
+	log := newTestLogger(nil)
+
 	config := &AdapterConfig{
 		Adapter: AdapterInfo{
 			Name:    "test-adapter",
@@ -529,35 +536,35 @@ func TestValidateAdapterVersion(t *testing.T) {
 	}
 
 	// Exact match
-	err := ValidateAdapterVersion(config, "1.0.0")
+	err := ValidateAdapterVersion(ctx, log, config, "1.0.0")
 	assert.NoError(t, err)
 
 	// Patch version differs - should pass (bug fix release)
-	err = ValidateAdapterVersion(config, "1.0.5")
+	err = ValidateAdapterVersion(ctx, log, config, "1.0.5")
 	assert.NoError(t, err)
 
 	// Minor version differs - should fail
-	err = ValidateAdapterVersion(config, "1.1.0")
+	err = ValidateAdapterVersion(ctx, log, config, "1.1.0")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "adapter version mismatch")
 
 	// Major version differs - should fail
-	err = ValidateAdapterVersion(config, "2.0.0")
+	err = ValidateAdapterVersion(ctx, log, config, "2.0.0")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "adapter version mismatch")
 
 	// Empty expected version (skip validation)
-	err = ValidateAdapterVersion(config, "")
+	err = ValidateAdapterVersion(ctx, log, config, "")
 	assert.NoError(t, err)
 
 	// Dev build versions (0.0.0-* skip validation)
-	err = ValidateAdapterVersion(config, "0.0.0-dev")
+	err = ValidateAdapterVersion(ctx, log, config, "0.0.0-dev")
 	assert.NoError(t, err)
 
-	err = ValidateAdapterVersion(config, "0.0.0-master")
+	err = ValidateAdapterVersion(ctx, log, config, "0.0.0-master")
 	assert.NoError(t, err)
 
-	err = ValidateAdapterVersion(config, "v0.0.0-dev")
+	err = ValidateAdapterVersion(ctx, log, config, "v0.0.0-dev")
 	assert.NoError(t, err)
 
 	// Empty config version (not provided in adapter config - skip validation)
@@ -566,28 +573,71 @@ func TestValidateAdapterVersion(t *testing.T) {
 			Name: "test-adapter",
 		},
 	}
-	err = ValidateAdapterVersion(noVersionConfig, "1.0.0")
+	err = ValidateAdapterVersion(ctx, log, noVersionConfig, "1.0.0")
 	assert.NoError(t, err)
 
 	// Pre-release version with same major.minor - should pass
-	err = ValidateAdapterVersion(config, "1.0.1-rc.1")
+	err = ValidateAdapterVersion(ctx, log, config, "1.0.1-rc.1")
 	assert.NoError(t, err)
 
-	// Invalid config version
+	// Non-semver config version - should warn and skip validation
 	invalidConfig := &AdapterConfig{
 		Adapter: AdapterInfo{
 			Name:    "test-adapter",
 			Version: "not-a-version",
 		},
 	}
-	err = ValidateAdapterVersion(invalidConfig, "1.0.0")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid config adapter version")
+	var buf bytes.Buffer
+	logWithCapture := newTestLogger(&buf)
 
-	// Invalid expected version
-	err = ValidateAdapterVersion(config, "not-a-version")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid expected adapter version")
+	err = ValidateAdapterVersion(ctx, logWithCapture, invalidConfig, "1.0.0")
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), "Skipping adapter version validation")
+	assert.Contains(t, buf.String(), "config version is not valid semver")
+
+	// Non-semver binary version - should warn and skip validation
+	buf.Reset()
+	err = ValidateAdapterVersion(ctx, logWithCapture, config, "not-a-version")
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), "Skipping adapter version validation")
+	assert.Contains(t, buf.String(), "binary version is not valid semver")
+
+	// Non-semver binary version "dev" (Konflux pipeline case)
+	buf.Reset()
+	err = ValidateAdapterVersion(ctx, logWithCapture, config, "dev")
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), "Skipping adapter version validation")
+	assert.Contains(t, buf.String(), "binary version is not valid semver")
+
+	// Non-semver config version with valid binary version
+	devConfig := &AdapterConfig{
+		Adapter: AdapterInfo{
+			Name:    "test-adapter",
+			Version: "dev",
+		},
+	}
+	buf.Reset()
+	err = ValidateAdapterVersion(ctx, logWithCapture, devConfig, "1.0.0")
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), "Skipping adapter version validation")
+	assert.Contains(t, buf.String(), "config version is not valid semver")
+
+	// Both versions non-semver (config parse fails first, so only config warning emitted)
+	buf.Reset()
+	err = ValidateAdapterVersion(ctx, logWithCapture, devConfig, "latest")
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), "Skipping adapter version validation")
+	assert.Contains(t, buf.String(), "config version is not valid semver")
+}
+
+func newTestLogger(buf *bytes.Buffer) logger.Logger {
+	cfg := logger.DefaultConfig()
+	cfg.Format = "text"
+	if buf != nil {
+		cfg.Writer = buf
+	}
+	l, _ := logger.NewLogger(cfg)
+	return l
 }
 
 func TestValidateFileReferencesInTaskConfig(t *testing.T) {

--- a/internal/configloader/validator.go
+++ b/internal/configloader/validator.go
@@ -1,6 +1,7 @@
 package configloader
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/criteria"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/manifest"
+	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/logger"
 )
 
 // templateVarRegex matches Go template variables like {{ .varName }} or {{ .nested.var }}
@@ -637,7 +639,9 @@ func isSliceOrArray(value interface{}) bool {
 // with the expected adapter version. Only major and minor versions are compared;
 // patch version differences are allowed (patch releases are bug fixes only).
 // For example, config "1.2.0" is compatible with adapter "1.2.3".
-func ValidateAdapterVersion(config *AdapterConfig, expectedVersion string) error {
+func ValidateAdapterVersion(
+	ctx context.Context, log logger.Logger, config *AdapterConfig, expectedVersion string,
+) error {
 	if expectedVersion == "" {
 		return nil
 	}
@@ -649,12 +653,18 @@ func ValidateAdapterVersion(config *AdapterConfig, expectedVersion string) error
 
 	configSemver, err := semver.NewVersion(configVersion)
 	if err != nil {
-		return fmt.Errorf("invalid config adapter version %q: %w", configVersion, err)
+		ctx = logger.WithLogField(ctx, "version", configVersion)
+		ctx = logger.WithErrorField(ctx, err)
+		log.Warn(ctx, "Skipping adapter version validation: config version is not valid semver")
+		return nil
 	}
 
 	expectedSemver, err := semver.NewVersion(expectedVersion)
 	if err != nil {
-		return fmt.Errorf("invalid expected adapter version %q: %w", expectedVersion, err)
+		ctx = logger.WithLogField(ctx, "version", expectedVersion)
+		ctx = logger.WithErrorField(ctx, err)
+		log.Warn(ctx, "Skipping adapter version validation: binary version is not valid semver")
+		return nil
 	}
 
 	// Skip validation for dev builds (0.0.0-*) where major, minor, and patch are all zero


### PR DESCRIPTION
## Summary
- The adapter crashed on startup when either the config or binary version was not valid semver (e.g. Konflux setting `APP_VERSION=dev`)
- Changed `ValidateAdapterVersion` to log a warning via `slog.Warn` and continue startup instead of returning a hard error when `semver.NewVersion()` fails to parse either version string
- When both versions ARE valid semver, the existing major.minor comparison logic remains unchanged

## Test plan
- [x] Existing tests updated: invalid version cases now expect no error (warn + skip)
- [x] New test cases: non-semver binary version (`"dev"`), non-semver config version, both non-semver
- [x] `make test` passes (all unit tests green)
- [ ] Verify with Konflux/Quay image that sets `APP_VERSION=dev` and a config with `adapter.version: "0.2.0"`

Fixes: https://redhat.atlassian.net/browse/HYPERFLEET-1203

🤖 Generated with [Claude Code](https://claude.com/claude-code)