### PR TITLE
HYPERFLEET-1186 - docs: restructure documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,547 +1,90 @@
 # HyperFleet Adapter
 
-HyperFleet Adapter Framework - configuration driven framework to run tasks for cluster provisioning.
+Configuration-driven framework for cluster lifecycle management. An adapter instance listens for CloudEvents from a message broker, executes a four-phase pipeline (extract params, check preconditions, apply resources, report status), and reports results back to the HyperFleet API.
 
-An instance of an adapter targets an specific resource such as a Cluster or NodePool. And provides a clear workflow:
+## Quick Start
 
-- **Listens to events**: A CloudEvent informs what resource to process.
-  - Supports different types of brokers via hyperfleet-broker lib.
-- **Param phase**: Gets parameters from environment, event and current resource status (by querying HyperFleet API)
-- **Decision phase**: Computes where an action has to be performed to a resource using the params
-- **Resource phase**: Creates resources using a configured client
-  - Kubernetes client: local or remote cluster
-  - Maestro client: remote cluster via Maestro server
-- **Status reporting**: Reports result of task execution to HyperFleet API
-  - Builds the payload evaluating the status of the resources created in the resource phase
+### Try Locally
 
-## Prerequisites
-
-- Go 1.24.6 or later
-- Docker (for building Docker images)
-- Kubernetes 1.19+ (for deployment)
-- Helm 3.0+ (for Helm chart deployment)
-- `golangci-lint` (for linting, optional)
-
-## Getting Started
-
-### Clone the Repository
+No cluster, broker, or API needed. Dry-run mode processes a CloudEvent from a JSON file using mock clients and prints a full execution trace:
 
 ```bash
-git clone https://github.com/openshift-hyperfleet/hyperfleet-adapter.git
-cd hyperfleet-adapter
+go run ./cmd/adapter/main.go serve \
+  --config test/testdata/dryrun/dryrun-kubernetes-adapter-config.yaml \
+  --task-config test/testdata/dryrun/kubernetes/dryrun-kubernetes-task-config.yaml \
+  --dry-run-event test/testdata/dryrun/event.json \
+  --dry-run-api-responses test/testdata/dryrun/dryrun-api-responses.json \
+  --dry-run-discovery test/testdata/dryrun/kubernetes/dryrun-kubernetes-discovery.json \
+  --dry-run-verbose
 ```
 
