### PR TITLE
HYPERFLEET-1245 - fix: default log level to info in examples

### DIFF
--- a/charts/examples/kubernetes/adapter-config.yaml
+++ b/charts/examples/kubernetes/adapter-config.yaml
@@ -4,9 +4,9 @@ adapter:
   version: "0.2.0"
 
 # Log the full merged configuration after load (default: false)
-debug_config: true
+debug_config: false
 log:
-  level: debug
+  level: info
 
 clients:
   hyperfleet_api:

--- a/charts/examples/kubernetes/values.yaml
+++ b/charts/examples/kubernetes/values.yaml
@@ -3,7 +3,7 @@ adapterConfig:
   files:
     adapter-config.yaml: examples/kubernetes/adapter-config.yaml
   log:
-    level: debug
+    level: info
 
 adapterTaskConfig:
   create: true

--- a/charts/examples/maestro-two-resources/adapter-config.yaml
+++ b/charts/examples/maestro-two-resources/adapter-config.yaml
@@ -4,9 +4,9 @@ adapter:
   version: "0.2.0"
 
 # Log the full merged configuration after load (default: false)
-debug_config: true
+debug_config: false
 log:
-  level: debug
+  level: info
 
 clients:
   hyperfleet_api:

--- a/charts/examples/maestro/adapter-config.yaml
+++ b/charts/examples/maestro/adapter-config.yaml
@@ -4,9 +4,9 @@ adapter:
   version: "0.2.0"
 
 # Log the full merged configuration after load (default: false)
-debug_config: true
+debug_config: false
 log:
-  level: debug
+  level: info
 
 clients:
   hyperfleet_api:


### PR DESCRIPTION
## Summary
- All example `adapter-config.yaml` files and example `values.yaml` had `level: debug` and `debug_config: true`
- Adapters bootstrapped from these examples run debug logging in production, adding noise and log volume
- Changed all examples to `level: info` and `debug_config: false`

## Test plan
- [ ] Deploy adapter using example configs, verify logs show info level (no debug)
- [ ] Confirm `--log-level debug` flag still enables debug when explicitly set