### PR TITLE
HYPERFLEET-1108 - fix: uncomment labels default in values.yaml

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -84,6 +84,7 @@ helm install hyperfleet-adapter oci://REGISTRY/hyperfleet-adapter \
 | podDisruptionBudget.enabled | bool | `true` | Enable the PDB |
 | podDisruptionBudget.maxUnavailable | int | `1` | Maximum number of pods that can be unavailable during disruption |
 | podLabels | object | `{}` | Additional labels applied to all pods |
+| labels | object | `{}` | Custom labels applied to all resources managed by this Helm chart (Deployment, Service, ServiceAccount, ClusterRole, ClusterRoleBinding, ConfigMaps, etc.) Useful for labeling resources for cleanup, tracking, or organization. Example:   labels:     environment: production     team: platform     hyperfleet-e2e-run: e2e-20260615-102422-bb5nfo2d |
 | podSecurityContext | object | `{"fsGroup":65532,"runAsNonRoot":true,"runAsUser":65532}` | Pod-level security context |
 | podSecurityContext.fsGroup | int | `65532` | Filesystem group for volume mounts |
 | podSecurityContext.runAsNonRoot | bool | `true` | Run all containers as non-root |

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -234,7 +234,7 @@ podLabels: {}
 #     environment: production
 #     team: platform
 #     hyperfleet-e2e-run: e2e-20260615-102422-bb5nfo2d
-# labels: {}
+labels: {}
 
 # -- Pod-level security context
 podSecurityContext:


### PR DESCRIPTION
## Summary

- HYPERFLEET-1108
- Uncomment `labels: {}` so the key is visible in `helm show values` output

Addresses nitpick from [#187](https://github.com/openshift-hyperfleet/hyperfleet-adapter/pull/187#discussion_r3442947548) that was merged before the fix could be applied.

## Test Plan

- [ ] `make test-helm` passes