### PR TITLE
HYPERFLEET-1101 - chore: add pre-commit hooks with LeakTK secret scanning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+default_install_hook_types: [pre-commit, commit-msg]
+
+repos:
+  # Secret scanning (VPN-free, open-source alternative to rh-pre-commit)
+  - repo: https://github.com/leaktk/leaktk
+    rev: e62a495260dc1e396fa586e51bbe1355f6fc7d9d # v0.3.3
+    hooks:
+      - id: leaktk.git.pre-commit
+
+  # HyperFleet code quality hooks
+  - repo: https://github.com/openshift-hyperfleet/hyperfleet-hooks
+    rev: 7f5119208e5cdee3f0c688881b6a4b803095f203 # v0.2.1
+    hooks:
+      - id: hyperfleet-commitlint
+        stages: [commit-msg]
+      - id: hyperfleet-gofmt
+      - id: hyperfleet-golangci-lint
+      - id: hyperfleet-go-vet
+
+  # File hygiene
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-added-large-files

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,13 @@ Event-driven Kubernetes resource manager. Consumes CloudEvents from a message br
 
 Go 1.25.0 · Cobra CLI · Viper config · golangci-lint (bingo-managed) · Tekton CI (Konflux)
 
+## Setup (fresh clone)
+
+```bash
+make install-hooks    # Install pre-commit hooks (secret scanning, linting, etc.)
+make build            # Build binary → bin/hyperfleet-adapter
+```
+
 ## Verification Checklist
 
 ```bash
@@ -14,7 +21,20 @@ make test-integration # Integration tests via testcontainers (needs Docker/Podma
 make build            # Build binary → bin/hyperfleet-adapter
 ```
 
-`make test-all` runs all of the above plus `make test-helm`. Pre-commit hooks: `make install-hooks`.
+`make test-all` runs `make lint`, `make test`, `make test-integration`, and `make test-helm`.
+
+### Pre-commit Hooks
+Install: `make install-hooks`
+
+Hooks:
+- `leaktk.git.pre-commit` — secret scanning (open-source, no VPN required)
+- `hyperfleet-commitlint` — validates commit message format (commit-msg stage)
+- `hyperfleet-gofmt` — Go code formatting
+- `hyperfleet-golangci-lint` — linting
+- `hyperfleet-go-vet` — Go vet checks
+- `trailing-whitespace` — removes trailing whitespace
+- `end-of-file-fixer` — ensures files end with newline
+- `check-added-large-files` — prevents large files from being committed
 
 ## CLI
 

--- a/Makefile
+++ b/Makefile
@@ -324,9 +324,16 @@ test-helm: $(KUBECONFORM) verify-helm-docs ## Test Helm charts (lint, template, 
 
 ##@ Code Quality
 
+.PHONY: install-hooks
+install-hooks: ## Install pre-commit hooks
+	pre-commit install
+
 .PHONY: fmt
 fmt: $(GOIMPORTS) ## Format code with goimports
 	$(GOIMPORTS) -w .
+
+.PHONY: gofmt
+gofmt: fmt ## Alias for fmt
 
 .PHONY: fmt-check
 fmt-check: ## Check if code is formatted
@@ -340,6 +347,9 @@ fmt-check: ## Check if code is formatted
 .PHONY: vet
 vet: ## Run go vet
 	$(GO) vet ./...
+
+.PHONY: go-vet
+go-vet: vet ## Alias for vet
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT) ## Run golangci-lint


### PR DESCRIPTION
## Summary

Creates the standard HyperFleet pre-commit configuration from scratch:

- **LeakTK v0.3.3** for secret scanning — open-source, no VPN required
- **hyperfleet-hooks v0.1.1** for commit message validation, Go formatting, linting, and vet
- **pre-commit-hooks v6.0.0** for file hygiene (trailing whitespace, end-of-file-fixer, check-added-large-files)

### Changes

- `.pre-commit-config.yaml` — created with standard config
- `Makefile` — added `install-hooks`, `gofmt` (alias for `fmt`), `go-vet` (alias for `vet`) targets
- `AGENTS.md` — expanded pre-commit hooks section with complete hook list

### After merging

Team members should run `make install-hooks` to install the new hooks. First commit after installation takes 3-5 minutes while LeakTK compiles (one-time).

Ref: https://redhat.atlassian.net/browse/HYPERFLEET-1101