### PR TITLE
HYPERFLEET-1247 - fix: distinguish broken URL 404 from resource 404

### DIFF
--- a/docs/adapter-authoring-guide.md
+++ b/docs/adapter-authoring-guide.md
@@ -785,24 +785,29 @@ The resource executor treats apply and delete operations differently when they f
 
 This means a list containing both apply and delete operations behaves predictably: a delete failure does not prevent the next resource from being deleted, but an apply failure stops further processing.
 
-### Force-deleted resources (404 handling)
+### Resource not found (404 handling)
 
-When a resource is force-deleted externally (e.g., removed from the HyperFleet API while the adapter is running), the precondition API call returns a `404 Not Found`. Instead of treating this as a hard failure, the adapter handles it gracefully:
+When a precondition API call returns `404 Not Found`, it can mean the resource no longer exists (e.g., deleted externally, incorrect ID in the event, direct DB removal) or that the precondition URL itself is misconfigured. The adapter distinguishes between two types of 404:
+
+- **Resource not found** (default): any 404 is treated as a legitimate "resource does not exist" unless proven otherwise. This includes responses with specific error codes (`HYPERFLEET-NTF-001`, `HYPERFLEET-NTF-002`, `HYPERFLEET-NTF-003`), as well as 404s where the response body was stripped by a proxy or gateway. The adapter handles this gracefully — resources are skipped and post-actions still execute.
+- **Broken endpoint** (error code `HYPERFLEET-NTF-000`): the catch-all 404 handler confirms no route matched the URL. The adapter treats this as a configuration error and reports failure status.
+
+When the adapter detects a resource-not-found 404:
 
 - `adapter.resourcesSkipped` is set to `true`
 - `adapter.skipReason` is set to `"ResourceNotFound"`
 - The resources phase is skipped entirely
 - Post-actions still execute, so the adapter can report the skip back to the API
 
-This means your post-action CEL expressions can detect force-deletion and report an appropriate status:
+This means your post-action CEL expressions can detect the missing resource and report an appropriate status:
 
 ```cel
 adapter.?skipReason.orValue("") == "ResourceNotFound"
-  ? "Resource was deleted externally"
+  ? "Resource does not exist"
   : adapter.?skipReason.orValue("unknown reason")
 ```
 
-The same 404 handling applies during post-action execution: if a post-action API call returns 404, remaining post-actions are skipped gracefully rather than failed.
+The same 404 handling applies during post-action execution: a post-action 404 is treated as resource-not-found and remaining post-actions are skipped gracefully, unless the response contains error code `HYPERFLEET-NTF-000` indicating a misconfigured URL.
 
 ### Partial delete failures
 
