### PR TITLE
HYPERFLEET-1206 - fix: make rabbitmq.queue optional in Helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,9 +243,7 @@ test-helm: ## Test Helm charts (lint, template, validate)
 		--set broker.create=true \
 		--set broker.type=rabbitmq \
 		--set broker.rabbitmq.url=amqp://guest:guest@rabbitmq:5672/ \
-		--set broker.rabbitmq.queue=test-queue \
-		--set broker.rabbitmq.exchange=test-exchange \
-		--set broker.rabbitmq.routingKey=test-key) \
+		--set broker.rabbitmq.exchange=test-exchange) \
 		&& echo "$$output" | grep -q 'type: rabbitmq' \
 		|| { echo "ERROR: expected rabbitmq broker type in rendered output"; exit 1; }
 	@echo "RabbitMQ broker template OK"
@@ -260,9 +258,7 @@ test-helm: ## Test Helm charts (lint, template, validate)
 		--set broker.create=true \
 		--set broker.type=rabbitmq \
 		--set broker.rabbitmq.url=amqp://guest:guest@rabbitmq:5672/ \
-		--set broker.rabbitmq.queue=test-queue \
 		--set broker.rabbitmq.exchange=test-exchange \
-		--set broker.rabbitmq.routingKey=test-key \
 		--set broker.googlepubsub.projectId=my-project \
 		--set broker.googlepubsub.topic=my-topic \
 		--set broker.googlepubsub.subscriptionId=my-sub) \
@@ -270,8 +266,8 @@ test-helm: ## Test Helm charts (lint, template, validate)
 		|| { echo "ERROR: expected rabbitmq broker type in output"; exit 1; }
 	@echo "RabbitMQ broker type selection OK"
 	@echo ""
-	@echo "Testing that rabbitmq without queue fails validation..."
-	@if helm template test-release charts/ \
+	@echo "Testing that rabbitmq renders OK without queue (queue is optional)..."
+	@helm template test-release charts/ \
 		--set image.registry=quay.io \
 		--set image.repository=openshift-hyperfleet/hyperfleet-adapter \
 		--set image.tag=test \
@@ -279,10 +275,10 @@ test-helm: ## Test Helm charts (lint, template, validate)
 		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
 		--set broker.create=true \
 		--set broker.type=rabbitmq \
-		--set broker.rabbitmq.url=amqp://guest:guest@rabbitmq:5672/ > /dev/null 2>&1; then \
-		echo "ERROR: expected helm template to fail when broker.rabbitmq.queue is missing"; exit 1; \
-	fi
-	@echo "RabbitMQ missing queue validation OK"
+		--set broker.rabbitmq.url=amqp://guest:guest@rabbitmq:5672/ \
+		--set broker.rabbitmq.exchange=test-exchange > /dev/null \
+		|| { echo "ERROR: helm template failed when broker.rabbitmq.queue is omitted (queue should be optional)"; exit 1; }
+	@echo "RabbitMQ optional queue validation OK"
 	@echo ""
 	@echo "Testing that rabbitmq without exchange fails validation..."
 	@if helm template test-release charts/ \
@@ -298,22 +294,6 @@ test-helm: ## Test Helm charts (lint, template, validate)
 		echo "ERROR: expected helm template to fail when broker.rabbitmq.exchange is missing"; exit 1; \
 	fi
 	@echo "RabbitMQ missing exchange validation OK"
