### PR TITLE
HYPERFLEET-1080 - chore: add when clause to post-action examples and test configs

### DIFF
--- a/charts/examples/kubernetes/adapter-task-config.yaml
+++ b/charts/examples/kubernetes/adapter-task-config.yaml
@@ -162,6 +162,8 @@ post:
 
   post_actions:
     - name: "reportClusterStatus"
+      when:
+        expression: "!adapter.resourcesSkipped"
       api_call:
         method: "PUT"
         url: "/clusters/{{ .clusterId }}/statuses"

--- a/docs/adapter-authoring-guide.md
+++ b/docs/adapter-authoring-guide.md
@@ -1499,6 +1499,8 @@ Post-actions target the NodePool status endpoint instead of the cluster one:
 ```yaml
 post_actions:
   - name: "reportNodepoolStatus"
+    when:
+      expression: "!adapter.resourcesSkipped"
     api_call:
       method: "PUT"
       url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}/nodepools/{{ .nodepoolId }}/statuses"

--- a/test/integration/config-loader/testdata/adapter-config-template.yaml
+++ b/test/integration/config-loader/testdata/adapter-config-template.yaml
@@ -373,8 +373,12 @@ post:
   # ============================================================================
   # Post actions are executed after resources are created/updated
   post_actions:
-    # Report cluster status to HyperFleet API (always executed)
+    # Report cluster status to HyperFleet API.
+    # Skipped when the adapter did no work (preconditions not met / resources skipped)
+    # to avoid overwriting a previously reported status with stale data.
     - name: "reportClusterStatus"
+      when:
+        expression: "!adapter.resourcesSkipped"
       api_call:
         method: "PUT"
         url: "/clusters/{{ .clusterId }}/statuses"

--- a/test/testdata/dryrun/cel-showcase/dryrun-cel-showcase-task-config.yaml
+++ b/test/testdata/dryrun/cel-showcase/dryrun-cel-showcase-task-config.yaml
@@ -434,6 +434,8 @@ post:
 
   post_actions:
     - name: "updateStatus"
+      when:
+        expression: "!adapter.resourcesSkipped"
       api_call:
         method: "PUT"
         url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}/statuses"

--- a/test/testdata/dryrun/kubernetes-delete/dryrun-kubernetes-delete-task-config.yaml
+++ b/test/testdata/dryrun/kubernetes-delete/dryrun-kubernetes-delete-task-config.yaml
@@ -184,6 +184,8 @@ post:
 
   post_actions:
     - name: updateStatus
+      when:
+        expression: "!adapter.resourcesSkipped"
       api_call:
         method: PUT
         url: /api/hyperfleet/v1/clusters/{{ .clusterId }}/statuses

--- a/test/testdata/dryrun/kubernetes/dryrun-kubernetes-task-config.yaml
+++ b/test/testdata/dryrun/kubernetes/dryrun-kubernetes-task-config.yaml
@@ -204,6 +204,8 @@ post:
 
   post_actions:
     - name: "updateStatus"
+      when:
+        expression: "!adapter.resourcesSkipped"
       api_call:
         method: "PUT"
         url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}/statuses"

--- a/test/testdata/dryrun/maestro-delete/dryrun-maestro-delete-task-config.yaml
+++ b/test/testdata/dryrun/maestro-delete/dryrun-maestro-delete-task-config.yaml
@@ -191,6 +191,8 @@ post:
 
   post_actions:
     - name: updateStatus
+      when:
+        expression: "!adapter.resourcesSkipped"
       api_call:
         method: PUT
         url: /api/hyperfleet/v1/clusters/{{ .clusterId }}/statuses

--- a/test/testdata/dryrun/maestro/dryrun-maestro-adapter-task-config.yaml
+++ b/test/testdata/dryrun/maestro/dryrun-maestro-adapter-task-config.yaml
@@ -309,8 +309,10 @@ post:
         observed_time: '{{ now | date "2006-01-02T15:04:05Z07:00" }}'
       name: statusPayload
   post_actions:
-    - api_call:
+    - name: updateStatus
+      when:
+        expression: "!adapter.resourcesSkipped"
+      api_call:
         body: '{{ .statusPayload }}'
         method: PUT
         url: /api/hyperfleet/v1/clusters/{{ .clusterId }}/statuses
-      name: updateStatus

--- a/test/testdata/task-config.yaml
+++ b/test/testdata/task-config.yaml
@@ -109,8 +109,10 @@ post:
         observed_time: '{{ now | date "2006-01-02T15:04:05Z07:00" }}'
       name: clusterStatusPayload
   post_actions:
-    - api_call:
+    - name: updateStatus
+      when:
+        expression: "!adapter.resourcesSkipped"
+      api_call:
         body: '{{ .clusterStatusPayload }}'
         method: PUT
         url: /clusters/{{ .clusterId }}/statuses
-      name: updateStatus


### PR DESCRIPTION
## Summary

- Add `when: expression: "!adapter.resourcesSkipped"` to all post-action configs that were missing it (examples, test data, dry-run configs, integration test template, and docs)
- All 11 YAML files with `post_actions` now consistently use the `when` clause introduced by HYPERFLEET-876
- Update the nodepool status reporting example in `docs/adapter-authoring-guide.md` to include the `when` clause

## Scope

This PR covers the **hyperfleet-adapter** repository only. The ticket also mentions `hyperfleet-infra` and `hyperfleet-e2e` which require separate PRs.

## Test plan

- [x] All unit tests pass (15 packages)
- [x] Config-loader integration tests pass
- [x] Executor integration tests pass
- [x] Verified all 11 YAML files with `post_actions` now have consistent `when` clause
- [x] No Go code changes — only YAML configs and Markdown docs

Fixes: https://redhat.atlassian.net/browse/HYPERFLEET-1080