### PR TITLE
HYPERFLEET-1186 - docs: Use the OCI artifact for the release chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ The adapter requires a running message broker and HyperFleet API. The [hyperflee
 |---------|-----------------|
 | `make local-up-gcp` | GKE cluster + images + API + adapters + Maestro |
 | `make install-hyperfleet` | Everything on an existing K8s cluster using RabbitMQ (no GCP needed) |
-| `make install-hyperfleet-adapters` | Install sample Hyperfleet Adapters |
+| `make install-adapters` | Install sample Hyperfleet Adapters |
 | `make status` | Verify the deployment |
 
 Make sure you define the following environment variables:
 * `HELMFILE_ENV`: accepted values : `kind`, `gcp`
 * `NAMESPACE`: namespace where HyperFleet components will be deployed
-* `REGISTRY`: The registry namespace from which to pull the images. `quay.io/openshift-hyperfleet` for released images
+* `REGISTRY`: The registry namespace from which to pull the images. `quay.io/redhat-services-prod/hyperfleet-tenant/hyperfleet` for released images
 * `API_IMAGE_TAG`: image tag for `hyperfleet-api` container image
 * `SENTINEL_IMAGE_TAG`: image tag for `hyperfleet-sentinel` container image
 * `ADAPTER_IMAGE_TAG`: image tag for `hyperfleet-adapter` container image

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -6,6 +6,8 @@ This guide explains how to configure and deploy an adapter instance using the He
 
 ## Configuration Overview
 
+The HyperFleet Adapter Helm chart is released as an oci artifact at : oci://quay.io/redhat-services-prod/hyperfleet-tenant/hyperfleet/hyperfleet-adapter-chart. 
+
 An adapter deployment requires three pieces of configuration, all settable through Helm values:
 
 | Config | Helm value | Purpose |
@@ -208,8 +210,8 @@ gcloud projects add-iam-policy-binding MY_PROJECT \
 ```yaml
 image:
   registry: quay.io
-  repository: openshift-hyperfleet/hyperfleet-adapter
-  tag: v0.2.0
+  repository: redhat-services-prod/hyperfleet-tenant/hyperfleet/hyperfleet-adapter
+  tag: <version>
 
 adapterConfig:
   create: true
@@ -237,15 +239,15 @@ broker:
 ```yaml
 image:
   registry: quay.io
-  repository: openshift-hyperfleet/my-adapter
-  tag: v1.0.0
+  repository: redhat-services-prod/hyperfleet-tenant/hyperfleet/hyperfleet-adapter
+  tag: <version>
 
 adapterConfig:
   create: true
   yaml:
     adapter:
       name: my-adapter
-      version: "1.0.0"
+      version: "<version-no-v-prefix>"
     clients:
       hyperfleet_api:
         base_url: http://hyperfleet-api:8000

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -6,7 +6,7 @@ This guide explains how to configure and deploy an adapter instance using the He
 
 ## Configuration Overview
 
-The HyperFleet Adapter Helm chart is released as an oci artifact at : oci://quay.io/redhat-services-prod/hyperfleet-tenant/hyperfleet/hyperfleet-adapter-chart. 
+The HyperFleet Adapter Helm chart is released as an OCI artifact at `oci://quay.io/redhat-services-prod/hyperfleet-tenant/hyperfleet/hyperfleet-adapter-chart`.
 
 An adapter deployment requires three pieces of configuration, all settable through Helm values:
 


### PR DESCRIPTION
## Summary

Updates the references to images and charts to the (konflux) registry references for  released artifacts

- HYPERFLEET-1186

## Test Plan

- [ ] Unit tests added/updated
- [ ] `make test-all` passes
- [ ] `make lint` passes
- [ ] Helm chart changes validated with `make test-helm` (if applicable)
- [ ] Deployed to a development cluster and verified (if Helm/config changes)
- [ ] E2E tests passed (if cross-component or major changes)
