### PR TITLE
HYPERFLEET-1317 - chore: add Ruclo to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,7 @@ approvers:
 - pnguyen44
 - rafabene
 - rh-amarin
+- Ruclo
 - tirthct
 - vkareh
 - kuudori
@@ -26,6 +27,7 @@ reviewers:
 - pnguyen44
 - rafabene
 - rh-amarin
+- Ruclo
 - tirthct
 - vkareh
 - kuudori


### PR DESCRIPTION
## Summary
- Add GitHub user Ruclo (Michal Vavrinec) as reviewer and approver to OWNERS

## JIRA
https://redhat.atlassian.net/browse/HYPERFLEET-1317