-	@echo ""
-	@echo "Testing that rabbitmq without routingKey fails validation..."
-	@if helm template test-release charts/ \
-		--set image.registry=quay.io \
-		--set image.repository=openshift-hyperfleet/hyperfleet-adapter \
-		--set image.tag=test \
-		--set adapterConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
-		--set adapterTaskConfig.yaml="apiVersion: hyperfleet.redhat.com/v1alpha1" \
-		--set broker.create=true \
-		--set broker.type=rabbitmq \
-		--set broker.rabbitmq.url=amqp://guest:guest@rabbitmq:5672/ \
-		--set broker.rabbitmq.queue=test-queue \
-		--set broker.rabbitmq.exchange=test-exchange > /dev/null 2>&1; then \
-		echo "ERROR: expected helm template to fail when broker.rabbitmq.routingKey is missing"; exit 1; \
-	fi
-	@echo "RabbitMQ missing routingKey validation OK"
 
 ##@ Code Quality
 

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -259,9 +259,6 @@ Per Helm Chart Conventions Standard section 9 (Deprecation and Migration Pattern
 {{- end -}}
 {{- end -}}
 {{- if .Values.broker.rabbitmq }}
-{{- if hasKey .Values.broker.rabbitmq "routing_key" }}
-{{- fail "broker.rabbitmq.routing_key has been renamed to broker.rabbitmq.routingKey (camelCase). Please update your values." }}
-{{- end -}}
 {{- if hasKey .Values.broker.rabbitmq "exchange_type" }}
 {{- fail "broker.rabbitmq.exchange_type has been renamed to broker.rabbitmq.exchangeType (camelCase). Please update your values." }}
 {{- end -}}
@@ -304,14 +301,8 @@ Validate that required fields are set for the resolved broker type.
   {{- if not .Values.broker.rabbitmq.url -}}
     {{- fail "broker.rabbitmq.url is required when broker type is rabbitmq" -}}
   {{- end -}}
-  {{- if not .Values.broker.rabbitmq.queue -}}
-    {{- fail "broker.rabbitmq.queue is required when broker type is rabbitmq" -}}
-  {{- end -}}
   {{- if not .Values.broker.rabbitmq.exchange -}}
     {{- fail "broker.rabbitmq.exchange is required when broker type is rabbitmq" -}}
-  {{- end -}}
-  {{- if not .Values.broker.rabbitmq.routingKey -}}
-    {{- fail "broker.rabbitmq.routingKey is required when broker type is rabbitmq" -}}
   {{- end -}}
 {{- end -}}
 {{- end }}

--- a/charts/templates/configmap-broker.yaml
+++ b/charts/templates/configmap-broker.yaml
@@ -50,7 +50,6 @@ data:
         url: {{ .Values.broker.rabbitmq.url | quote }}
         queue: {{ .Values.broker.rabbitmq.queue | quote }}
         exchange: {{ .Values.broker.rabbitmq.exchange | quote }}
-        routing_key: {{ .Values.broker.rabbitmq.routingKey | quote }}
         exchange_type: {{ .Values.broker.rabbitmq.exchangeType | default "topic" | quote }}
   {{- end }}
   {{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -99,10 +99,10 @@ broker:
     createSubscriptionIfMissing: false
   rabbitmq:
     url: ""
-    queue: ""
+    queue: ""        # optional prefix {queue}-{subscription_id} — if omitted, queue name is derived as "{topic}-{subscriptionId}"
     exchange: ""
     exchangeType: "topic"
-    routingKey: ""
+
 # Override default command
 command:
   - /app/adapter

--- a/docs/adapter-authoring-guide.md
+++ b/docs/adapter-authoring-guide.md
@@ -1487,17 +1487,29 @@ clients:
     retry_attempts: 3
     retry_backoff: exponential
   broker:
-    subscription_id: "my-adapter-sub"
-    topic: "cluster-events"
+    subscription_id: "my-adapter"   # must be unique per adapter — shared IDs cause competing consumers, not fan-out
+    topic: "hyperfleet-clusters"    # for RabbitMQ: queue name prefix only (not a routing key)
   kubernetes:
     api_version: "v1"
 ```
 
 </details>
 
+1. **Configure the broker connection** — the Helm chart creates a `broker.yaml` ConfigMap from the `broker.*` Helm values. For RabbitMQ, set `broker.rabbitmq.exchange` to the value of the sentinel's `clients.broker.topic` — this is the exchange the sentinel publishes to and the only coupling point between them.
+
+   ```yaml
+   # Helm values
+   broker:
+     type: rabbitmq
+     rabbitmq:
+       url: "amqp://user:pass@rabbitmq:5672/"
+       exchange: "hyperfleet-clusters"   # must match sentinel's clients.broker.topic
+       exchange_type: "topic"
+   ```
+
 1. **Deploy using the Helm chart** — the generic `adapter/` chart mounts your task config as a ConfigMap and sets the environment variables.
 
-2. **Set up broker subscription** — ensure your adapter has a dedicated subscription on the cluster events topic so it receives events independently of other adapters (fan-out pattern).
+2. **Set up broker subscription** — for Google Pub/Sub, ensure your adapter has a dedicated subscription on the cluster events topic so it receives events independently of other adapters (fan-out pattern). For RabbitMQ, fan-out is achieved automatically by giving each adapter a unique `subscription_id` — the broker library creates a separate queue per adapter.
 
 3. Set permissions for the adapter to read from the broker subscription. This is cloud provider specific.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -115,8 +115,59 @@ clients:
 
 ### Broker (`clients.broker`)
 
-- `subscription_id` (string): Broker subscription ID (required at runtime).
-- `topic` (string): Broker topic (required at runtime).
+These fields appear in the **adapter deployment config** and control which events the adapter consumes. The actual broker connection details (URL, credentials, exchange) live in a separate `broker.yaml` file managed by the Helm chart.
+
+- `subscription_id` (string, required): A unique identifier for this adapter instance's subscription. **Must be unique across adapter instances** that should each receive all events independently (fan-out). Two adapters with the same `subscription_id` and same queue name will share a queue and compete for messages — each event goes to only one of them.
+- `topic` (string, required): For RabbitMQ, this is the AMQP queue name prefix (not a routing key — see below). Set it to a meaningful value that identifies this adapter's event stream (e.g. `hyperfleet-clusters`). For Google Pub/Sub this is the Pub/Sub topic name.
+
+Set these values directly in the adapter config YAML. The env var overrides (`HYPERFLEET_BROKER_SUBSCRIPTION_ID`, `HYPERFLEET_BROKER_TOPIC`) exist as an escape hatch but are not required — values in the YAML take effect without them.
+
+### Broker connection config (`broker.yaml`)
+
+The broker connection is configured separately, via a mounted `broker.yaml` (or the Helm `broker.*` values). This file is read by the hyperfleet-broker library directly and **does not support Viper/env var overrides** — it is pure YAML.
+
+#### Google Pub/Sub
+
+```yaml
+broker:
+  type: googlepubsub
+  googlepubsub:
+    project_id: "my-gcp-project"
+    topic: "cluster-events"
+    subscription_id: "my-adapter-sub"
+    dead_letter_topic: ""            # optional
+    create_topic_if_missing: false
+    create_subscription_if_missing: false
+```
+
+#### RabbitMQ
+
+```yaml
+broker:
+  type: rabbitmq
+  rabbitmq:
+    url: "amqp://user:pass@rabbitmq:5672/"   # required; amqp:// or amqps://
+    exchange: "hyperfleet-clusters"           # required; must match sentinel's clients.broker.topic
+    exchange_type: "topic"                    # optional; default: topic
+    queue: "my-adapter"                       # optional; see queue naming below
+    prefetch_count: 0                         # optional; 0 = broker default
+    prefetch_size: 0                          # optional; 0 = no limit
+    consumer_tag: ""                          # optional; auto-assigned if empty
+    publisher_confirm: false                  # optional; enable publisher confirms
+```
+
+**Connecting to the sentinel.** The sentinel publishes events to a RabbitMQ exchange whose name equals the sentinel's `clients.broker.topic` (e.g. `hyperfleet-clusters`). The adapter's `broker.yaml` `exchange` field must match this value exactly — this is the only coupling point between sentinel and adapter.
+
+**Queue naming in RabbitMQ.** The adapter binds a queue to the exchange and consumes from it. The queue name is derived as:
+
+- If `queue` is set: `{queue}-{subscription_id}` (e.g. `my-adapter-adapter-1`)
+- If `queue` is omitted: `{topic}-{subscription_id}` (e.g. `hyperfleet-clusters-adapter-1`)
+
+The queue-to-exchange binding always uses an **empty routing key** — all queues bound to the same exchange receive all messages published to it.
+
+**Fan-out vs competing consumers.** Because queue name is derived from both `topic` and `subscription_id`, two adapters sharing the same values for both fields will land on the same queue and compete (each event goes to one adapter). Give each adapter instance a unique `subscription_id` in its adapter config YAML to ensure each gets an independent copy of every event.
+
+`url` and `exchange` are required. `queue` is optional.
 
 ### Kubernetes (`clients.kubernetes`)
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -99,17 +99,23 @@ kubectl exec <pod> -- curl -s localhost:8080/readyz | jq .
 
 | Log Pattern | Cause | Resolution |
 |-------------|-------|------------|
-| `"Missing required broker configuration"` | `subscriptionId` or `topic` not set | Check broker ConfigMap and env vars |
+| `"Missing required broker configuration"` | `subscription_id` or `topic` not set in adapter config | Check adapter config ConfigMap; set values directly in YAML (not via env vars for RabbitMQ) |
 | `"Failed to create subscriber"` | Broker backend misconfiguration | Verify broker connection settings (Pub/Sub project, RabbitMQ URL) |
-| `"Failed to subscribe to topic"` | Topic doesn't exist or permissions denied | Verify topic exists and service account has subscribe permission |
+| `"Failed to subscribe to topic"` | Topic doesn't exist or permissions denied | Verify topic/exchange exists and adapter has access |
 | `"Subscription error"` | Transient broker error | Usually recovers; monitor for frequency |
 | `"Fatal subscription error, shutting down"` | Unrecoverable broker error | Check broker service health; adapter will restart via liveness probe |
 
 **Steps:**
-1. Check broker ConfigMap: `kubectl get configmap <release>-broker -o yaml`
-2. For Google Pub/Sub: verify subscription exists and IAM permissions
-3. For RabbitMQ: verify exchange, queue, and connectivity from the pod network
-4. Check if broker service is healthy independently
+1. Check broker ConfigMap: `kubectl get configmap <release>-hyperfleet-adapter-broker -o yaml`
+2. Check adapter config ConfigMap: `kubectl get configmap <release>-hyperfleet-adapter-config -o yaml`
+3. For Google Pub/Sub: verify subscription exists and IAM permissions
+4. For RabbitMQ:
+   - Verify `broker.yaml` `exchange` matches the sentinel's `clients.broker.topic` — this is the most common misconfiguration
+   - Verify `subscription_id` in the adapter config is unique per adapter instance (shared IDs cause competing consumers, not fan-out)
+   - Check the queue exists and is bound to the exchange: `rabbitmqctl list_bindings`
+   - Check the queue has consumers: `rabbitmqctl list_queues name messages consumers`
+   - Verify TCP connectivity to RabbitMQ from the pod network
+5. Check if broker service is healthy independently
 
 ---
 
@@ -250,9 +256,9 @@ Events are ACKed on failure and not automatically retried. To reprocess:
    gcloud pubsub topics publish <topic> --message '<event-json>'
    ```
 
-   For RabbitMQ:
+   For RabbitMQ (the adapter's queue binding uses an empty routing key, so publish with `routing_key=""`):
    ```bash
-   rabbitmqadmin publish exchange=<exchange> routing_key=<key> payload='<event-json>'
+   rabbitmqadmin publish exchange=<exchange> routing_key="" payload='<event-json>'
    ```
 3. Monitor `hyperfleet_adapter_events_processed_total` for the reprocessed event
 


### PR DESCRIPTION
Removes the hard Helm validation that required `broker.rabbitmq.queue` to be
  set when using RabbitMQ. The hyperfleet-broker library already has a
  well-defined fallback: when `queue` is omitted, the AMQP queue name is derived
  as `{topic}-{subscriptionId}`.

  Also expands `docs/configuration.md` to properly cover the RabbitMQ broker
  config — the section previously listed only `subscription_id` and `topic` with
  no mention of the broker connection config or queue naming semantics.

  ## Changes

  - `charts/templates/_helpers.tpl` — remove `fail` guard for
    `broker.rabbitmq.queue`; `url`, `exchange`, and `routingKey` remain required
  - `charts/values.yaml` — add inline comment on `queue` explaining the fallback
  - `docs/configuration.md` — add full RabbitMQ field reference, queue naming
    logic, and explanation of `subscription_id` fan-out vs. competing-consumer
    semantics