### PR TITLE
HYPERFLEET-1213 - ci: add Helm chart OCI build pipeline

### DIFF
--- a/.tekton/hyperfleet-adapter-chart-push.yaml
+++ b/.tekton/hyperfleet-adapter-chart-push.yaml
@@ -1,0 +1,244 @@
+# Helm chart OCI build pipeline (HYPERFLEET-1213).
+#
+# Hand-authored because Konflux's configure-pac generator only emits container
+# build pipelines; there is no generated Helm chart build. This references the
+# build-helm-chart-oci-ta task directly, modeled on konflux-ci/caching's
+# .tekton/squid-helm-push.yaml.
+#
+# IMAGE_MAPPINGS is intentionally omitted: the chart packages with its
+# values.yaml defaults as-is. Pinning the chart's image references to the
+# Konflux-built image is deferred to the chart values / release work.
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift-hyperfleet/hyperfleet-adapter?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: hyperfleet-charts
+    appstudio.openshift.io/component: hyperfleet-adapter-chart
+    pipelines.appstudio.openshift.io/type: build
+  name: hyperfleet-adapter-chart-on-push
+  namespace: hyperfleet-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/hyperfleet-tenant/hyperfleet/hyperfleet-adapter-chart:{{revision}}
+  - name: path-context
+    value: charts
+  pipelineSpec:
+    description: |
+      This pipeline is ideal for building Helm charts while maintaining trust after pipeline customization.
+    params:
+    - description: Source Repository URL
+      name: git-url
+      type: string
+    - default: ""
+      description: Revision of the Source Repository
+      name: revision
+      type: string
+    - description: Fully Qualified Output Image
+      name: output-image
+      type: string
+    - default: .
+      description: Path to the source code of an application's component from where
+        to build the chart.
+      name: path-context
+      type: string
+    - default: "false"
+      description: Skip checks against built image
+      name: skip-checks
+      type: string
+    - default: ""
+      description: Build dependencies to be prefetched by Cachi2
+      name: prefetch-input
+      type: string
+    - default: ""
+      description: Image tag expiration time, time values could be something like
+        1h, 2d, 3w for hours, days, and weeks, respectively.
+      name: image-expires-after
+      type: string
+    - default: "true"
+      description: Use the package registry proxy when prefetching dependencies
+      name: enable-package-registry-proxy
+      type: string
+    - default: .
+      description: Target directories to scan with SAST tools. Multiple values should
+        be separated with commas.
+      name: sast-target-dirs
+      type: string
+    results:
+    - description: OCI artifact URL of the built Helm chart
+      name: IMAGE_URL
+      value: $(tasks.build-helm-chart.results.IMAGE_URL)
+    - description: Digest of the built Helm chart OCI artifact
+      name: IMAGE_DIGEST
+      value: $(tasks.build-helm-chart.results.IMAGE_DIGEST)
+    - description: Source repository URL, consumed by Tekton Chains for provenance
+      name: CHAINS-GIT_URL
+      value: $(tasks.clone-repository.results.url)
+    - description: Source commit SHA, consumed by Tekton Chains for provenance
+      name: CHAINS-GIT_COMMIT
+      value: $(tasks.clone-repository.results.commit)
+    tasks:
+    - name: init
+      taskRef:
+        params:
+        - name: name
+          value: init
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:5a423246792ac501ea279229b42ee57da9927da441c04b5c9ff86817b0856b08
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: clone-repository
+      params:
+      - name: url
+        value: $(params.git-url)
+      - name: revision
+        value: $(params.revision)
+      - name: ociStorage
+        value: $(params.output-image).git
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - init
+      taskRef:
+        params:
+        - name: name
+          value: git-clone-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:d30f13dd15daf89dd6dc645243b3444d35570d13f7840c3fd65e366022515205
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: basic-auth
+        workspace: git-auth
+    - name: prefetch-dependencies
+      params:
+      - name: input
+        value: $(params.prefetch-input)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      - name: enable-package-registry-proxy
+        value: $(params.enable-package-registry-proxy)
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: prefetch-dependencies-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:3dc78afbf3a441e0280067433cb28ea3d2d0088ec214c73bf063f145b4f273ef
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: git-basic-auth
+        workspace: git-auth
+      - name: netrc
+        workspace: netrc
+    - name: build-helm-chart
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: CHART_CONTEXT
+        value: $(params.path-context)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+      - prefetch-dependencies
+      taskRef:
+        params:
+        - name: name
+          value: build-helm-chart-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-build-helm-chart-oci-ta:0.3@sha256:d3d7e1892617fb1c057f1910715cb8bb4f980f43135ab482e88d0299effdc473
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: sast-shell-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-helm-chart.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-helm-chart.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: TARGET_DIRS
+        value: $(params.sast-target-dirs)
+      runAfter:
+      - build-helm-chart
+      taskRef:
+        params:
+        - name: name
+          value: sast-shell-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:3cbb3535af6e7d4396858179a6427caaffb2e68775594795692fc01f28ae313f
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-unicode-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-helm-chart.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-helm-chart.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: TARGET_DIRS
+        value: $(params.sast-target-dirs)
+      runAfter:
+      - build-helm-chart
+      taskRef:
+        params:
+        - name: name
+          value: sast-unicode-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:223812001607b07f0e07d56bef7b7d619144e660c0c57f21ddd44ce0c8c4785b
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    workspaces:
+    - name: git-auth
+      optional: true
+    - name: netrc
+      optional: true
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-hyperfleet-adapter-chart
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
## What

Adds a hand-authored Pipelines-as-Code build for the Helm chart in `charts/`, publishing it as an OCI artifact via the `build-helm-chart-oci-ta` task. New file: `.tekton/hyperfleet-adapter-chart-push.yaml`.

## Why

Rolls the proven hyperfleet-api chart build pattern out to this repo as part of moving Helm chart distribution to OCI on Quay. Konflux's `configure-pac` only generates container build pipelines, so the chart build references the task directly (modeled on `konflux-ci/caching`).

## How it works

- Triggers on push to `main`, alongside the existing image build
- `init` → `git-clone-oci-ta` → `prefetch-dependencies-oci-ta` → `build-helm-chart-oci-ta` → SAST checks
- Packages `charts/` and pushes to the tenant build registry; Tekton Chains generates provenance

## Dependency / merge order

The `hyperfleet-adapter-chart` Component must exist in the `hyperfleet-tenant` (konflux-release-data) **before** this build will associate to it. That config change lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)