### PR TITLE
HYPERFLEET-1178 - feat: add dry-run to test helm chart examples

### DIFF
--- a/charts/examples/kubernetes/dryrun-discovery.json
+++ b/charts/examples/kubernetes/dryrun-discovery.json
@@ -1,0 +1,75 @@
+{
+  "abc123-k8s": {
+    "apiVersion": "v1",
+    "kind": "Namespace",
+    "metadata": {
+      "name": "abc123-k8s",
+      "uid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "resourceVersion": "100",
+      "creationTimestamp": "2026-02-18T10:22:10Z",
+      "labels": {
+        "hyperfleet.io/cluster-id": "abc123",
+        "hyperfleet.io/cluster-name": "abc123",
+        "hyperfleet.io/managed-by": "kubernetes-example",
+        "hyperfleet.io/resource-type": "namespace"
+      },
+      "annotations": {
+        "hyperfleet.io/created-by": "hyperfleet-adapter",
+        "hyperfleet.io/generation": "77"
+      }
+    },
+    "spec": {
+      "finalizers": ["kubernetes"]
+    },
+    "status": {
+      "phase": "Active"
+    }
+  },
+  "hello-world-job": {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "name": "hello-world-job",
+      "namespace": "abc123-k8s",
+      "uid": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+      "resourceVersion": "200",
+      "creationTimestamp": "2026-02-18T10:22:11Z",
+      "labels": {
+        "hyperfleet.io/cluster-id": "abc123",
+        "hyperfleet.io/resource-type": "job"
+      },
+      "annotations": {
+        "hyperfleet.io/generation": "77"
+      }
+    },
+    "spec": {
+      "backoffLimit": 0,
+      "template": {
+        "spec": {
+          "restartPolicy": "Never",
+          "containers": [
+            {
+              "name": "hello-world",
+              "image": "alpine:3.19"
+            }
+          ]
+        }
+      }
+    },
+    "status": {
+      "conditions": [
+        {
+          "type": "Complete",
+          "status": "True",
+          "reason": "Completed",
+          "message": "Job completed successfully",
+          "lastTransitionTime": "2026-02-18T10:22:30Z"
+        }
+      ],
+      "startTime": "2026-02-18T10:22:12Z",
+      "completionTime": "2026-02-18T10:22:30Z",
+      "succeeded": 1,
+      "active": 0
+    }
+  }
+}

--- a/charts/examples/kubernetes/dryrun.sh
+++ b/charts/examples/kubernetes/dryrun.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run the kubernetes chart example as a dry-run inside a container.
+# The binary is built on the host (for Linux, matching host architecture) and
+# mounted into a minimal container. The resource file is mounted to /etc/adapter/
+# so that the task config's manifest.ref: /etc/adapter/job.yaml resolves correctly.
+#
+# Execute from the repository root:
+#   bash charts/examples/kubernetes/dryrun.sh
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+EXAMPLE_DIR="charts/examples/kubernetes"
+DRYRUN_DIR="test/testdata/dryrun"
+# Map host arch to Go/Docker equivalents
+case "$(uname -m)" in
+  arm64|aarch64) GOARCH=arm64; PLATFORM=linux/arm64 ;;
+  x86_64|amd64)  GOARCH=amd64; PLATFORM=linux/amd64 ;;
+  *) echo "Unsupported architecture: $(uname -m)"; exit 1 ;;
+esac
+
+BINARY="$REPO_ROOT/bin/hyperfleet-adapter-linux-$GOARCH"
+
+if [[ ! -f "$BINARY" ]]; then
+  echo "Binary not found at bin/hyperfleet-adapter-linux-$GOARCH — building for linux/$GOARCH..."
+  (cd "$REPO_ROOT" && GOOS=linux GOARCH=$GOARCH CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o "$BINARY" ./cmd/adapter)
+fi
+
+CONTAINER_TOOL=$(command -v podman 2>/dev/null || command -v docker 2>/dev/null)
+
+$CONTAINER_TOOL run --rm \
+  --platform "$PLATFORM" \
+  -v "$BINARY":/usr/local/bin/hyperfleet-adapter:z \
+  -v "$REPO_ROOT/$EXAMPLE_DIR/adapter-task-config.yaml":/etc/adapter/adapter-task-config.yaml:z \
+  -v "$REPO_ROOT/$EXAMPLE_DIR/adapter-task-resource-job.yaml":/etc/adapter/job.yaml:z \
+  -v "$REPO_ROOT/$EXAMPLE_DIR/dryrun-discovery.json":/example/dryrun-discovery.json:z \
+  -v "$REPO_ROOT/$DRYRUN_DIR":/dryrun:z \
+  alpine:3.21 \
+  /usr/local/bin/hyperfleet-adapter serve \
+    --dry-run-verbose \
+    --config /dryrun/dryrun-kubernetes-adapter-config.yaml \
+    --task-config /etc/adapter/adapter-task-config.yaml \
+    --dry-run-event /dryrun/event.json \
+    --dry-run-api-responses /dryrun/dryrun-api-responses.json \
+    --dry-run-discovery /example/dryrun-discovery.json

