### PR TITLE
HYPERFLEET-1108 - feat: add support for custom labels in Helm chart

### DIFF
--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -38,6 +38,9 @@ helm.sh/chart: {{ include "hyperfleet-adapter.chart" . }}
 {{ include "hyperfleet-adapter.selectorLabels" . }}
 app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.labels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -226,6 +226,16 @@ podDisruptionBudget:
 # -- Additional labels applied to all pods
 podLabels: {}
 
+# -- Custom labels applied to all resources managed by this Helm chart
+# (Deployment, Service, ServiceAccount, ClusterRole, ClusterRoleBinding, ConfigMaps, etc.)
+# Useful for labeling resources for cleanup, tracking, or organization.
+# Example:
+#   labels:
+#     environment: production
+#     team: platform
+#     hyperfleet-e2e-run: e2e-20260615-102422-bb5nfo2d
+# labels: {}
+
 # -- Pod-level security context
 podSecurityContext:
   # -- Filesystem group for volume mounts


### PR DESCRIPTION
## Summary

Add possibility to set labels when installing chart

- HYPERFLEET-1108

## Test Plan

- [ ] Unit tests added/updated
- [ ] `make test-all` passes
- [ ] `make lint` passes
- [ ] Helm chart changes validated with `make test-helm` (if applicable)
- [ ] Deployed to a development cluster and verified (if Helm/config changes)
- [ ] E2E tests passed (if cross-component or major changes)