@@ -1753,4 +1758,4 @@ See also [Preconditions — Supported operators](#supported-operators).
 | `CEL expression parse error` | Invalid CEL syntax | Verify parentheses, string quoting, and optional chaining syntax (`?.` for safe field access). |
 | Discovery returns empty | Labels don't match or wrong namespace | Verify `discovery.namespace` is correct. Use `by_name` for a simpler lookup. Check resource labels match the selector exactly. |
 | `observed_generation` is a string | Using Go Template instead of CEL expression | Use `expression: "generation"` instead of `"{{ .generation }}"`. |
-| Post-action API call returns 404 | Wrong status endpoint path | Cluster statuses: `/clusters/{id}/statuses`. NodePool statuses: `/clusters/{id}/nodepools/{id}/statuses`. |
+| Post-action API call returns 404 with error status | Wrong status endpoint path (error code `HYPERFLEET-NTF-000`) | Cluster statuses: `/clusters/{id}/statuses`. NodePool statuses: `/clusters/{id}/nodepools/{id}/statuses`. |

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -129,9 +129,9 @@ func (e *Executor) Execute(ctx context.Context, data interface{}) *ExecutionResu
 	result.PreconditionResults = precondOutcome.Results
 
 	switch {
-	case precondOutcome.Error != nil && apierrors.IsNotFoundError(precondOutcome.Error):
-		// Resource was force-deleted: API returned 404. Log and stop processing gracefully.
-		// No point running resources or post-actions for a resource that no longer exists.
+	case precondOutcome.Error != nil && apierrors.IsResourceNotFoundError(precondOutcome.Error):
+		// Resource no longer exists (e.g. deleted externally, wrong ID in event).
+		// Stop processing gracefully.
 		e.log.Infof(ctx, "Phase %s: resource not found, stopping processing gracefully",
 			result.CurrentPhase)
 		result.ResourcesSkipped = true
@@ -203,8 +203,8 @@ func (e *Executor) Execute(ctx context.Context, data interface{}) *ExecutionResu
 	result.PostActionResults = postResults
 
 	if err != nil {
-		if apierrors.IsNotFoundError(err) {
-			// Resource was force-deleted mid-execution. Log and continue, don't fail.
+		if apierrors.IsResourceNotFoundError(err) {
+			// Resource no longer exists. Log and continue, don't fail.
 			e.log.Infof(ctx, "Phase %s: resource not found, skipping remaining post-actions",
 				result.CurrentPhase)
 			result.ResourcesSkipped = true

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -41,16 +41,44 @@ func mockErrorResponse(statusCode int) (*hyperfleetapi.Response, error) {
 	return resp, apiErr
 }
 
-// mock404Response returns a 404 response without an error. The MockClient only
-// returns (nil, error) when an error is set, so using mockErrorResponse for 404
-// tests causes ExecuteAPICall to wrap the error in a new APIError with StatusCode=0,
-// which breaks IsNotFoundError detection. Setting only the response lets
-// ValidateAPIResponse create the correct APIError{StatusCode:404}.
+// mock404Response returns a 404 response with code HYPERFLEET-NTF-002,
+// representing a real resource that was not found.
+// The MockClient only returns (nil, error) when an error is set, so using
+// mockErrorResponse for 404 tests causes ExecuteAPICall to wrap the error
+// in a new APIError with StatusCode=0, which breaks detection. Setting
+// only the response lets ValidateAPIResponse create the correct APIError.
 func mock404Response() *hyperfleetapi.Response {
+	body := `{
+		"type": "https://api.hyperfleet.io/errors/resource-not-found",
+		"title": "Resource Not Found",
+		"status": 404,
+		"detail": "Cluster with id='abc123' not found",
+		"code": "HYPERFLEET-NTF-002",
+		"trace_id": "019ed716-f3cf-7b8e-b400-0796be4722c3"
+	}`
 	return &hyperfleetapi.Response{
 		StatusCode: 404,
 		Status:     "404 Not Found",
-		Body:       []byte(`{"error":"not found"}`),
+		Body:       []byte(body),
+		Attempts:   1,
+	}
+}
+
+// mockBrokenEndpoint404Response returns a 404 with code HYPERFLEET-NTF-000,
+// representing a misconfigured/broken precondition URL.
+func mockBrokenEndpoint404Response() *hyperfleetapi.Response {
+	body := `{
+		"type": "https://api.hyperfleet.io/errors/endpoint-not-found",
+		"title": "Endpoint Not Found",
+		"status": 404,
+		"detail": "The requested endpoint does not exist",
+		"code": "HYPERFLEET-NTF-000",
+		"trace_id": ""
+	}`
+	return &hyperfleetapi.Response{
+		StatusCode: 404,
+		Status:     "404 Not Found",
+		Body:       []byte(body),
 		Attempts:   1,
 	}
 }
@@ -1454,7 +1482,7 @@ func findFamily(families []*dto.MetricFamily, name string) *dto.MetricFamily {
 }
 
 // TestPrecondition404_GracefulStop verifies that when a precondition API call returns 404
-// (resource force-deleted), the executor stops gracefully: status remains "success",
+// (resource no longer exists), the executor stops gracefully: status remains "success",
 // resources are skipped, and no error state is set.
 func new404PreconditionConfig() *configloader.Config {
 	return &configloader.Config{
@@ -1533,7 +1561,7 @@ func TestPrecondition404_GracefulStop(t *testing.T) {
 }
 
 // TestPostAction404_GracefulHandling verifies that when a post-action API call returns 404
-// (resource force-deleted), the executor does not mark the execution as failed.
+// (resource no longer exists), the executor does not mark the execution as failed.
 func TestPostAction404_GracefulHandling(t *testing.T) {
 	mockClient := newMockAPIClient()
 	mockClient.GetResponse = &hyperfleetapi.Response{
@@ -1626,6 +1654,56 @@ func TestPreconditionFail_PostAction404(t *testing.T) {
 	// No post-action error recorded (404 is handled gracefully)
 	assert.Nil(t, result.Errors[PhasePostActions],
 		"post-action 404 should not add an error")
+}
+
+// TestPreconditionBrokenURL404_ReportsError verifies that when a
+// precondition API call returns 404 due to a misconfigured URL (error
+// code HYPERFLEET-NTF-000), the adapter treats it as an error rather than a graceful stop.
+func TestPreconditionBrokenURL404_ReportsError(t *testing.T) {
+	mockClient := newMockAPIClient()
+	mockClient.GetResponse = mockBrokenEndpoint404Response()
+
+	config := new404PreconditionConfig()
+	exec := build404TestExecutor(t, config, mockClient)
+
+	ctx := logger.WithEventID(context.Background(), "test-broken-url-404")
+	result := exec.Execute(ctx, map[string]interface{}{"id": "cls-123"})
+
+	assert.Equal(t, StatusFailed, result.Status,
+		"broken URL 404 should mark execution as failed")
+
+	assert.True(t, result.ResourcesSkipped,
+		"resources should be skipped on precondition failure")
+
+	assert.NotEmpty(t, result.Errors,
+		"errors should be recorded for a broken URL 404")
+}
+
+// TestPostActionBrokenURL404_ReportsError verifies that when a post-action
+// API call returns 404 due to a misconfigured URL (error code
+// HYPERFLEET-NTF-000), the adapter treats it as an error instead of a graceful stop.
+func TestPostActionBrokenURL404_ReportsError(t *testing.T) {
+	mockClient := newMockAPIClient()
+	mockClient.GetResponse = &hyperfleetapi.Response{
+		StatusCode: 200,
+		Body: []byte(
+			`{"id":"cluster-456","status":{"conditions":` +
+				`[{"type":"Reconciled","status":"False"}]}}`,
+		),
+	}
+	mockClient.PutResponse = mockBrokenEndpoint404Response()
+
+	config := new404PostActionConfig()
+	exec := build404TestExecutor(t, config, mockClient)
+
+	ctx := logger.WithEventID(context.Background(), "test-post-broken-url-404")
+	result := exec.Execute(ctx, map[string]interface{}{"id": "cls-123"})
+
+	assert.Equal(t, StatusFailed, result.Status,
+		"broken URL 404 in post-actions should mark execution as failed")
+
+	assert.NotNil(t, result.Errors[PhasePostActions],
+		"post-action error should be recorded for a broken URL 404")
 }
 
 func getCounterValue(t *testing.T, families []*dto.MetricFamily, metricName, labelName, labelValue string) float64 {

--- a/pkg/errors/api_error.go
+++ b/pkg/errors/api_error.go
@@ -2,6 +2,7 @@ package errors
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -30,6 +31,28 @@ type APIError struct {
 	StatusCode int
 	// Attempts is how many attempts were made (including retries)
 	Attempts int
+}
+
+// brokenEndpointCode is the RFC 9457 error code the HyperFleet API returns
+// from its catch-all 404 handler when no route matched the request URL.
+const brokenEndpointCode = "HYPERFLEET-NTF-000"
+
+// problemDetails is a subset of RFC 9457 Problem Details used to distinguish
+// resource-not-found from broken-endpoint 404 responses.
+type problemDetails struct {
+	Code string `json:"code"`
+}
+
+// parseProblemDetails attempts to parse the response body as RFC 9457 Problem Details.
+func (e *APIError) parseProblemDetails() (problemDetails, bool) {
+	if !e.HasResponseBody() {
+		return problemDetails{}, false
+	}
+	var pd problemDetails
+	if err := json.Unmarshal(e.ResponseBody, &pd); err != nil {
+		return problemDetails{}, false
+	}
+	return pd, true
 }
 
 // Error implements the error interface.
@@ -71,6 +94,22 @@ func (e *APIError) IsClientError() bool {
 // IsNotFound returns true if the error was a 404 Not Found
 func (e *APIError) IsNotFound() bool {
 	return e.StatusCode == 404
+}
+
+// IsResourceNotFound returns true when the 404 represents a real resource that
+// was not found, as opposed to a broken/misconfigured URL.
+// It defaults to true for any 404 (safe fallback if proxies strip the response
+// body), and only returns false when the RFC 9457 body contains the catch-all
+// error code HYPERFLEET-NTF-000, which signals no route matched the request URL.
+func (e *APIError) IsResourceNotFound() bool {
+	if !e.IsNotFound() {
+		return false
+	}
+	pd, ok := e.parseProblemDetails()
+	if !ok {
+		return true
+	}
+	return pd.Code != brokenEndpointCode
 }
 
 // IsUnauthorized returns true if the error was a 401 Unauthorized
@@ -162,4 +201,11 @@ func IsAPIError(err error) (*APIError, bool) {
 func IsNotFoundError(err error) bool {
 	apiErr, ok := IsAPIError(err)
 	return ok && apiErr.IsNotFound()
+}
+
+// IsResourceNotFoundError checks whether err is a 404 APIError that represents
+// a real resource not found (not a broken/misconfigured endpoint URL).
+func IsResourceNotFoundError(err error) bool {
+	apiErr, ok := IsAPIError(err)
+	return ok && apiErr.IsResourceNotFound()
 }

--- a/pkg/errors/api_error_test.go
+++ b/pkg/errors/api_error_test.go
@@ -7,6 +7,152 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func resourceNotFoundBody() []byte {
+	return []byte(`{
+		"type": "https://api.hyperfleet.io/errors/resource-not-found",
+		"title": "Resource Not Found",
+		"status": 404,
+		"detail": "Cluster with id='cls-123' not found",
+		"instance": "/api/hyperfleet/v1/clusters/cls-123",
+		"code": "HYPERFLEET-NTF-002",
+		"trace_id": "019ed716-f3cf-7b8e-b400-0796be4722c3"
+	}`)
+}
+
+func brokenEndpointBody() []byte {
+	return []byte(`{
+		"type": "https://api.hyperfleet.io/errors/endpoint-not-found",
+		"title": "Endpoint Not Found",
+		"status": 404,
+		"detail": "The requested endpoint '/api/hyperfleet/v1/clusters-BROKEN/cls-123' does not exist",
+		"instance": "/api/hyperfleet/v1/clusters-BROKEN/cls-123",
+		"code": "HYPERFLEET-NTF-000",
+		"trace_id": ""
+	}`)
+}
+
+func new404APIError(url string, body []byte) *APIError {
+	return NewAPIError(
+		"GET", url, 404, "404 Not Found",
+		body, 1, 0, fmt.Errorf("not found"),
+	)
+}
+
+func TestIsResourceNotFound(t *testing.T) {
+	tests := []struct {
+		err  *APIError
+		name string
+		want bool
+	}{
+		{
+			name: "resource not found with HYPERFLEET-NTF-002 code",
+			err:  new404APIError("/clusters/cls-123", resourceNotFoundBody()),
+			want: true,
+		},
+		{
+			name: "nodepool not found with HYPERFLEET-NTF-003 code",
+			err: new404APIError("/clusters/cls-123/nodepools/np-1", []byte(`{
+				"type": "https://api.hyperfleet.io/errors/not-found",
+				"title": "NodePool Not Found",
+				"status": 404,
+				"detail": "NodePool with id='np-1' not found",
+				"code": "HYPERFLEET-NTF-003"
+			}`)),
+			want: true,
+		},
+		{
+			name: "broken endpoint with HYPERFLEET-NTF-000 code",
+			err:  new404APIError("/clusters-BROKEN/cls-123", brokenEndpointBody()),
+			want: false,
+		},
+		{
+			name: "404 without response body defaults to resource not found",
+			err:  new404APIError("/clusters/cls-123", nil),
+			want: true,
+		},
+		{
+			name: "404 with unparseable body defaults to resource not found",
+			err:  new404APIError("/clusters/cls-123", []byte("not json")),
+			want: true,
+		},
+		{
+			name: "404 with empty JSON object defaults to resource not found",
+			err:  new404APIError("/clusters/cls-123", []byte("{}")),
+			want: true,
+		},
+		{
+			name: "non-404 with trace_id",
+			err: NewAPIError(
+				"GET", "/clusters/cls-123",
+				500, "500 Internal Server Error",
+				resourceNotFoundBody(), 1, 0,
+				fmt.Errorf("server error"),
+			),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.err.IsResourceNotFound(),
+				"IsResourceNotFound mismatch for %q", tt.name)
+		})
+	}
+}
+
+func TestIsResourceNotFoundError(t *testing.T) {
+	tests := []struct {
+		err  error
+		name string
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "plain error",
+			err:  fmt.Errorf("something went wrong"),
+			want: false,
+		},
+		{
+			name: "resource not found direct",
+			err:  new404APIError("/clusters/cls-123", resourceNotFoundBody()),
+			want: true,
+		},
+		{
+			name: "resource not found wrapped",
+			err: fmt.Errorf("precondition failed: %w",
+				new404APIError("/clusters/cls-123", resourceNotFoundBody())),
+			want: true,
+		},
+		{
+			name: "broken endpoint direct",
+			err:  new404APIError("/clusters-BROKEN/cls-123", brokenEndpointBody()),
+			want: false,
+		},
+		{
+			name: "broken endpoint wrapped",
+			err: fmt.Errorf("precondition failed: %w",
+				new404APIError("/clusters-BROKEN/cls-123", brokenEndpointBody())),
+			want: false,
+		},
+		{
+			name: "404 without body defaults to resource not found",
+			err:  new404APIError("/clusters/cls-123", nil),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsResourceNotFoundError(tt.err),
+				"IsResourceNotFoundError mismatch for %q", tt.name)
+		})
+	}
+}
+
 func TestIsNotFoundError(t *testing.T) {
 	tests := []struct {
 		err  error

--- a/test/testdata/dryrun/dryrun-404-api-responses.json
+++ b/test/testdata/dryrun/dryrun-404-api-responses.json
@@ -9,14 +9,16 @@
         {
           "statusCode": 404,
           "headers": {
-            "Content-Type": "application/json"
+            "Content-Type": "application/problem+json"
           },
           "body": {
-            "kind": "Error",
-            "id": "404",
-            "href": "/api/hyperfleet/v1/errors/404",
-            "code": "HYPERFLEET-NTF-001",
-            "reason": "Cluster 'abc123' not found"
+            "type": "https://api.hyperfleet.io/errors/resource-not-found",
+            "title": "Resource Not Found",
+            "status": 404,
+            "detail": "Cluster with id='abc123' not found",
+            "instance": "/api/hyperfleet/v1/clusters/abc123",
+            "code": "HYPERFLEET-NTF-002",
+            "trace_id": "019ed716-f3cf-7b8e-b400-0796be4722c3"
           }
         }
       ]
@@ -30,14 +32,16 @@
         {
           "statusCode": 404,
           "headers": {
-            "Content-Type": "application/json"
+            "Content-Type": "application/problem+json"
           },
           "body": {
-            "kind": "Error",
-            "id": "404",
-            "href": "/api/hyperfleet/v1/errors/404",
-            "code": "HYPERFLEET-NTF-001",
-            "reason": "Cluster 'abc123' not found"
+            "type": "https://api.hyperfleet.io/errors/resource-not-found",
+            "title": "Resource Not Found",
+            "status": 404,
+            "detail": "Cluster with id='abc123' not found",
+            "instance": "/api/hyperfleet/v1/clusters/abc123/statuses",
+            "code": "HYPERFLEET-NTF-002",
+            "trace_id": "019ed716-f3cf-7b8e-b400-0796be4722c3"
           }
         }
       ]

--- a/test/testdata/dryrun/dryrun-post-action-404-api-responses.json
+++ b/test/testdata/dryrun/dryrun-post-action-404-api-responses.json
@@ -45,14 +45,16 @@
         {
           "statusCode": 404,
           "headers": {
-            "Content-Type": "application/json"
+            "Content-Type": "application/problem+json"
           },
           "body": {
-            "kind": "Error",
-            "id": "404",
-            "href": "/api/hyperfleet/v1/errors/404",
-            "code": "HYPERFLEET-NTF-001",
-            "reason": "Cluster 'abc123' not found"
+            "type": "https://api.hyperfleet.io/errors/resource-not-found",
+            "title": "Resource Not Found",
+            "status": 404,
+            "detail": "Cluster with id='abc123' not found",
+            "instance": "/api/hyperfleet/v1/clusters/abc123/statuses",
+            "code": "HYPERFLEET-NTF-002",
+            "trace_id": "019ed716-f3cf-7b8e-b400-0796be4722c3"
           }
         }
       ]


### PR DESCRIPTION
## Summary

- Adapter now checks the RFC 9457 error code on 404 responses to distinguish broken endpoints from force-deleted resources
- A 404 with code `HYPERFLEET-NTF-000` (catch-all, no route matched) is treated as a configuration error
- Any other 404 (including missing/stripped response body) defaults to resource-not-found — graceful handling
- Added `IsResourceNotFound()` / `IsResourceNotFoundError()` to `pkg/errors/api_error.go`
- Updated test fixtures to use RFC 9457 format
- Updated adapter-authoring-guide documentation

## Dependencies

- Requires API PR: https://github.com/openshift-hyperfleet/hyperfleet-api/pull/251

## Test plan

- [x] Unit tests for `IsResourceNotFound` with NTF-000/NTF-002/NTF-003/empty body/unparseable body
- [x] Unit tests for `IsResourceNotFoundError` with direct and wrapped errors
- [x] Executor test: broken URL 404 (NTF-000) results in error status
- [x] Executor test: resource not found 404 (NTF-002) continues graceful handling
- [x] All existing 404 tests still pass
- [x] `make lint` passes with 0 issues

Fixes: https://redhat.atlassian.net/browse/HYPERFLEET-1247