--- a/charts/examples/maestro-two-resources/dryrun-discovery.json
+++ b/charts/examples/maestro-two-resources/dryrun-discovery.json
@@ -1,0 +1,209 @@
+{
+  "abc123-mw2-cm": {
+    "apiVersion": "work.open-cluster-management.io/v1",
+    "kind": "ManifestWork",
+    "metadata": {
+      "name": "abc123-mw2-cm",
+      "namespace": "cluster1",
+      "uid": "aa111111-36df-5ebf-9007-87a65a27dfab",
+      "resourceVersion": "1",
+      "creationTimestamp": "2026-02-18T10:22:10Z",
+      "generation": 1,
+      "labels": {
+        "hyperfleet.io/cluster-id": "abc123",
+        "hyperfleet.io/adapter": "maestro-two-resources-example",
+        "hyperfleet.io/component": "configuration",
+        "hyperfleet.io/generation": "77",
+        "maestro.io/source-id": "maestro-two-resources-example"
+      }
+    },
+    "spec": {
+      "workload": {
+        "manifests": [
+          {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {
+              "name": "cluster-config",
+              "namespace": "abc123-mw2",
+              "labels": {
+                "hyperfleet.io/cluster-id": "abc123",
+                "hyperfleet.io/cluster-name": "abc123",
+                "hyperfleet.io/managed-by": "maestro-two-resources-example"
+              }
+            },
+            "data": {
+              "cluster_id": "abc123",
+              "cluster_name": "abc123"
+            }
+          }
+        ]
+      },
+      "deleteOption": {
+        "propagationPolicy": "Background"
+      }
+    },
+    "status": {
+      "conditions": [
+        {
+          "type": "Applied",
+          "status": "True",
+          "reason": "AppliedManifestWorkComplete",
+          "message": "Apply manifest work complete",
+          "lastTransitionTime": "2026-02-18T10:22:10Z",
+          "observedGeneration": 1
+        },
+        {
+          "type": "Available",
+          "status": "True",
+          "reason": "ResourcesAvailable",
+          "message": "All resources are available",
+          "lastTransitionTime": "2026-02-18T10:22:10Z",
+          "observedGeneration": 1
+        }
+      ],
+      "resourceStatus": {
+        "manifests": [
+          {
+            "resourceMeta": {
+              "ordinal": 0,
+              "group": "",
+              "version": "v1",
+              "kind": "ConfigMap",
+              "resource": "configmaps",
+              "name": "cluster-config",
+              "namespace": "abc123-mw2"
+            },
+            "conditions": [
+              {
+                "type": "Applied",
+                "status": "True",
+                "reason": "AppliedManifestComplete",
+                "message": "Apply manifest complete",
+                "lastTransitionTime": "2026-02-18T10:22:10Z"
+              },
+              {
+                "type": "Available",
+                "status": "True",
+                "reason": "ResourceAvailable",
+                "message": "Resource is available",
+                "lastTransitionTime": "2026-02-18T10:22:10Z"
+              }
+            ],
+            "statusFeedback": {}
+          }
+        ]
+      }
+    }
+  },
+  "abc123-mw2": {
+    "apiVersion": "work.open-cluster-management.io/v1",
+    "kind": "ManifestWork",
+    "metadata": {
+      "name": "abc123-mw2",
+      "namespace": "cluster1",
+      "uid": "bb222222-36df-5ebf-9007-87a65a27dfab",
+      "resourceVersion": "1",
+      "creationTimestamp": "2026-02-18T10:22:10Z",
+      "generation": 1,
+      "labels": {
+        "hyperfleet.io/cluster-id": "abc123",
+        "hyperfleet.io/adapter": "maestro-two-resources-example",
+        "hyperfleet.io/component": "infrastructure",
+        "hyperfleet.io/generation": "77",
+        "maestro.io/source-id": "maestro-two-resources-example"
+      }
+    },
+    "spec": {
+      "workload": {
+        "manifests": [
+          {
+            "apiVersion": "v1",
+            "kind": "Namespace",
+            "metadata": {
+              "name": "abc123-mw2",
+              "labels": {
+                "hyperfleet.io/cluster-id": "abc123",
+                "hyperfleet.io/cluster-name": "abc123",
+                "hyperfleet.io/managed-by": "maestro-two-resources-example",
+                "hyperfleet.io/resource-type": "namespace"
+              }
+            }
+          }
+        ]
+      },
+      "deleteOption": {
+        "propagationPolicy": "Foreground"
+      }
+    },
+    "status": {
+      "conditions": [
+        {
+          "type": "Applied",
+          "status": "True",
+          "reason": "AppliedManifestWorkComplete",
+          "message": "Apply manifest work complete",
+          "lastTransitionTime": "2026-02-18T10:22:10Z",
+          "observedGeneration": 1
+        },
+        {
+          "type": "Available",
+          "status": "True",
+          "reason": "ResourcesAvailable",
+          "message": "All resources are available",
+          "lastTransitionTime": "2026-02-18T10:22:10Z",
+          "observedGeneration": 1
+        }
+      ],
+      "resourceStatus": {
+        "manifests": [
+          {
+            "resourceMeta": {
+              "ordinal": 0,
+              "group": "",
+              "version": "v1",
+              "kind": "Namespace",
+              "resource": "namespaces",
+              "name": "abc123-mw2",
+              "namespace": ""
+            },
+            "conditions": [
+              {
+                "type": "Applied",
+                "status": "True",
+                "reason": "AppliedManifestComplete",
+                "message": "Apply manifest complete",
+                "lastTransitionTime": "2026-02-18T10:22:10Z"
+              },
+              {
+                "type": "Available",
+                "status": "True",
+                "reason": "ResourceAvailable",
+                "message": "Resource is available",
+                "lastTransitionTime": "2026-02-18T10:22:10Z"
+              },
+              {
+                "type": "StatusFeedbackSynced",
+                "status": "True",
+                "reason": "StatusFeedbackSynced",
+                "message": "",
+                "lastTransitionTime": "2026-02-18T10:22:10Z"
+              }
+            ],
+            "statusFeedback": {
+              "values": [
+                {
+                  "name": "phase",
+                  "fieldValue": {
+                    "type": "String",
+                    "string": "Active"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/charts/examples/maestro-two-resources/dryrun.sh
+++ b/charts/examples/maestro-two-resources/dryrun.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run the maestro-two-resources chart example as a dry-run inside a container.
+# The binary is built on the host (for Linux, matching host architecture) and
+# mounted into a minimal container. The two resource files are mounted to /etc/adapter/
+# so that the task config's manifest.ref paths resolve correctly:
+#   /etc/adapter/manifestwork-configmap.yaml
+#   /etc/adapter/manifestwork-namespace.yaml
+#
+# Execute from the repository root:
+#   bash charts/examples/maestro-two-resources/dryrun.sh
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+EXAMPLE_DIR="charts/examples/maestro-two-resources"
+DRYRUN_DIR="test/testdata/dryrun"
+
+# Map host arch to Go/Docker equivalents
+case "$(uname -m)" in
+  arm64|aarch64) GOARCH=arm64; PLATFORM=linux/arm64 ;;
+  x86_64|amd64)  GOARCH=amd64; PLATFORM=linux/amd64 ;;
+  *) echo "Unsupported architecture: $(uname -m)"; exit 1 ;;
+esac
+
+BINARY="$REPO_ROOT/bin/hyperfleet-adapter-linux-$GOARCH"
+
+if [[ ! -f "$BINARY" ]]; then
+  echo "Binary not found at bin/hyperfleet-adapter-linux-$GOARCH — building for linux/$GOARCH..."
+  (cd "$REPO_ROOT" && GOOS=linux GOARCH=$GOARCH CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o "$BINARY" ./cmd/adapter)
+fi
+
+CONTAINER_TOOL=$(command -v podman 2>/dev/null || command -v docker 2>/dev/null)
+
+$CONTAINER_TOOL run --rm \
+  --platform "$PLATFORM" \
+  -v "$BINARY":/usr/local/bin/hyperfleet-adapter:z \
+  -v "$REPO_ROOT/$EXAMPLE_DIR/adapter-task-config.yaml":/etc/adapter/adapter-task-config.yaml:z \
+  -v "$REPO_ROOT/$EXAMPLE_DIR/adapter-task-resource-manifestwork-configmap.yaml":/etc/adapter/manifestwork-configmap.yaml:z \
+  -v "$REPO_ROOT/$EXAMPLE_DIR/adapter-task-resource-manifestwork-namespace.yaml":/etc/adapter/manifestwork-namespace.yaml:z \
+  -v "$REPO_ROOT/$EXAMPLE_DIR/dryrun-discovery.json":/example/dryrun-discovery.json:z \
+  -v "$REPO_ROOT/$DRYRUN_DIR":/dryrun:z \
+  alpine:3.21 \
+  /usr/local/bin/hyperfleet-adapter serve \
+    --dry-run-verbose \
+    --config /dryrun/dryrun-maestro-adapter-config.yaml \
+    --task-config /etc/adapter/adapter-task-config.yaml \
+    --dry-run-event /dryrun/event.json \
+    --dry-run-api-responses /dryrun/dryrun-api-responses.json \
+    --dry-run-discovery /example/dryrun-discovery.json

--- a/charts/examples/maestro/dryrun-discovery.json
+++ b/charts/examples/maestro/dryrun-discovery.json
@@ -1,0 +1,158 @@
+{
+  "abc123-mw": {
+    "apiVersion": "work.open-cluster-management.io/v1",
+    "kind": "ManifestWork",
+    "metadata": {
+      "name": "abc123-mw",
+      "namespace": "cluster1",
+      "uid": "fc58b0b8-36df-5ebf-9007-87a65a27dfab",
+      "resourceVersion": "1",
+      "creationTimestamp": "2026-02-18T10:22:10Z",
+      "generation": 1,
+      "labels": {
+        "hyperfleet.io/cluster-id": "abc123",
+        "hyperfleet.io/adapter": "maestro-example",
+        "hyperfleet.io/component": "infrastructure",
+        "hyperfleet.io/generation": "77",
+        "hyperfleet.io/resource-group": "cluster-setup",
+        "maestro.io/source-id": "maestro-example",
+        "app.kubernetes.io/managed-by": "maestro-example"
+      }
+    },
+    "spec": {
+      "workload": {
+        "manifests": [
+          {
+            "apiVersion": "v1",
+            "kind": "Namespace",
+            "metadata": {
+              "name": "abc123-mw",
+              "labels": {
+                "hyperfleet.io/cluster-id": "abc123",
+                "hyperfleet.io/managed-by": "maestro-example",
+                "hyperfleet.io/resource-type": "namespace"
+              }
+            }
+          },
+          {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {
+              "name": "cluster-config",
+              "namespace": "abc123-mw",
+              "labels": {
+                "hyperfleet.io/cluster-id": "abc123",
+                "hyperfleet.io/cluster-name": "abc123"
+              }
+            },
+            "data": {
+              "cluster_id": "abc123",
+              "cluster_name": "abc123"
+            }
+          }
+        ]
+      },
+      "deleteOption": {
+        "propagationPolicy": "Foreground",
+        "gracePeriodSeconds": 30
+      }
+    },
+    "status": {
+      "conditions": [
+        {
+          "type": "Applied",
+          "status": "True",
+          "reason": "AppliedManifestWorkComplete",
+          "message": "Apply manifest work complete",
+          "lastTransitionTime": "2026-02-18T10:22:10Z",
+          "observedGeneration": 1
+        },
+        {
+          "type": "Available",
+          "status": "True",
+          "reason": "ResourcesAvailable",
+          "message": "All resources are available",
+          "lastTransitionTime": "2026-02-18T10:22:10Z",
+          "observedGeneration": 1
+        }
+      ],
+      "resourceStatus": {
+        "manifests": [
+          {
+            "resourceMeta": {
+              "ordinal": 0,
+              "group": "",
+              "version": "v1",
+              "kind": "Namespace",
+              "resource": "namespaces",
+              "name": "abc123-mw",
+              "namespace": ""
+            },
+            "conditions": [
+              {
+                "type": "Applied",
+                "status": "True",
+                "reason": "AppliedManifestComplete",
+                "message": "Apply manifest complete",
+                "lastTransitionTime": "2026-02-18T10:22:10Z"
+              },
+              {
+                "type": "Available",
+                "status": "True",
+                "reason": "ResourceAvailable",
+                "message": "Resource is available",
+                "lastTransitionTime": "2026-02-18T10:22:10Z"
+              },
+              {
+                "type": "StatusFeedbackSynced",
+                "status": "True",
+                "reason": "StatusFeedbackSynced",
+                "message": "",
+                "lastTransitionTime": "2026-02-18T10:22:10Z"
+              }
+            ],
+            "statusFeedback": {
+              "values": [
+                {
+                  "name": "phase",
+                  "fieldValue": {
+                    "type": "String",
+                    "string": "Active"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "resourceMeta": {
+              "ordinal": 1,
+              "group": "",
+              "version": "v1",
+              "kind": "ConfigMap",
+              "resource": "configmaps",
+              "name": "cluster-config",
+              "namespace": "abc123-mw"
+            },
+            "conditions": [
+              {
+                "type": "Applied",
+                "status": "True",
+                "reason": "AppliedManifestComplete",
+                "message": "Apply manifest complete",
+                "lastTransitionTime": "2026-02-18T10:22:10Z"
+              },
+              {
+                "type": "Available",
+                "status": "True",
+                "reason": "ResourceAvailable",
+                "message": "Resource is available",
+                "lastTransitionTime": "2026-02-18T10:22:10Z"
+              }
+            ],
+            "statusFeedback": {}
+          }
+        ]
+      }
+    }
+  }
+}

--- a/charts/examples/maestro/dryrun.sh
+++ b/charts/examples/maestro/dryrun.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run the maestro chart example as a dry-run inside a container.
+# The binary is built on the host (for Linux, matching host architecture) and
+# mounted into a minimal container. The resource file is mounted to /etc/adapter/
+# so that the task config's manifest.ref: /etc/adapter/manifestwork.yaml resolves correctly.
+#
+# Execute from the repository root:
+#   bash charts/examples/maestro/dryrun.sh
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+EXAMPLE_DIR="charts/examples/maestro"
+DRYRUN_DIR="test/testdata/dryrun"
+
+# Map host arch to Go/Docker equivalents
+case "$(uname -m)" in
+  arm64|aarch64) GOARCH=arm64; PLATFORM=linux/arm64 ;;
+  x86_64|amd64)  GOARCH=amd64; PLATFORM=linux/amd64 ;;
+  *) echo "Unsupported architecture: $(uname -m)"; exit 1 ;;
+esac
+
+BINARY="$REPO_ROOT/bin/hyperfleet-adapter-linux-$GOARCH"
+
+if [[ ! -f "$BINARY" ]]; then
+  echo "Binary not found at bin/hyperfleet-adapter-linux-$GOARCH — building for linux/$GOARCH..."
+  (cd "$REPO_ROOT" && GOOS=linux GOARCH=$GOARCH CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o "$BINARY" ./cmd/adapter)
+fi
+
+CONTAINER_TOOL=$(command -v podman 2>/dev/null || command -v docker 2>/dev/null)
+
+$CONTAINER_TOOL run --rm \
+  --platform "$PLATFORM" \
+  -v "$BINARY":/usr/local/bin/hyperfleet-adapter:z \
+  -v "$REPO_ROOT/$EXAMPLE_DIR/adapter-task-config.yaml":/etc/adapter/adapter-task-config.yaml:z \
+  -v "$REPO_ROOT/$EXAMPLE_DIR/adapter-task-resource-manifestwork.yaml":/etc/adapter/manifestwork.yaml:z \
+  -v "$REPO_ROOT/$EXAMPLE_DIR/dryrun-discovery.json":/example/dryrun-discovery.json:z \
+  -v "$REPO_ROOT/$DRYRUN_DIR":/dryrun:z \
+  alpine:3.21 \
+  /usr/local/bin/hyperfleet-adapter serve \
+    --dry-run-verbose \
+    --config /dryrun/dryrun-maestro-adapter-config.yaml \
+    --task-config /etc/adapter/adapter-task-config.yaml \
+    --dry-run-event /dryrun/event.json \
+    --dry-run-api-responses /dryrun/dryrun-api-responses.json \
+    --dry-run-discovery /example/dryrun-discovery.json


### PR DESCRIPTION
## Summary

Adds dryrun.sh scripts to each chart example (kubernetes, maestro, maestro-two-resources) so adapters can be exercised locally without a broker or cluster.

 The scripts build a Linux binary on the host (arch-aware: arm64/amd64) and mount it into a minimal alpine:3.21 container, avoiding the overhead of the golang:1.25 image and Go module cache management. The host binary is written to bin/hyperfleet-adapter-linux-<arch> to avoid overwriting the native macOS build.

  Key details:
  - Binary is auto-built on first run if not present; skipped on subsequent runs
  - --platform is set from uname -m so the correct image architecture is pulled
  - Task config and resource files are mounted under /etc/adapter/ to satisfy the file-reference base-directory validation
  - Shared dryrun fixtures (event.json, dryrun-api-responses.json, adapter config) are mounted from test/testdata/dryrun/