-### Install Dependencies
-
-```bash
-make mod-tidy
-```
-
-### Build
-
-```bash
-# Build the binary
-make build
-
-# The binary will be created at: bin/hyperfleet-adapter
-```
-
-### Run Tests
-
-```bash
-# Run unit tests
-make test
-
-# Run integration tests (pre-built envtest - unprivileged, CI/CD friendly)
-make test-integration
-
-# Run integration tests with K3s (faster, may need privileges)
-make test-integration-k3s
-
-# Run all tests
-make test-all
-```
-
-### Linting
-
-```bash
-# Run linter
-make lint
-
-# Format code
-make fmt
-```
-
-## Development
-
-### Project Structure
-
-```
-hyperfleet-adapter/
-├── cmd/
-│   └── adapter/            # Main application entry point
-├── pkg/
-│   ├── constants/          # Shared constants (annotations, labels)
-│   ├── errors/             # Error handling utilities
-│   ├── health/             # Health and metrics servers
-│   ├── logger/             # Structured logging with context support
-│   ├── otel/               # OpenTelemetry tracing utilities
-│   ├── utils/              # General utility functions
-│   └── version/            # Version information
-├── internal/
-│   ├── config_loader/      # Configuration loading and validation
-│   ├── criteria/           # Precondition and CEL evaluation
-│   ├── executor/           # Event execution engine (phases pipeline)
-│   ├── hyperfleet_api/     # HyperFleet API client
-│   ├── k8s_client/         # Kubernetes client wrapper
-│   ├── maestro_client/     # Maestro/OCM ManifestWork client
-│   ├── manifest/           # Manifest utilities (generation, rendering)
-│   └── transport_client/   # TransportClient interface (unified apply)
-├── test/
-│   └── integration/        # Integration tests
-│       ├── config-loader/  # Config loader integration tests
-│       ├── executor/       # Executor integration tests
-│       ├── k8s_client/     # K8s client integration tests
-│       ├── maestro_client/ # Maestro client integration tests
-│       └── testutil/       # Test utilities
-├── charts/                 # Helm chart for Kubernetes deployment
-├── configs/                # Configuration templates and examples
-├── scripts/                # Build and test scripts
-├── Dockerfile              # Multi-stage Docker build
-├── Makefile                # Build and test automation
-├── go.mod                  # Go module dependencies
-└── README.md               # This file
-```
-
-### Available Make Targets
-
-| Target | Description |
-|--------|-------------|
-| `make build` | Build binary |
-| `make test` | Run unit tests |
-| `make test-integration` | Run integration tests with pre-built envtest (unprivileged, CI/CD friendly) |
-| `make test-integration-k3s` | Run integration tests with K3s (faster, may need privileges) |
-| `make test-all` | Run all tests (unit + integration) |
-| `make test-coverage` | Generate test coverage report |
-| `make lint` | Run golangci-lint |
-| `make image` | Build container image |
-| `make image-push` | Build and push container image to registry |
-| `make image-dev` | Build and push to personal Quay registry (requires QUAY_USER) |
-| `make fmt` | Format code |
-| `make mod-tidy` | Tidy Go module dependencies |
-| `make clean` | Clean build artifacts |
-| `make verify` | Run lint and test |
-
-💡 **Tip:** Use `make help` to see all available targets with descriptions
-
-### Tool Dependency Management (Bingo)
-
-HyperFleet Adapter uses [bingo](https://github.com/bwplotka/bingo) to manage Go tool dependencies with pinned versions.
-
-**Managed tools**:
-
-- `goimports` - Code formatting and import organization
-- `golangci-lint` - Code linting
-
-**Common operations**:
-
-```bash
-# Install all tools
-bingo get
-
-# Install a specific tool
-bingo get <tool>
-
-# Update a tool to latest version
-bingo get <tool>@latest
-
-# List all managed tools
-bingo list
-```
-
-Tool versions are tracked in `.bingo/*.mod` files and loaded automatically via `include .bingo/Variables.mk` in the Makefile.
-
-### Configuration
-
-A  HyperFleet Adapter requires several files for configuration:
-
-- **Adapter config**: Configures the adapter framework application
-- **Adapter Task config**: Configures the adapter task steps that will create resources
-- **Broker configuration**: Configures the specific broker to use by the adapter framework to receive CloudEvents
-
-To see all configuration options read [configuration.md](docs/configuration.md) file
-
-#### Adapter configuration
-
-The adapter deployment configuration (`AdapterConfig`) controls runtime and infrastructure
-settings for the adapter process, such as client connections, retries, and broker
-subscription details. It is loaded with Viper, so values can be overridden by CLI flags
-and environment variables in this priority order: CLI flags > env vars > file > defaults.
-
-Fields use **snake_case** naming.
-
-- **Path**: `HYPERFLEET_ADAPTER_CONFIG` (required)
-- **Common fields**: `adapter.name`, `adapter.version`, `debug_config`, `clients.*`
-  (HyperFleet API: `clients.hyperfleet_api`, Maestro: `clients.maestro`, broker: `clients.broker`, Kubernetes: `clients.kubernetes`)
-
-Reference examples:
-
-- `configs/adapter-deployment-config.yaml` (full reference with env/flag notes)
-- `charts/examples/kubernetes/adapter-config.yaml` (minimal deployment example)
-
-#### Adapter task configuration
-
-The adapter task configuration (`AdapterTaskConfig`) defines the **business logic** for
-processing events: parameters, preconditions, resources to create, and post-actions.
-This file is loaded as **static YAML** (no Viper overrides) and is required at runtime.
-
-- **Path**: `HYPERFLEET_TASK_CONFIG` (required)
-- **Key sections**: `params`, `preconditions`, `resources`, `post`
-- **Resource manifests**: inline YAML or external file via `manifest.ref`
-
-Reference examples:
-
-- `charts/examples/kubernetes/adapter-task-config.yaml` (worked example)
-- `configs/adapter-task-config-template.yaml` (complete schema reference)
-
-### Broker Configuration
-
-Broker configuration is particular since responsibility is split between:
-
-- **Hyperfleet broker library**: configures the connection to a concrete broker (google pubsub, rabbitmq, ...)
-  - Configured using a YAML file specified by the `BROKER_CONFIG_FILE` environment variable
-- **Adapter**: configures which topic/subscriptions to use on the broker
-  - Configure topic/subscription in the `adapter-config.yaml` but can be overridden with env variables or cli params
-
-See the Helm chart documentation for broker configuration options.
-
-## Dry-Run Mode
-
-Dry-run mode lets you simulate the full adapter execution pipeline locally without connecting to any real infrastructure (no broker, no Kubernetes cluster, no HyperFleet API). It processes a single CloudEvent from a JSON file and produces a detailed trace of what the adapter would do.
-
-### Usage
-
-```bash
-hyperfleet-adapter serve \
-  --config ./adapter-config.yaml \
-  --task-config ./task-config.yaml \
-  --dry-run-event ./event.json
-```
-
-Dry-run mode is activated when the `--dry-run-event` flag is present. Instead of subscribing to a broker, the adapter loads the event from the specified file and runs through all phases (params, preconditions, resources, post-actions) using mock clients.
-
-### Flags
-
-| Flag | Required | Description |
-|------|----------|-------------|
-| `--dry-run-event <path>` | Yes | Path to a CloudEvent JSON file to process |
-| `--dry-run-api-responses <path>` | No | Path to mock API responses JSON file (defaults to 200 OK for all requests) |
-| `--dry-run-discovery <path>` | No | Path to mock discovery overrides JSON file (simulates server-populated fields) |
-| `--dry-run-verbose` | No | Show rendered manifests and API request/response bodies in output |
-| `--dry-run-output <format>` | No | Output format: `text` (default) or `json` |
-
-### Input Files
-
-#### CloudEvent File (`--dry-run-event`)
-
-A standard CloudEvents JSON file:
-
-```json
-{
-  "specversion": "1.0",
-  "id": "abc123",
-  "type": "io.hyperfleet.cluster.updated",
-  "source": "/api/clusters_mgmt/v1/clusters/abc123",
-  "time": "2025-01-15T10:30:00Z",
-  "datacontenttype": "application/json",
-  "data": {
-    "id": "abc123",
-    "kind": "Cluster",
-    "href": "/api/clusters_mgmt/v1/clusters/abc123",
-    "generation": 5
-  }
-}
-```
-
-#### Mock API Responses File (`--dry-run-api-responses`)
-
-Defines canned responses for HyperFleet API calls. Requests are matched by HTTP method and URL regex pattern. When multiple responses are defined for a match, they are returned sequentially (the last response repeats):
-
-```json
-{
-  "responses": [
-    {
-      "match": {
-        "method": "GET",
-        "urlPattern": "/api/hyperfleet/v1/clusters/.*"
-      },
-      "responses": [
-        {
-          "statusCode": 200,
-          "headers": { "Content-Type": "application/json" },
-          "body": { "id": "abc-123", "name": "abc123", "kind": "Cluster" }
-        }
-      ]
-    }
-  ]
-}
-```
-
-If no file is provided, all API requests return 200 OK by default.
-
-#### Discovery Overrides File (`--dry-run-discovery`)
-
-Maps rendered resource names to complete resource objects, allowing you to simulate server-populated fields (status, uid, resourceVersion, etc.) that would normally be set by the Kubernetes API server:
-
-```json
-{
-  "rendered-resource-name": {
-    "apiVersion": "work.open-cluster-management.io/v1",
-    "kind": "ManifestWork",
-    "metadata": { "name": "manifestwork-001", "namespace": "cluster1" },
-    "status": { "conditions": [{ "type": "Applied", "status": "True" }] }
-  }
-}
-```
-
-These overrides replace applied manifests in the in-memory store, making the simulated discovery results available as `resources.*` in post-action CEL expressions.
-
-Having the discovery mocked is useful to develop the status payload to return to the hyperfleet_api
-
-### Output
-
-The trace output shows the result of each execution phase:
-
-1. **Event Info** - Event ID and type
-2. **Phase 1: Parameter Extraction** - Extracted parameters and their values
-3. **Phase 2: Preconditions** - Precondition evaluation results (SUCCESS/FAILED/NOT MET) with API calls made
-4. **Phase 3: Resources** - Resource operations (CREATE/UPDATE/RECREATE) with kind, namespace, and name
-5. **Phase 3.5: Discovery Results** - Resources available for post-action CEL evaluation
-6. **Phase 4: Post Actions** - Post-action API calls and skip reasons
-7. **Result** - Overall SUCCESS or FAILED
-
-Use `--dry-run-verbose` to include rendered manifests and full API request/response bodies.
-
-Use `--dry-run-output json` for structured JSON output suitable for programmatic consumption.
-
-### Examples
-
-Minimal dry-run (mock API returns 200 OK for everything):
-
-```bash
-hyperfleet-adapter serve \
-  --config ./adapter-config.yaml \
-  --task-config ./task-config.yaml \
-  --dry-run-event ./event.json
-```
-
-Full dry-run with mock API responses, discovery overrides, and verbose JSON output:
-
-```bash
-hyperfleet-adapter serve \
-  --config ./adapter-config.yaml \
-  --task-config ./task-config.yaml \
-  --dry-run-event ./event.json \
-  --dry-run-api-responses ./api-responses.json \
-  --dry-run-discovery ./discovery-overrides.json \
-  --dry-run-verbose \
-  --dry-run-output json
-```
-
-Example input files are available in `test/testdata/dryrun/`.
-
-## Deployment
-
-### Using Helm Chart
-
-The project includes a Helm chart for Kubernetes deployment.
-
-```bash
-# Install the chart
-helm install hyperfleet-adapter ./charts/
-
-# Install with custom values
-helm install hyperfleet-adapter ./charts/ -f ./charts/examples/values.yaml
-
-# Upgrade deployment
-helm upgrade hyperfleet-adapter ./charts/
-
-# Uninstall
-helm delete hyperfleet-adapter
-```
-
-For detailed Helm chart documentation, see [charts/README.md](./charts/README.md).
-
-### Container Image
-
-Build and push container images:
-
-```bash
-# Build container image
-make image
-
-# Build with custom tag
-make image IMAGE_TAG=v1.0.0
-
-# Build and push to default registry
-make image-push
-
-# Build and push to personal Quay registry (for development)
-QUAY_USER=myuser make image-dev
-```
-
-Default image: `quay.io/openshift-hyperfleet/hyperfleet-adapter:latest`
-
-The container build automatically embeds version metadata (version, git commit, build date) into the binary. The git commit is passed from the build machine via `--build-arg GIT_COMMIT`. To override:
-
-```bash
-make image GIT_COMMIT=abc1234
-```
-
-## Testing
-
-### Unit Tests
-
-```bash
-# Run unit tests (fast, no dependencies)
-make test
-```
-
-Unit tests include:
-
-- Logger functionality and context handling
-- Error handling and error codes
-- Operation ID middleware
-- Template rendering and parsing
-- Kubernetes client logic
-
-### Integration Tests
-
-Integration tests use **Testcontainers** with **dynamically installed envtest** - works in any CI/CD platform without requiring privileged containers.
-
-<details>
-<summary>Click to expand: Setup and run integration tests</summary>
-
-#### Prerequisites
-
-- **Docker or Podman** must be running (both fully supported!)
-  - Docker: `docker info`
-  - Podman: `podman info`
-- The Makefile automatically detects and configures your container runtime
-- **Podman users**: Corporate proxy settings are auto-detected from Podman machine
-
-#### Run Tests
-
-```bash
-# Run integration tests with pre-built envtest (default - unprivileged)
-make test-integration
-
-# Run integration tests with K3s (faster, may need privileges)
-make test-integration-k3s
-
-# Run all tests (unit + integration)
-make test-all
-
-# Generate coverage report
-make test-coverage
-```
-
-The first run will download golang:alpine and install envtest (~20-30 seconds). Subsequent runs are faster with caching.
-
-#### Advantages
-
-- ✅ **Simple Setup**: Just needs Docker/Podman (no binary installation, no custom Dockerfile)
-- ✅ **Unprivileged**: Works in ANY CI/CD platform (OpenShift, Tekton, restricted runners)
-- ✅ **Real API**: Kubernetes API server + etcd (sufficient for most integration tests)
-- ✅ **Podman Optimized**: Auto-detects proxy, works in corporate networks
-- ✅ **CI/CD Ready**: No privileged mode required
-- ✅ **Isolated**: Fresh environment for each test suite
-
-**Performance**: ~30-40 seconds for complete test suite (10 suites, 24 test cases).
-
-**Alternative**: Use K3s (`make test-integration-k3s`) for 2x faster tests if privileged containers are available.
-
-- ⚠️ Requires Docker or rootful Podman
-- ✅ Makefile automatically checks Podman mode and provides helpful instructions if incompatible
-
-</details>
-
-📖 **Full guide:** [`test/integration/k8sclient/README.md`](test/integration/k8sclient/README.md)
-
-### Test Coverage
-
-```bash
-# Generate coverage report
-make test-coverage
-
-# Generate HTML coverage report
-make test-coverage-html
-```
-
-**Expected Total Coverage:** ~65-75% (unit + integration tests)
-
-📊 **Test Status:** See [`TEST_STATUS.md`](TEST_STATUS.md) for detailed coverage analysis
-
-## Logging
-
-The adapter uses structured logging with context-aware fields:
-
-- **Transaction ID** (`txid`): Request transaction identifier
-- **Operation ID** (`opid`): Unique operation identifier
-- **Adapter ID** (`adapter_id`): Adapter instance identifier
-- **Cluster ID** (`cluster_id`): Cluster identifier
-
-Logs are formatted with prefixes like: `[opid=abc123][adapter_id=adapter-1] message`
-
-## Error Handling
-
-The adapter uses a structured error handling system:
-
-- **Error Codes**: Standardized error codes with prefixes
-- **Error References**: API references for error documentation
-- **Error Types**: Common error types (NotFound, Validation, Conflict, etc.)
-
-See `pkg/errors/error.go` for error handling implementation.
-
-## Contributing
-
-Welcome contributions! Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines on:
-
-- Code style and standards
-- Testing requirements
-- Pull request process
-- Commit message guidelines
-
-## Repository Access
-
-All members of the **hyperfleet** team have write access to this repository.
-
-### Steps to Apply for Repository Access
-
-If you're a team member and need access to this repository:
-
-1. **Verify Organization Membership**: Ensure you're a member of the `openshift-hyperfleet` organization
-2. **Check Team Assignment**: Confirm you're added to the hyperfleet team within the organization
-3. **Repository Permissions**: All hyperfleet team members automatically receive write access
-4. **OWNERS File**: Code reviews and approvals are managed through the OWNERS file
-
-For access issues, contact a repository administrator or organization owner.
-
-## License
-
-This project is licensed under the Apache License 2.0 - see the [LICENSE](./LICENSE) file for details.
+See [Dry-Run Mode](./docs/development.md#dry-run-mode) for flags, mock file formats, and JSON output.
+
+### Deploy the Full Stack
+
+The adapter requires a running message broker and HyperFleet API. The [hyperfleet-infra](https://github.com/openshift-hyperfleet/hyperfleet-infra) repository provides a one-command setup that deploys the complete HyperFleet stack including pre-configured adapters:
+
+| Command | What it deploys |
+|---------|-----------------|
+| `make local-up-gcp` | GKE cluster + images + API + adapters + Maestro |
+| `make install-hyperfleet` | Everything on an existing K8s cluster using RabbitMQ (no GCP needed) |
+| `make install-hyperfleet-adapters` | Install sample Hyperfleet Adapters |
+| `make status` | Verify the deployment |
+
+Make sure you define the following environment variables:
+* `HELMFILE_ENV`: accepted values : `kind`, `gcp`
+* `NAMESPACE`: namespace where HyperFleet components will be deployed
+* `REGISTRY`: The registry namespace from which to pull the images. `quay.io/openshift-hyperfleet` for released images
+* `API_IMAGE_TAG`: image tag for `hyperfleet-api` container image
+* `SENTINEL_IMAGE_TAG`: image tag for `hyperfleet-sentinel` container image
+* `ADAPTER_IMAGE_TAG`: image tag for `hyperfleet-adapter` container image
+
+See [hyperfleet-infra](https://github.com/openshift-hyperfleet/hyperfleet-infra) for required environment variables and full instructions.
 
 ## Documentation
 
-- [Architecture](https://github.com/openshift-hyperfleet/architecture) - System architecture and API documentation
-- [Metrics](docs/metrics.md) - Prometheus metric definitions and PromQL examples
-- [Alerts](docs/alerts.md) - Recommended alert rules and monitoring queries
-- [Runbook](docs/runbook.md) - Operational runbook for on-call engineers
-- [Configuration](docs/configuration.md) - Configuration reference
-- [Adapter Authoring Guide](docs/adapter-authoring-guide.md) - Guide to creating adapter task configurations
-- [Helm Chart](./charts/README.md) - Helm chart documentation
-- [Contributing Guidelines](./CONTRIBUTING.md) - Development and contribution guidelines
+### For Operators (deploying and running adapters)
 
-## Support
+- **[Deployment Guide](docs/deployment.md)** — configuration, Helm values, and deployment instructions
+- **[Helm Values Reference](./charts/README.md)** — auto-generated chart values table
+- **[Configuration Reference](docs/configuration.md)** — all deployment config fields, CLI flags, and env vars
+- **[Metrics](docs/metrics.md)** — Prometheus metric definitions, labels, and PromQL queries
+- **[Alerts](docs/alerts.md)** — recommended alert rules and monitoring queries
+- **[Runbook](docs/runbook.md)** — failure modes, recovery procedures, and escalation paths
 
-For issues, questions, or contributions, please open an issue on GitHub.
+### For Adapter Authors (writing task configurations)
+
+- **[Adapter Authoring Guide](docs/adapter-authoring-guide.md)** — params, preconditions, resources, CEL expressions, status reporting
+
+### For Developers
+
+- **[Development Guide](./docs/development.md)** - setup, build and test guidelines.
+- **[CONTRIBUTING.md](./CONTRIBUTING.md)** - code style, testing requirements, PR process, and commit guidelines
+
+### Architecture
+
+- **[HyperFleet Architecture](https://github.com/openshift-hyperfleet/architecture)** — system architecture and API documentation
+- **[HyperFleet API Spec](https://github.com/openshift-hyperfleet/hyperfleet-api-spec)** — OpenAPI specification
+- **[Broker Library](https://github.com/openshift-hyperfleet/hyperfleet-broker)** — message broker abstraction
+
+## CLI Reference
+
+| Command | Description |
+|---------|-------------|
+| `adapter serve` | Start the adapter, subscribe to broker, and process events |
+| `adapter config-dump` | Print the merged configuration and exit |
+| `adapter version` | Print version, commit, and build date |
+
+All `serve` flags have environment variable equivalents — run `adapter serve --help` for the full list.
+
+---
+
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for code style, testing requirements, PR process, and commit guidelines.
+
+All members of the **hyperfleet** team have write access. Code reviews and approvals are managed through the OWNERS file.
+
+## License
+
+This project is licensed under the Apache License 2.0 — see the [LICENSE](./LICENSE) file for details.

--- a/charts/README.md
+++ b/charts/README.md
@@ -21,6 +21,8 @@ helm install hyperfleet-adapter oci://REGISTRY/hyperfleet-adapter \
 | ---- | ------ | --- |
 | HyperFleet Team | <hyperfleet-team@redhat.com> |  |
 
+> For the full deployment guide (configuration overview, env var mapping, examples), see [Deployment Guide](../docs/deployment.md).
+
 ## Values
 
 | Key | Type | Default | Description |

--- a/charts/README.md.gotmpl
+++ b/charts/README.md.gotmpl
@@ -21,6 +21,8 @@ helm install {{ template "chart.name" . }} oci://REGISTRY/{{ template "chart.nam
 
 {{ template "chart.requirementsSection" . }}
 
+> For the full deployment guide (configuration overview, env var mapping, examples), see [Deployment Guide](../docs/deployment.md).
+
 {{ template "chart.valuesSection" . }}
 
 ----------------------------------------------

--- a/docs/adapter-authoring-guide.md
+++ b/docs/adapter-authoring-guide.md
@@ -1,6 +1,6 @@
 # HyperFleet Adapter Authoring Guide
 
-> **Audience:** Developers building adapter configurations for HyperFleet cluster lifecycle tasks.
+> **Audience:** Adapter authors writing task configurations for HyperFleet cluster lifecycle events.
 
 ---
 
@@ -785,6 +785,25 @@ The resource executor treats apply and delete operations differently when they f
 
 This means a list containing both apply and delete operations behaves predictably: a delete failure does not prevent the next resource from being deleted, but an apply failure stops further processing.
 
+### Force-deleted resources (404 handling)
+
+When a resource is force-deleted externally (e.g., removed from the HyperFleet API while the adapter is running), the precondition API call returns a `404 Not Found`. Instead of treating this as a hard failure, the adapter handles it gracefully:
+
+- `adapter.resourcesSkipped` is set to `true`
+- `adapter.skipReason` is set to `"ResourceNotFound"`
+- The resources phase is skipped entirely
+- Post-actions still execute, so the adapter can report the skip back to the API
+
+This means your post-action CEL expressions can detect force-deletion and report an appropriate status:
+
+```cel
+adapter.?skipReason.orValue("") == "ResourceNotFound"
+  ? "Resource was deleted externally"
+  : adapter.?skipReason.orValue("unknown reason")
+```
+
+The same 404 handling applies during post-action execution: if a post-action API call returns 404, remaining post-actions are skipped gracefully rather than failed.
+
 ### Partial delete failures
 
 When one or more delete operations fail:
@@ -1030,6 +1049,31 @@ This means your adapter does not need to poll or wait. The framework and Sentine
 Post-actions build a status payload and send it to the HyperFleet API. This is how the system knows your adapter's work is done (or failed, or in progress).
 
 The process has two steps: **build payloads**, then **execute post actions**.
+
+### Conditional post-actions (`when`)
+
+Post-actions can be gated with a CEL expression. When the expression evaluates to `false`, the action is **skipped** (not failed) — useful for sending different status reports depending on execution outcome.
+
+```yaml
+post_actions:
+  - name: "reportSuccess"
+    when:
+      expression: "adapter.?executionStatus.orValue('') == 'success'"
+    api_call:
+      method: "PUT"
+      url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}/statuses"
+      body: "{{ .successPayload }}"
+
+  - name: "reportFailure"
+    when:
+      expression: "adapter.?executionStatus.orValue('') != 'success'"
+    api_call:
+      method: "PUT"
+      url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}/statuses"
+      body: "{{ .failurePayload }}"
+```
+
+The `when` expression has access to the full execution context: all `adapter.*` metadata, extracted params, and `resources.*`. If `when` is omitted, the action always executes (existing behavior). If the expression fails to parse or evaluate, the action is marked as **failed**.
 
 ### Building payloads
 
@@ -1552,6 +1596,23 @@ generation
 
 # JSON serialization (debugging)
 toJson(resources.resource0)
+```
+
+### String extension functions (`ext.Strings()`)
+
+The CEL environment registers `ext.Strings()`, making the following methods available on string values:
+
+`charAt`, `indexOf`, `lastIndexOf`, `lowerAscii`, `upperAscii`, `replace`, `split`, `substring`, `trim`, `join`
+
+```cel
+# Lowercase a cluster name
+clusterName.lowerAscii()
+
+# Split a comma-separated list and check membership
+"us-east-1,us-west-2".split(",").exists(r, r == region)
+
+# Trim whitespace from a captured value
+resources.?myResource.?metadata.?name.orValue("").trim()
 ```
 
 ### Common patterns

--- a/docs/adapter-authoring-guide.md
+++ b/docs/adapter-authoring-guide.md
@@ -1567,6 +1567,8 @@ More information about deployment can be found in [Architecture repository - Hyp
 
 ## Appendix A: CEL Quick Reference
 
+> For the full CEL reference including implementation details, see [CEL Conventions](conventions/cel.md).
+
 ```cel
 # Optional chaining — safe access to fields that may not exist
 resources.?clusterNamespace.?status.?phase.orValue("")
@@ -1723,6 +1725,8 @@ Go Templates are used in: URLs, manifest field values, direct string values in p
 
 ## Appendix C: Condition Operators Reference
 
+See also [Preconditions — Supported operators](#supported-operators).
+
 | Operator | Value type | Example |
 |----------|-----------|---------|
 | `equals` | any | `value: "True"` |
@@ -1731,8 +1735,11 @@ Go Templates are used in: URLs, manifest field values, direct string values in p
 | `notIn` | array | `value: ["deprecated-region"]` |
 | `contains` | string | `value: "prod"` |
 | `greaterThan` | numeric | `value: 0` |
+| `greaterThanOrEqual` | numeric | `value: 0` |
 | `lessThan` | numeric | `value: 100` |
+| `lessThanOrEqual` | numeric | `value: 100` |
 | `exists` | (none) | Field must exist, no value needed |
+| `notExists` | (none) | Field must not exist, no value needed |
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -194,10 +194,9 @@ When tracing is enabled, the adapter uses standard [OpenTelemetry environment va
 | `OTEL_TRACES_SAMPLER` | Sampler type (`always_on`, `always_off`, `traceidratio`, `parentbased_*`) | `parentbased_traceidratio` |
 | `OTEL_TRACES_SAMPLER_ARG` | Sampling ratio (0.0–1.0) | `1.0` |
 
-When no `OTEL_EXPORTER_OTLP_ENDPOINT` is set, traces are written to stdout for local development. 
+When no `OTEL_EXPORTER_OTLP_ENDPOINT` is set, traces are written to stdout for local development.
 
-The Helm chart exposes `tracing.enabled`, `tracing.otlpEndpoint`, `tracing.otlpProtocol`, `tracing.serviceName`, `tracing.sampler`, `tracing.samplerArg`, and `tracing.propagators` in `values.yaml` which map to these environment variables.
-
+The Helm chart exposes `tracing.enabled`, `tracing.otlpEndpoint`, `tracing.otlpProtocol`, `tracing.serviceName`, `tracing.sampler`, `tracing.samplerArg`, and `tracing.propagators` in `values.yaml` which map to these environment variables. For Helm deployment details, see the [Deployment Guide — Tracing](deployment.md#tracing).
 
 ## Command-line parameters
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,7 +75,7 @@ clients:
 ### Top-level fields
 
 - `adapter.name` (string, required): Adapter name.
-- `adapter.version` (string, optional): when set, the binary validates it matches the running version.
+- `adapter.version` (string, optional): when set, the binary validates it matches the running version. Only major and minor versions are compared — patch differences are allowed (e.g., config `1.2.0` with binary `1.2.3` is valid). Non-semver versions (e.g., `dev`, `latest`, custom tags) skip validation gracefully.
 - `debug_config` (bool, optional): Log the merged config after load. Default: `false`.
 
 ### Logging (`log`)
@@ -175,6 +175,29 @@ The queue-to-exchange binding always uses an **empty routing key** — all queue
 - `kube_config_path` (string): Path to kubeconfig (empty uses in-cluster auth).
 - `qps` (float): Client-side QPS limit (0 uses defaults).
 - `burst` (int): Client-side burst limit (0 uses defaults).
+
+### Tracing (OpenTelemetry)
+
+Tracing is configured entirely through environment variables — there is no YAML section.
+
+- `HYPERFLEET_TRACING_ENABLED` (bool): Enable or disable tracing. Default: `true` in the binary, `false` in the Helm chart. Set to `false` to suppress OTLP export errors when no collector is available.
+
+When tracing is enabled, the adapter uses standard [OpenTelemetry environment variables](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/):
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP collector endpoint (e.g., `http://otel-collector:4317`) | — (stdout exporter) |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Signal-specific endpoint; overrides the above for traces only | — |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | Protocol: `grpc` or `http/protobuf` | `grpc` |
+| `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` | Signal-specific protocol override | — |
+| `OTEL_SERVICE_NAME` | Service name reported in spans | `adapter.name` from config |
+| `OTEL_TRACES_SAMPLER` | Sampler type (`always_on`, `always_off`, `traceidratio`, `parentbased_*`) | `parentbased_traceidratio` |
+| `OTEL_TRACES_SAMPLER_ARG` | Sampling ratio (0.0–1.0) | `1.0` |
+
+When no `OTEL_EXPORTER_OTLP_ENDPOINT` is set, traces are written to stdout for local development. 
+
+The Helm chart exposes `tracing.enabled`, `tracing.otlpEndpoint`, `tracing.otlpProtocol`, `tracing.serviceName`, `tracing.sampler`, `tracing.samplerArg`, and `tracing.propagators` in `values.yaml` which map to these environment variables.
+
 
 ## Command-line parameters
 

--- a/docs/conventions/cel.md
+++ b/docs/conventions/cel.md
@@ -1,6 +1,6 @@
 # CEL Expressions
 
-> **Audience:** Framework developers contributing to the adapter codebase.
+> **Audience:** Framework developers contributing to the adapter codebase. For practical CEL patterns aimed at adapter authors, see [Adapter Authoring Guide — Appendix A](../adapter-authoring-guide.md#appendix-a-cel-quick-reference).
 
 Used in precondition expressions, lifecycle delete conditions, and post-action `when` gates.
 

--- a/docs/conventions/cel.md
+++ b/docs/conventions/cel.md
@@ -1,5 +1,7 @@
 # CEL Expressions
 
+> **Audience:** Framework developers contributing to the adapter codebase.
+
 Used in precondition expressions, lifecycle delete conditions, and post-action `when` gates.
 
 ## Variables

--- a/docs/conventions/logging.md
+++ b/docs/conventions/logging.md
@@ -1,5 +1,7 @@
 # Logging Conventions
 
+> **Audience:** Framework developers contributing to the adapter codebase.
+
 Uses `log/slog` wrapped in `pkg/logger`. Every log call takes `context.Context` as first parameter.
 
 ## Patterns

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -85,39 +85,7 @@ These fields have first-class Helm values that the chart injects as environment 
 
 ### Fields settable via the `env` list
 
-These adapter config fields have environment variable overrides but no dedicated Helm value. Set them using the `env` list:
-
-| Adapter config field | Environment variable |
-|---------------------|---------------------|
-| `debug_config` | `HYPERFLEET_DEBUG_CONFIG` |
-| `log.format` | `LOG_FORMAT` |
-| `log.output` | `LOG_OUTPUT` |
-| `clients.maestro.grpc_server_address` | `HYPERFLEET_MAESTRO_GRPC_SERVER_ADDRESS` |
-| `clients.maestro.http_server_address` | `HYPERFLEET_MAESTRO_HTTP_SERVER_ADDRESS` |
-| `clients.maestro.source_id` | `HYPERFLEET_MAESTRO_SOURCE_ID` |
-| `clients.maestro.client_id` | `HYPERFLEET_MAESTRO_CLIENT_ID` |
-| `clients.maestro.auth.type` | `HYPERFLEET_MAESTRO_AUTH_TYPE` |
-| `clients.maestro.auth.tls_config.ca_file` | `HYPERFLEET_MAESTRO_CA_FILE` |
-| `clients.maestro.auth.tls_config.cert_file` | `HYPERFLEET_MAESTRO_CERT_FILE` |
-| `clients.maestro.auth.tls_config.key_file` | `HYPERFLEET_MAESTRO_KEY_FILE` |
-| `clients.maestro.auth.tls_config.http_ca_file` | `HYPERFLEET_MAESTRO_HTTP_CA_FILE` |
-| `clients.maestro.timeout` | `HYPERFLEET_MAESTRO_TIMEOUT` |
-| `clients.maestro.server_healthiness_timeout` | `HYPERFLEET_MAESTRO_SERVER_HEALTHINESS_TIMEOUT` |
-| `clients.maestro.retry_attempts` | `HYPERFLEET_MAESTRO_RETRY_ATTEMPTS` |
-| `clients.maestro.keepalive.time` | `HYPERFLEET_MAESTRO_KEEPALIVE_TIME` |
-| `clients.maestro.keepalive.timeout` | `HYPERFLEET_MAESTRO_KEEPALIVE_TIMEOUT` |
-| `clients.maestro.insecure` | `HYPERFLEET_MAESTRO_INSECURE` |
-| `clients.hyperfleet_api.timeout` | `HYPERFLEET_API_TIMEOUT` |
-| `clients.hyperfleet_api.retry_attempts` | `HYPERFLEET_API_RETRY_ATTEMPTS` |
-| `clients.hyperfleet_api.retry_backoff` | `HYPERFLEET_API_RETRY_BACKOFF` |
-| `clients.hyperfleet_api.base_delay` | `HYPERFLEET_API_BASE_DELAY` |
-| `clients.hyperfleet_api.max_delay` | `HYPERFLEET_API_MAX_DELAY` |
-| `clients.kubernetes.api_version` | `HYPERFLEET_KUBERNETES_API_VERSION` |
-| `clients.kubernetes.kube_config_path` | `HYPERFLEET_KUBERNETES_KUBE_CONFIG_PATH` |
-| `clients.kubernetes.qps` | `HYPERFLEET_KUBERNETES_QPS` |
-| `clients.kubernetes.burst` | `HYPERFLEET_KUBERNETES_BURST` |
-
-Example:
+Many adapter config fields have environment variable overrides but no dedicated Helm value. Set them using the `env` list. The naming convention is `HYPERFLEET_<SECTION>_<FIELD>` for most fields. For example:
 
 ```yaml
 env:
@@ -128,6 +96,8 @@ env:
   - name: LOG_FORMAT
     value: "text"
 ```
+
+The [Configuration Reference](configuration.md#environment-variables) lists every adapter config field with its environment variable equivalent.
 
 ---
 
@@ -164,47 +134,15 @@ The broker config controls the message broker connection. It can be sourced in t
 | Inline YAML | `broker.yaml` | Full broker config as a YAML string |
 | Existing ConfigMap | `broker.configMapName` | Pre-existing ConfigMap (set `broker.create: false`) |
 
-When using individual properties, `broker.type` must be set to `googlepubsub` or `rabbitmq`.
-
-### Google Pub/Sub
-
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `broker.type` | Must be `googlepubsub` | — |
-| `broker.googlepubsub.projectId` | Google Cloud project ID | `""` |
-| `broker.googlepubsub.topic` | Pub/Sub topic name | `""` |
-| `broker.googlepubsub.subscriptionId` | Subscription ID | `""` |
-| `broker.googlepubsub.deadLetterTopic` | Dead letter topic | `""` |
-| `broker.googlepubsub.createTopicIfMissing` | Auto-create topic (dev/test only) | `false` |
-| `broker.googlepubsub.createSubscriptionIfMissing` | Auto-create subscription (dev/test only) | `false` |
-
-### RabbitMQ
-
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `broker.type` | Must be `rabbitmq` | — |
-| `broker.rabbitmq.url` | AMQP connection URL (required) | `""` |
-| `broker.rabbitmq.queue` | Queue name (required) | `""` |
-| `broker.rabbitmq.exchange` | Exchange name (required) | `""` |
-| `broker.rabbitmq.exchangeType` | Exchange type | `topic` |
+When using individual properties, `broker.type` must be set to `googlepubsub` or `rabbitmq`. See the [Helm Values Reference](../charts/README.md) for the full list of `broker.googlepubsub.*` and `broker.rabbitmq.*` parameters with defaults. For broker config semantics (queue naming, fan-out behavior, exchange coupling), see the [Configuration Reference](configuration.md#broker).
 
 ---
 
 ## Tracing
 
-OpenTelemetry distributed tracing. The Helm chart defaults to tracing **disabled** (the binary defaults to enabled).
+OpenTelemetry distributed tracing. The Helm chart defaults to tracing **disabled** (the binary defaults to enabled). When no endpoint is configured, traces are written to stdout.
 
-| Parameter | Env var set by chart | Default |
-|-----------|---------------------|---------|
-| `tracing.enabled` | `HYPERFLEET_TRACING_ENABLED` | `false` |
-| `tracing.serviceName` | `OTEL_SERVICE_NAME` | `hyperfleet-adapter` |
-| `tracing.otlpEndpoint` | `OTEL_EXPORTER_OTLP_ENDPOINT` | `""` (stdout) |
-| `tracing.otlpProtocol` | `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc` |
-| `tracing.sampler` | `OTEL_TRACES_SAMPLER` | `parentbased_traceidratio` |
-| `tracing.samplerArg` | `OTEL_TRACES_SAMPLER_ARG` | `1.0` |
-| `tracing.propagators` | `OTEL_PROPAGATORS` | `tracecontext,baggage` |
-
-When no endpoint is configured, traces are written to stdout.
+See the [Helm Values Reference](../charts/README.md) for the full list of `tracing.*` parameters and defaults, and the [Configuration Reference](configuration.md#tracing-opentelemetry) for the underlying OTEL environment variables.
 
 ---
 
@@ -291,6 +229,7 @@ broker:
     queue: my-adapter
     exchange: hyperfleet
     exchangeType: topic
+    routingKey: adapter.events # Optional
 ```
 
 ### Full (inline adapter config, external task config, Maestro, Pub/Sub, tracing)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,385 @@
+# Deployment Guide
+
+> **Audience:** Operators deploying the adapter to Kubernetes via Helm.
+
+This guide explains how to configure and deploy an adapter instance using the Helm chart. For the exhaustive list of every Helm value with types and defaults, see the [Helm Values Reference](../charts/README.md).
+
+## Configuration Overview
+
+An adapter deployment requires three pieces of configuration, all settable through Helm values:
+
+| Config | Helm value | Purpose |
+|--------|-----------|---------|
+| **Adapter config** | `adapterConfig.*` | Infrastructure: adapter identity, client connections, timeouts |
+| **Task config** | `adapterTaskConfig.*` | Business logic: params, preconditions, resources, status reporting |
+| **Broker config** | `broker.*` | Message broker connection: Pub/Sub or RabbitMQ settings |
+
+The adapter binary loads two config files at startup (adapter config + task config). The Helm chart creates ConfigMaps for both and mounts them into the pod. Some adapter config fields also have environment variable overrides — the chart auto-sets several of these from dedicated Helm values, and you can set additional ones via the `env` list.
+
+### How adapter config fields map to Helm values
+
+There are three ways to set deployment config fields, in decreasing order of convenience:
+
+| Mechanism | When to use | Example |
+|-----------|------------|---------|
+| **`adapterConfig.yaml` blob** | Fields with no env var support | Provide the full adapter config as inline YAML |
+| **Dedicated Helm value** | Fields the chart exposes directly | `adapterConfig.log.level: debug` |
+| **`env` list** | Fields with env var support but no dedicated Helm value | `env: [{name: HYPERFLEET_MAESTRO_GRPC_SERVER_ADDRESS, value: "..."}]` |
+
+The [Configuration Reference](configuration.md) lists every field with its env var and CLI flag equivalents.
+
+---
+
+## Adapter Config (yaml blob)
+
+The adapter config defines the adapter identity, logging, and client connections (Maestro, HyperFleet API, Kubernetes). It can be sourced in three ways:
+
+| Option | Helm value | Description |
+|--------|-----------|-------------|
+| Inline YAML | `adapterConfig.yaml` | Full adapter config as YAML (structured object or string) |
+| Chart-packaged files | `adapterConfig.files` | Reference files bundled with the chart via `$.Files.Get` |
+| Existing ConfigMap | `adapterConfig.configMapName` | Pre-existing ConfigMap (set `adapterConfig.create: false`) |
+
+### Fields requiring `adapterConfig.yaml`
+
+These fields have no environment variable override and can only be set by providing the full adapter config as inline YAML via `adapterConfig.yaml`:
+
+- `adapter.name` — adapter identity name
+- `adapter.version` — version string for binary validation
+- `clients.hyperfleet_api.default_headers` — custom headers for API requests
+
+When you use `adapterConfig.yaml`, the Helm values `adapterConfig.log.level`, `adapterConfig.hyperfleetApi.baseUrl`, and `adapterConfig.hyperfleetApi.version` still work — they are injected as env vars which take priority over the YAML file.
+
+Example with inline YAML:
+
+```yaml
+adapterConfig:
+  create: true
+  yaml:
+    adapter:
+      name: my-adapter
+      version: "0.1.0"
+    clients:
+      hyperfleet_api:
+        base_url: http://hyperfleet-api:8000
+        version: v1
+        timeout: 10s
+        retry_attempts: 3
+        retry_backoff: exponential
+      broker:
+        subscription_id: my-adapter-sub
+        topic: cluster-events
+      kubernetes:
+        api_version: "v1"
+```
+
+### Dedicated Helm values
+
+These fields have first-class Helm values that the chart injects as environment variables:
+
+| Parameter | Description | Env var set by chart | Default |
+|-----------|-------------|---------------------|---------|
+| `adapterConfig.log.level` | Log level (`debug`, `info`, `warn`, `error`) | `LOG_LEVEL` | `info` |
+| `adapterConfig.hyperfleetApi.baseUrl` | HyperFleet API base URL | `HYPERFLEET_API_BASE_URL` | `http://hyperfleet-api:8000` |
+| `adapterConfig.hyperfleetApi.version` | API version | `HYPERFLEET_API_VERSION` | `v1` |
+
+### Fields settable via the `env` list
+
+These adapter config fields have environment variable overrides but no dedicated Helm value. Set them using the `env` list:
+
+| Adapter config field | Environment variable |
+|---------------------|---------------------|
+| `debug_config` | `HYPERFLEET_DEBUG_CONFIG` |
+| `log.format` | `LOG_FORMAT` |
+| `log.output` | `LOG_OUTPUT` |
+| `clients.maestro.grpc_server_address` | `HYPERFLEET_MAESTRO_GRPC_SERVER_ADDRESS` |
+| `clients.maestro.http_server_address` | `HYPERFLEET_MAESTRO_HTTP_SERVER_ADDRESS` |
+| `clients.maestro.source_id` | `HYPERFLEET_MAESTRO_SOURCE_ID` |
+| `clients.maestro.client_id` | `HYPERFLEET_MAESTRO_CLIENT_ID` |
+| `clients.maestro.auth.type` | `HYPERFLEET_MAESTRO_AUTH_TYPE` |
+| `clients.maestro.auth.tls_config.ca_file` | `HYPERFLEET_MAESTRO_CA_FILE` |
+| `clients.maestro.auth.tls_config.cert_file` | `HYPERFLEET_MAESTRO_CERT_FILE` |
+| `clients.maestro.auth.tls_config.key_file` | `HYPERFLEET_MAESTRO_KEY_FILE` |
+| `clients.maestro.auth.tls_config.http_ca_file` | `HYPERFLEET_MAESTRO_HTTP_CA_FILE` |
+| `clients.maestro.timeout` | `HYPERFLEET_MAESTRO_TIMEOUT` |
+| `clients.maestro.server_healthiness_timeout` | `HYPERFLEET_MAESTRO_SERVER_HEALTHINESS_TIMEOUT` |
+| `clients.maestro.retry_attempts` | `HYPERFLEET_MAESTRO_RETRY_ATTEMPTS` |
+| `clients.maestro.keepalive.time` | `HYPERFLEET_MAESTRO_KEEPALIVE_TIME` |
+| `clients.maestro.keepalive.timeout` | `HYPERFLEET_MAESTRO_KEEPALIVE_TIMEOUT` |
+| `clients.maestro.insecure` | `HYPERFLEET_MAESTRO_INSECURE` |
+| `clients.hyperfleet_api.timeout` | `HYPERFLEET_API_TIMEOUT` |
+| `clients.hyperfleet_api.retry_attempts` | `HYPERFLEET_API_RETRY_ATTEMPTS` |
+| `clients.hyperfleet_api.retry_backoff` | `HYPERFLEET_API_RETRY_BACKOFF` |
+| `clients.hyperfleet_api.base_delay` | `HYPERFLEET_API_BASE_DELAY` |
+| `clients.hyperfleet_api.max_delay` | `HYPERFLEET_API_MAX_DELAY` |
+| `clients.kubernetes.api_version` | `HYPERFLEET_KUBERNETES_API_VERSION` |
+| `clients.kubernetes.kube_config_path` | `HYPERFLEET_KUBERNETES_KUBE_CONFIG_PATH` |
+| `clients.kubernetes.qps` | `HYPERFLEET_KUBERNETES_QPS` |
+| `clients.kubernetes.burst` | `HYPERFLEET_KUBERNETES_BURST` |
+
+Example:
+
+```yaml
+env:
+  - name: HYPERFLEET_MAESTRO_GRPC_SERVER_ADDRESS
+    value: "maestro-grpc.maestro.svc.cluster.local:8090"
+  - name: HYPERFLEET_MAESTRO_TIMEOUT
+    value: "30s"
+  - name: LOG_FORMAT
+    value: "text"
+```
+
+---
+
+## Task Config
+
+The task config defines the adapter's business logic (params, preconditions, resources, post-actions). See the [Adapter Authoring Guide](adapter-authoring-guide.md) for how to write one.
+
+| Option | Helm value | Description |
+|--------|-----------|-------------|
+| Inline YAML | `adapterTaskConfig.yaml` | Full task config as YAML (mutually exclusive with files/external) |
+| Chart-packaged files | `adapterTaskConfig.files` | Reference files bundled with the chart (can combine with external) |
+| External content | `adapterTaskConfig.external` | Content passed via `--set-file` (can combine with files) |
+| Existing ConfigMap | `adapterTaskConfig.configMapName` | Pre-existing ConfigMap (set `adapterTaskConfig.create: false`) |
+
+Example with `--set-file`:
+
+```bash
+helm install my-adapter ./charts/ \
+  --set-file adapterTaskConfig.external.task-config=/path/to/my-task-config.yaml \
+  -f my-values.yaml
+```
+
+> **Note:** Files referenced via `manifest.ref` in the task config are not processed by Helm — they use Go templates resolved at adapter runtime.
+
+---
+
+## Broker Configuration
+
+The broker config controls the message broker connection. It can be sourced in three ways:
+
+| Option | Helm value | Description |
+|--------|-----------|-------------|
+| Individual properties | `broker.googlepubsub.*` or `broker.rabbitmq.*` | Chart builds the broker YAML |
+| Inline YAML | `broker.yaml` | Full broker config as a YAML string |
+| Existing ConfigMap | `broker.configMapName` | Pre-existing ConfigMap (set `broker.create: false`) |
+
+When using individual properties, `broker.type` must be set to `googlepubsub` or `rabbitmq`.
+
+### Google Pub/Sub
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `broker.type` | Must be `googlepubsub` | — |
+| `broker.googlepubsub.projectId` | Google Cloud project ID | `""` |
+| `broker.googlepubsub.topic` | Pub/Sub topic name | `""` |
+| `broker.googlepubsub.subscriptionId` | Subscription ID | `""` |
+| `broker.googlepubsub.deadLetterTopic` | Dead letter topic | `""` |
+| `broker.googlepubsub.createTopicIfMissing` | Auto-create topic (dev/test only) | `false` |
+| `broker.googlepubsub.createSubscriptionIfMissing` | Auto-create subscription (dev/test only) | `false` |
+
+### RabbitMQ
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `broker.type` | Must be `rabbitmq` | — |
+| `broker.rabbitmq.url` | AMQP connection URL (required) | `""` |
+| `broker.rabbitmq.queue` | Queue name (required) | `""` |
+| `broker.rabbitmq.exchange` | Exchange name (required) | `""` |
+| `broker.rabbitmq.exchangeType` | Exchange type | `topic` |
+
+---
+
+## Tracing
+
+OpenTelemetry distributed tracing. The Helm chart defaults to tracing **disabled** (the binary defaults to enabled).
+
+| Parameter | Env var set by chart | Default |
+|-----------|---------------------|---------|
+| `tracing.enabled` | `HYPERFLEET_TRACING_ENABLED` | `false` |
+| `tracing.serviceName` | `OTEL_SERVICE_NAME` | `hyperfleet-adapter` |
+| `tracing.otlpEndpoint` | `OTEL_EXPORTER_OTLP_ENDPOINT` | `""` (stdout) |
+| `tracing.otlpProtocol` | `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc` |
+| `tracing.sampler` | `OTEL_TRACES_SAMPLER` | `parentbased_traceidratio` |
+| `tracing.samplerArg` | `OTEL_TRACES_SAMPLER_ARG` | `1.0` |
+| `tracing.propagators` | `OTEL_PROPAGATORS` | `tracecontext,baggage` |
+
+When no endpoint is configured, traces are written to stdout.
+
+---
+
+## Environment Variables
+
+### Auto-set by the chart
+
+The chart automatically sets these environment variables from Helm values:
+
+| Variable | Source | Condition |
+|----------|--------|-----------|
+| `LOG_LEVEL` | `adapterConfig.log.level` | Always |
+| `HYPERFLEET_API_BASE_URL` | `adapterConfig.hyperfleetApi.baseUrl` | Always |
+| `HYPERFLEET_API_VERSION` | `adapterConfig.hyperfleetApi.version` | Always |
+| `BROKER_CONFIG_FILE` | Hardcoded `/etc/broker/broker.yaml` | Always |
+| `HYPERFLEET_BROKER_SUBSCRIPTION_ID` | `broker.googlepubsub.subscriptionId` | When broker type is `googlepubsub` |
+| `HYPERFLEET_BROKER_TOPIC` | `broker.googlepubsub.topic` | When broker type is `googlepubsub` |
+| `BROKER_URL` | `broker.rabbitmq.url` | When broker type is `rabbitmq` |
+| `BROKER_QUEUE` | `broker.rabbitmq.queue` | When broker type is `rabbitmq` |
+| `HYPERFLEET_TRACING_ENABLED` | `tracing.enabled` | Always |
+| `OTEL_SERVICE_NAME` | `tracing.serviceName` | When tracing is enabled |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `tracing.otlpEndpoint` | When tracing is enabled |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `tracing.otlpProtocol` | When tracing is enabled |
+| `OTEL_TRACES_SAMPLER` | `tracing.sampler` | When tracing is enabled |
+| `OTEL_TRACES_SAMPLER_ARG` | `tracing.samplerArg` | When tracing is enabled |
+| `OTEL_PROPAGATORS` | `tracing.propagators` | When tracing is enabled |
+| `K8S_NAMESPACE` | Pod field `metadata.namespace` | When tracing is enabled |
+| `OTEL_RESOURCE_ATTRIBUTES` | Hardcoded `k8s.namespace.name=$(K8S_NAMESPACE)` | When tracing is enabled |
+
+### Custom environment variables
+
+Use the `env` list to inject arbitrary environment variables into the adapter container. This is the primary mechanism for setting adapter config fields that don't have dedicated Helm values (see [Fields settable via the `env` list](#fields-settable-via-the-env-list)).
+
+```yaml
+env:
+  - name: MY_VAR
+    value: "my-value"
+  - name: MY_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: my-secret
+        key: secret-key
+```
+
+---
+
+## GCP Workload Identity
+
+To use Google Pub/Sub with Workload Identity, bind a principal to the Kubernetes service account:
+
+```bash
+gcloud projects add-iam-policy-binding MY_PROJECT \
+  --member="principal://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL/subject/ns/NAMESPACE/sa/SERVICE_ACCOUNT" \
+  --role="roles/pubsub.subscriber"
+```
+
+---
+
+## Examples
+
+### Minimal (RabbitMQ, chart-packaged files)
+
+```yaml
+image:
+  registry: quay.io
+  repository: openshift-hyperfleet/hyperfleet-adapter
+  tag: v0.2.0
+
+adapterConfig:
+  create: true
+  files:
+    adapter-config.yaml: examples/kubernetes/adapter-config.yaml
+
+adapterTaskConfig:
+  create: true
+  files:
+    task-config.yaml: examples/kubernetes/adapter-task-config.yaml
+
+broker:
+  create: true
+  type: rabbitmq
+  rabbitmq:
+    url: amqp://user:password@rabbitmq.hyperfleet-system.svc.cluster.local:5672/
+    queue: my-adapter
+    exchange: hyperfleet
+    exchangeType: topic
+```
+
+### Full (inline adapter config, external task config, Maestro, Pub/Sub, tracing)
+
+```yaml
+image:
+  registry: quay.io
+  repository: openshift-hyperfleet/my-adapter
+  tag: v1.0.0
+
+adapterConfig:
+  create: true
+  yaml:
+    adapter:
+      name: my-adapter
+      version: "1.0.0"
+    clients:
+      hyperfleet_api:
+        base_url: http://hyperfleet-api:8000
+        version: v1
+        timeout: 10s
+        retry_attempts: 3
+        retry_backoff: exponential
+      maestro:
+        grpc_server_address: "maestro-grpc.maestro.svc.cluster.local:8090"
+        source_id: "my-adapter"
+        auth:
+          type: tls
+          tls_config:
+            ca_file: /etc/maestro/certs/grpc/ca.crt
+            cert_file: /etc/maestro/certs/grpc/client.crt
+            key_file: /etc/maestro/certs/grpc/client.key
+        timeout: 30s
+        keepalive:
+          time: 30s
+          timeout: 10s
+      broker:
+        subscription_id: my-adapter-sub
+        topic: cluster-events
+      kubernetes:
+        api_version: "v1"
+        qps: 100
+        burst: 200
+
+adapterTaskConfig:
+  create: true
+  external:
+    task-config: |
+      params:
+        - name: "clusterId"
+          source: "event.id"
+          type: "string"
+          required: true
+      resources: []
+      post:
+        payloads: []
+        post_actions: []
+
+broker:
+  create: true
+  type: googlepubsub
+  googlepubsub:
+    projectId: my-gcp-project
+    topic: cluster-events
+    subscriptionId: my-adapter-sub
+
+env:
+  - name: NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+
+tracing:
+  enabled: true
+  otlpEndpoint: http://otel-collector:4317
+
+rbac:
+  resources:
+    - namespaces
+    - configmaps
+
+extraVolumes:
+  - name: maestro-certs
+    secret:
+      secretName: maestro-client-certs
+extraVolumeMounts:
+  - name: maestro-certs
+    mountPath: /etc/maestro/certs/grpc
+    readOnly: true
+```
+
+See `charts/examples/kubernetes/` for additional working examples.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,4 +1,6 @@
-# Setup
+# Development Guide
+
+## Setup
 
 ```bash
 git clone https://github.com/openshift-hyperfleet/hyperfleet-adapter.git
@@ -7,7 +9,7 @@ make mod-tidy
 make build        # → bin/hyperfleet-adapter
 ```
 
-# Verification
+## Verification
 
 ```bash
 make fmt              # Format code + imports (golangci-lint fmt with gci)
@@ -17,7 +19,7 @@ make test-integration # Integration tests via testcontainers (needs Docker/Podma
 make test-all         # All of the above + make test-helm
 ```
 
-# Make Targets
+## Make Targets
 
 | Target | Description |
 |--------|-------------|
@@ -37,23 +39,23 @@ make test-all         # All of the above + make test-helm
 
 Use `make help` to see all available targets.
 
-# Integration Tests
+## Integration Tests
 
 <details>
 <summary>Setup and run integration tests</summary>
 
 Integration tests use **Testcontainers** with **envtest** — works in any CI/CD platform without privileged containers.
 
-## Prerequisites
+### Prerequisites
 
 - **Docker or Podman** must be running (both supported)
 - The Makefile automatically detects and configures your container runtime
 - **Podman users**: Corporate proxy settings are auto-detected from Podman machine. Define and export the environment variable : 
-```
+```bash
 DOCKER_HOST=unix://$XDG_RUNTIME_DIR/podman/podman.sock
 ```
 
-## Run
+### Run
 
 ```bash
 make test-integration       # envtest (default, unprivileged)
@@ -64,7 +66,7 @@ The first run downloads `golang:alpine` and installs envtest (~20-30 seconds). S
 
 </details>
 
-# Tool Dependencies (Bingo)
+## Tool Dependencies (Bingo)
 
 Build tools are pinned via [bingo](https://github.com/bwplotka/bingo) in `.bingo/` manifests:
 
@@ -73,7 +75,7 @@ bingo get           # Install all tools
 bingo list          # List managed tools
 ```
 
-# Container Image
+## Container Image
 
 ```bash
 # Build container image
@@ -95,7 +97,7 @@ The container build embeds version metadata (version, git commit, build date) in
 
 ---
 
-# Dry-Run Mode
+## Dry-Run Mode
 
 Dry-run mode simulates the full execution pipeline locally without connecting to any real infrastructure. It processes a single CloudEvent from a JSON file and produces a detailed trace.
 
@@ -107,9 +109,7 @@ hyperfleet-adapter serve \
 ```
 
 <details>
-<summary>Dry-run flags and input files</summary>
-
-## Flags
+<summary>Dry-run flags</summary>
 
 | Flag | Required | Description |
 |------|----------|-------------|
@@ -119,65 +119,6 @@ hyperfleet-adapter serve \
 | `--dry-run-verbose` | No | Show rendered manifests and API request/response bodies in output |
 | `--dry-run-output <format>` | No | Output format: `text` (default) or `json` |
 
-## CloudEvent file (`--dry-run-event`)
-
-```json
-{
-  "specversion": "1.0",
-  "id": "abc123",
-  "type": "io.hyperfleet.cluster.updated",
-  "source": "/api/hyperfleet/v1/clusters/abc123",
-  "data": {
-    "id": "abc123",
-    "kind": "Cluster",
-    "href": "/api/hyperfleet/v1/clusters/abc123",
-    "generation": 5
-  }
-}
-```
-
-## Mock API responses (`--dry-run-api-responses`)
-
-Requests are matched by HTTP method and URL regex. When multiple responses are defined for a match, they are returned sequentially (the last one repeats):
-
-```json
-{
-  "responses": [
-    {
-      "match": { "method": "GET", "urlPattern": "/api/hyperfleet/v1/clusters/.*" },
-      "responses": [
-        { "statusCode": 200, "body": { "id": "abc123", "name": "my-cluster", "generation": 5 } }
-      ]
-    },
-    {
-      "match": { "method": "PUT", "urlPattern": "/api/hyperfleet/v1/clusters/.*/statuses" },
-      "responses": [{ "statusCode": 200, "body": {} }]
-    }
-  ]
-}
-```
-
-If no file is provided, all API requests return 200 OK.
-
-## Discovery overrides (`--dry-run-discovery`)
-
-Maps rendered resource names to complete Kubernetes objects, simulating server-populated fields (status, uid, resourceVersion):
-
-```json
-{
-  "abc123": {
-    "apiVersion": "v1",
-    "kind": "Namespace",
-    "metadata": { "name": "abc123", "uid": "a1b2c3d4", "resourceVersion": "100" },
-    "status": { "phase": "Active" }
-  }
-}
-```
-
-## Output
-
-The trace walks through each phase: parameter extraction, preconditions (with API calls), resources (CREATE/UPDATE/RECREATE/DELETE), discovery results, and post-actions. Use `--dry-run-verbose` for full manifests and API bodies, or `--dry-run-output json` for machine-readable output.
-
-Example input files are available in `test/testdata/dryrun/`.
-
 </details>
+
+For mock file formats and a step-by-step development workflow, see [Adapter Authoring Guide — Dry-Run Mode](adapter-authoring-guide.md#10-dry-run-mode). Example input files are in `test/testdata/dryrun/`.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,183 @@
+# Setup
+
+```bash
+git clone https://github.com/openshift-hyperfleet/hyperfleet-adapter.git
+cd hyperfleet-adapter
+make mod-tidy
+make build        # → bin/hyperfleet-adapter
+```
+
+# Verification
+
+```bash
+make fmt              # Format code + imports (golangci-lint fmt with gci)
+make lint             # golangci-lint (config: .golangci.yml)
+make test             # Unit tests with race detection
+make test-integration # Integration tests via testcontainers (needs Docker/Podman)
+make test-all         # All of the above + make test-helm
+```
+
+# Make Targets
+
+| Target | Description |
+|--------|-------------|
+| `make build` | Build binary |
+| `make test` | Run unit tests |
+| `make test-integration` | Run integration tests with envtest (unprivileged) |
+| `make test-integration-k3s` | Run integration tests with K3s (faster, may need privileges) |
+| `make test-all` | Run all tests (unit + integration + helm) |
+| `make test-coverage` | Generate test coverage report |
+| `make lint` | Run golangci-lint |
+| `make fmt` | Format code |
+| `make image` | Build container image |
+| `make image-push` | Build and push container image |
+| `make image-dev` | Build and push to personal Quay registry |
+| `make mod-tidy` | Tidy Go module dependencies |
+| `make clean` | Clean build artifacts |
+
+Use `make help` to see all available targets.
+
+# Integration Tests
+
+<details>
+<summary>Setup and run integration tests</summary>
+
+Integration tests use **Testcontainers** with **envtest** — works in any CI/CD platform without privileged containers.
+
+## Prerequisites
+
+- **Docker or Podman** must be running (both supported)
+- The Makefile automatically detects and configures your container runtime
+- **Podman users**: Corporate proxy settings are auto-detected from Podman machine. Define and export the environment variable : 
+```
+DOCKER_HOST=unix://$XDG_RUNTIME_DIR/podman/podman.sock
+```
+
+## Run
+
+```bash
+make test-integration       # envtest (default, unprivileged)
+make test-integration-k3s   # K3s (faster, may need privileges)
+```
+
+The first run downloads `golang:alpine` and installs envtest (~20-30 seconds). Subsequent runs are cached.
+
+</details>
+
+# Tool Dependencies (Bingo)
+
+Build tools are pinned via [bingo](https://github.com/bwplotka/bingo) in `.bingo/` manifests:
+
+```bash
+bingo get           # Install all tools
+bingo list          # List managed tools
+```
+
+# Container Image
+
+```bash
+# Build container image
+make image
+
+# Build with custom tag
+make image IMAGE_TAG=v1.0.0
+
+# Build and push to default registry
+make image-push
+
+# Build and push to personal Quay registry (for development)
+QUAY_USER=myuser make image-dev
+```
+
+Default image: `quay.io/openshift-hyperfleet/hyperfleet-adapter:latest`
+
+The container build embeds version metadata (version, git commit, build date) into the binary.
+
+---
+
+# Dry-Run Mode
+
+Dry-run mode simulates the full execution pipeline locally without connecting to any real infrastructure. It processes a single CloudEvent from a JSON file and produces a detailed trace.
+
+```bash
+hyperfleet-adapter serve \
+  --config ./adapter-config.yaml \
+  --task-config ./task-config.yaml \
+  --dry-run-event ./event.json
+```
+
+<details>
+<summary>Dry-run flags and input files</summary>
+
+## Flags
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--dry-run-event <path>` | Yes | Path to a CloudEvent JSON file to process |
+| `--dry-run-api-responses <path>` | No | Path to mock API responses JSON file (defaults to 200 OK for all requests) |
+| `--dry-run-discovery <path>` | No | Path to mock discovery overrides JSON file (simulates server-populated fields) |
+| `--dry-run-verbose` | No | Show rendered manifests and API request/response bodies in output |
+| `--dry-run-output <format>` | No | Output format: `text` (default) or `json` |
+
+## CloudEvent file (`--dry-run-event`)
+
+```json
+{
+  "specversion": "1.0",
+  "id": "abc123",
+  "type": "io.hyperfleet.cluster.updated",
+  "source": "/api/hyperfleet/v1/clusters/abc123",
+  "data": {
+    "id": "abc123",
+    "kind": "Cluster",
+    "href": "/api/hyperfleet/v1/clusters/abc123",
+    "generation": 5
+  }
+}
+```
+
+## Mock API responses (`--dry-run-api-responses`)
+
+Requests are matched by HTTP method and URL regex. When multiple responses are defined for a match, they are returned sequentially (the last one repeats):
+
+```json
+{
+  "responses": [
+    {
+      "match": { "method": "GET", "urlPattern": "/api/hyperfleet/v1/clusters/.*" },
+      "responses": [
+        { "statusCode": 200, "body": { "id": "abc123", "name": "my-cluster", "generation": 5 } }
+      ]
+    },
+    {
+      "match": { "method": "PUT", "urlPattern": "/api/hyperfleet/v1/clusters/.*/statuses" },
+      "responses": [{ "statusCode": 200, "body": {} }]
+    }
+  ]
+}
+```
+
+If no file is provided, all API requests return 200 OK.
+
+## Discovery overrides (`--dry-run-discovery`)
+
+Maps rendered resource names to complete Kubernetes objects, simulating server-populated fields (status, uid, resourceVersion):
+
+```json
+{
+  "abc123": {
+    "apiVersion": "v1",
+    "kind": "Namespace",
+    "metadata": { "name": "abc123", "uid": "a1b2c3d4", "resourceVersion": "100" },
+    "status": { "phase": "Active" }
+  }
+}
+```
+
+## Output
+
+The trace walks through each phase: parameter extraction, preconditions (with API calls), resources (CREATE/UPDATE/RECREATE/DELETE), discovery results, and post-actions. Use `--dry-run-verbose` for full manifests and API bodies, or `--dry-run-output json` for machine-readable output.
+
+Example input files are available in `test/testdata/dryrun/`.
+
+</details>

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,6 +1,6 @@
 # HyperFleet Adapter Metrics
 
-> **Audience:** Developers integrating with adapter metrics and SREs building dashboards.
+> **Audience:** SREs building dashboards and operators monitoring the adapter.
 
 All metrics are exposed on the `/metrics` endpoint (port 9090) in Prometheus format. No additional configuration is needed.
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -16,8 +16,9 @@
    - [HyperFleet API Failures](#hyperfleet-api-failures)
    - [Maestro Client Failures](#maestro-client-failures)
    - [Kubernetes Client Failures](#kubernetes-client-failures)
-4. [Recovery Procedures](#recovery-procedures)
-5. [Escalation Paths](#escalation-paths)
+4. [Tracing / OpenTelemetry Issues](#tracing--opentelemetry-issues)
+5. [Recovery Procedures](#recovery-procedures)
+6. [Escalation Paths](#escalation-paths)
 
 ---
 
@@ -234,6 +235,30 @@ Non-retryable: forbidden, unauthorized, bad request, invalid, gone, method not s
 1. Check RBAC: `kubectl auth can-i --as=system:serviceaccount:<ns>:<sa> create <resource>`
 2. Check resource quotas: `kubectl describe resourcequota -n <namespace>`
 3. Check for finalizers blocking deletion: `kubectl get <resource> -o yaml | grep finalizers`
+
+---
+
+## Tracing / OpenTelemetry Issues
+
+**Symptoms:** OTLP export errors in logs at startup or during event processing. Traces not appearing in the collector.
+
+| Log Pattern | Cause | Resolution |
+|-------------|-------|------------|
+| `"failed to create OTLP exporter"` | Invalid endpoint or protocol | Verify `OTEL_EXPORTER_OTLP_ENDPOINT` is reachable and `OTEL_EXPORTER_OTLP_PROTOCOL` is `grpc` or `http/protobuf` |
+| `"failed to export spans"` | Collector is down or unreachable | Check OTLP collector health; verify network connectivity from the pod |
+| `"context deadline exceeded"` on spans | Slow or overloaded collector | Check collector resource usage; consider increasing export timeout |
+| Traces going to stdout unexpectedly | No OTLP endpoint configured | Set `OTEL_EXPORTER_OTLP_ENDPOINT` to point to your collector |
+
+**Default mismatch:** The binary defaults to tracing **enabled** (`HYPERFLEET_TRACING_ENABLED=true`), but the Helm chart defaults to tracing **disabled**. Running `adapter serve` locally without setting `HYPERFLEET_TRACING_ENABLED=false` will attempt OTLP export (falling back to stdout if no endpoint is set).
+
+**Steps:**
+1. Check if tracing is enabled: look for `"tracing enabled"` in startup logs
+2. To disable tracing entirely: `HYPERFLEET_TRACING_ENABLED=false`
+3. Verify collector connectivity:
+   ```bash
+   kubectl exec <pod> -- curl -s http://otel-collector:4317
+   ```
+4. Check Helm values: `tracing.enabled`, `tracing.otlpEndpoint`, `tracing.otlpProtocol`
 
 ---
 


### PR DESCRIPTION
## Summary

 Slim down README.md to a navigation hub and split deployment/development  content into focused standalone guides so operators and developers can  find what they need without cross-referencing multiple documents.

  - Add docs/deployment.md: Helm deployment guide covering the three-tier config mechanism (dedicated values, env list, adapterConfig.yaml blob), adapter/task/broker config sourcing options, tracing, auto-set env vars, and complete deployment examples (RabbitMQ + Maestro/Pub/Sub)
  - Add docs/development.md: developer setup, build, test, and dry-run guide
  - Slim README.md from ~530 to ~90 lines with audience-separated doc links (Operators / Adapter Authors / Developers / Architecture)
  - Add tracing (OpenTelemetry) section to docs/configuration.md and tracing troubleshooting section to docs/runbook.md
  - Add deployment guide link to charts/README.md.gotmpl and regenerate charts/README.md

- HYPERFLEET-1186

## Test Plan

- [ ] Unit tests added/updated
- [x] `make test-all` passes
- [x] `make lint` passes
- [x] Helm chart changes validated with `make test-helm` (if applicable)
- [ ] Deployed to a development cluster and verified (if Helm/config changes)
- [ ] E2E tests passed (if cross-component or major changes)
