### PR TITLE
HYPERFLEET-1290 - feat: move api_call as param source type

### DIFF
--- a/charts/examples/kubernetes/adapter-task-config.yaml
+++ b/charts/examples/kubernetes/adapter-task-config.yaml
@@ -4,19 +4,22 @@ params:
     type: "string"
     required: true
 
-preconditions:
-  - name: "checkClusterState"
-    api_call:
-      method: "GET"
-      url: "/clusters/{{ .clusterId }}"
-      timeout: 10s
-    capture:
-      - name: "generation"
-        field: "generation"
-      - name: "clusterName"
-        field: "name"
-      - name: "is_deleting"
-        expression: "has(checkClusterState.deleted_time)"
+  - name: checkClusterState
+    source:
+      api_call:
+        method: "GET"
+        url: "/clusters/{{ .clusterId }}"
+        timeout: 10s
+
+  - name: generation
+    source: checkClusterState.generation
+
+  - name: clusterName
+    source: checkClusterState.name
+
+  - name: is_deleting
+    source:
+      expression: "checkClusterState.?deleted_time.hasValue()"
 
 resources:
   - name: namespace

--- a/charts/examples/maestro-two-resources/adapter-task-config.yaml
+++ b/charts/examples/maestro-two-resources/adapter-task-config.yaml
@@ -23,38 +23,45 @@ params:
     source: event.generation
     type: int
 
+  - name: clusterStatus
+    source:
+      api_call:
+        method: GET
+        retry_attempts: 3
+        retry_backoff: exponential
+        timeout: 10s
+        url: /clusters/{{ .clusterId }}
+
+  - name: clusterName
+    source: clusterStatus.name
+
+  - name: timestamp
+    source: clusterStatus.created_time
+
+  # is_deleting is the canonical deletion gate used throughout payload expressions.
+  # Optional chaining avoids errors when deleted_time is absent and prevents
+  # false-positive Finalized=True when resources are absent for unrelated reasons.
+  - name: is_deleting
+    source:
+      expression: "clusterStatus.?deleted_time.hasValue()"
+
+  - name: reconciledConditionStatus
+    source:
+      expression: |
+        clusterStatus.status.conditions.filter(c, c.type == "Reconciled").size() > 0
+          ? clusterStatus.status.conditions.filter(c, c.type == "Reconciled")[0].status
+          : "False"
+
+  - name: placementClusterName
+    source:
+      expression: '"cluster1"' # TBC coming from placement adapter
+
 preconditions:
-  - api_call:
-      method: GET
-      retry_attempts: 3
-      retry_backoff: exponential
-      timeout: 10s
-      url: /clusters/{{ .clusterId }}
-    capture:
-      - field: name
-        name: clusterName
-      - field: generation
-        name: generationId
-      - field: created_time
-        name: timestamp
-      # is_deleting is the canonical deletion gate used throughout payload expressions.
-      # Capturing it here avoids repeating "has(clusterStatus.deleted_time)" everywhere and
-      # prevents false-positive Finalized=True when resources are absent for
-      # unrelated reasons (e.g., first reconciliation before provisioning).
-      - name: is_deleting
-        expression: "has(clusterStatus.deleted_time)"
-      - expression: |
-          status.conditions.filter(c, c.type == "Reconciled").size() > 0
-            ? status.conditions.filter(c, c.type == "Reconciled")[0].status
-            : "False"
-        name: reconciledConditionStatus
-      - name: placementClusterName
-        expression: '"cluster1"' # TBC coming from placement adapter
+  - name: clusterStatus
     conditions:
       - field: reconciledConditionStatus
         operator: equals
         value: "False"
-    name: clusterStatus
   - expression: |
       reconciledConditionStatus == "False"
     name: validationCheck

--- a/charts/examples/maestro/adapter-task-config.yaml
+++ b/charts/examples/maestro/adapter-task-config.yaml
@@ -9,41 +9,48 @@ params:
     required: true
     source: event.generation
     type: int
+
+  - name: clusterStatus
+    source:
+      api_call:
+        method: GET
+        retry_attempts: 3
+        retry_backoff: exponential
+        timeout: 10s
+        url: /clusters/{{ .clusterId }}
+
+  - name: clusterName
+    source: clusterStatus.name
+
+  - name: timestamp
+    source: clusterStatus.created_time
+
+  # is_deleting is the canonical deletion gate used throughout payload expressions.
+  # Optional chaining avoids errors when deleted_time is absent and prevents
+  # false-positive Finalized=True when resources are absent for unrelated reasons.
+  - name: is_deleting
+    source:
+      expression: "clusterStatus.?deleted_time.hasValue()"
+
+  - name: reconciledConditionStatus
+    source:
+      expression: |
+        clusterStatus.status.conditions.filter(c, c.type == "Reconciled").size() > 0
+          ? clusterStatus.status.conditions.filter(c, c.type == "Reconciled")[0].status
+          : "False"
+
+  - name: placementClusterName
+    source:
+      expression: '"cluster1"' # TBC coming from placement adapter
+
 # Preconditions with valid operators and CEL expressions
 preconditions:
-  - api_call:
-      method: GET
-      retry_attempts: 3
-      retry_backoff: exponential
-      timeout: 10s
-      url: /clusters/{{ .clusterId }}
-    capture:
-      - field: name
-        name: clusterName
-      - field: generation
-        name: generationId
-      - field: created_time
-        name: timestamp
-      # is_deleting is the canonical deletion gate used throughout payload expressions.
-      # Capturing it here avoids repeating "has(clusterStatus.deleted_time)" everywhere and
-      # prevents false-positive Finalized=True when resources are absent for
-      # unrelated reasons (e.g., first reconciliation before provisioning).
-      # has() safely checks map key presence without requiring deleted_time to exist.
-      - name: is_deleting
-        expression: "has(clusterStatus.deleted_time)"
-      - expression: |
-          status.conditions.filter(c, c.type == "Reconciled").size() > 0
-            ? status.conditions.filter(c, c.type == "Reconciled")[0].status
-            : "False"
-        name: reconciledConditionStatus
-      - name: placementClusterName
-        expression: '"cluster1"' # TBC coming from placement adapter
+  - name: clusterStatus
     # Structured conditions with valid operators
     conditions:
       - field: reconciledConditionStatus
         operator: equals
         value: "False"
-    name: clusterStatus
   - # Valid CEL expression
     expression: |
       reconciledConditionStatus == "False"

--- a/configs/adapter-task-config-template.yaml
+++ b/configs/adapter-task-config-template.yaml
@@ -78,92 +78,72 @@ params:
   #   default: false
   #   description: "Enable experimental feature"
 
+  # API call source fetches data from the HyperFleet API as a named param.
+  # The full JSON response is stored under the param name and can be referenced
+  # by later params using dot-notation (e.g. "clusterData.generation") 
+  - name: "clusterData"
+    source:
+      api_call:
+        method: "GET"
+        # The adapter prepends /api/hyperfleet/<version> automatically for relative paths
+        # Full paths (/api/hyperfleet/v1/...) are also accepted
+        url: "/clusters/{{ .clusterId }}"
+        timeout: 10s
+        retry_attempts: 3
+        retry_backoff: "exponential"
+
+  # Derivation from an api_call param
+  - name: "clusterName"
+    source: "clusterData.name"
+
+  # CEL expression source - evaluate over previously resolved params
+  # Expressions see all params resolved so far as top-level variables
+  - name: "reconciledConditionStatus"
+    source:
+      expression: |
+        clusterData.status.conditions.filter(c, c.type == "Reconciled").size() > 0
+          ? clusterData.status.conditions.filter(c, c.type == "Reconciled")[0].status
+          : "False"
+
+  - name: "generationId"
+    source: "clusterData.generation"
+
+  # DELETION SUPPORT — capture these two params when lifecycle.delete is used
+  # deleted_time: raw timestamp from the API (null when resource is not pending deletion).
+  # is_deleting: boolean convenience variable — use this in lifecycle.when expressions
+  #              and payload conditions instead of repeating "clusterData.?deleted_time.hasValue()".
+  # - name: "deleted_time"
+  #   source: "clusterData.deleted_time"
+  # - name: "is_deleting"
+  #   source:
+  #     expression: "clusterData.?deleted_time.hasValue()"
+
 
 # ============================================================================
 # Global Preconditions
 # ============================================================================
-# These preconditions run sequentially and validate cluster state before resource operations.
-#
-# DATA SCOPES:
-# ============
-# Capture scope (field/expression): API response data only
-#   - Access: status.conditions, items[0].name, etc.
-#
-# Conditions scope (conditions/expression): Full execution context
-#   - params.*             : Original extracted params
-#   - <precondition-name>.*: Full API response (e.g., clusterStatus.status.conditions)
-#   - capturedField        : Explicitly captured values
-#   - adapter.*            : Adapter metadata
-#   - resources.*          : Created resources (empty during preconditions)
-#
+# Preconditions decide whether the Resources phase executes
+# Expressions have access to all resolved params and adapter metadata
 preconditions:
   # ==========================================================================
-  # Step 1: Get cluster status
+  # Validate cluster state
   # ==========================================================================
   - name: "clusterStatus"
-    api_call:
-      method: "GET"
-      # NOTE: API path includes /api/hyperfleet/ prefix
-      url: "/clusters/{{ .clusterId }}"
-      timeout: 10s
-      retry_attempts: 3
-      retry_backoff: "exponential"
-    # Capture fields from the API response. Captured values become variables for use in resources section.
-    # SCOPE: API response data only
-    # Supports two modes:
-    #   - field: Simple dot notation or JSONPath expression for extracting values
-    #   - expression: CEL expression for computed values
-    # Only one of 'field' or 'expression' can be set per capture.
-    capture:
-      # Simple dot notation
-      - name: "clusterName"
-        field: "name"
-      - name: "reconciledConditionStatus"
-        expression: |
-          status.conditions.filter(c, c.type == "Reconciled").size() > 0
-            ? status.conditions.filter(c, c.type == "Reconciled")[0].status
-            : "False"
-      - name: "generationId"
-        field: "generation"
-
-      # JSONPath for complex extraction (filter by field value)
-      # See: https://kubernetes.io/docs/reference/kubectl/jsonpath/
-      # - name: "lzNamespaceStatus"
-      #   field: "{.items[?(@.adapter=='landing-zone-adapter')].data.namespace.status}"
-
-      # CEL expression for computed values
-      # - name: "activeItemCount"
-      #   expression: "items.filter(i, i.status == 'active').size()"
-
-      # DELETION SUPPORT — capture these two fields when lifecycle.delete is used.
-      # deleted_time: raw timestamp from the API (null when resource is not pending deletion).
-      # is_deleting: boolean convenience variable — use this in lifecycle.when expressions
-      #              and payload conditions instead of repeating "has(clusterStatus.deleted_time)".
-      # - name: "deleted_time"
-      #   field: "deleted_time"
-      # - name: "is_deleting"
-      #   expression: "has(clusterStatus.deleted_time)"
-
-    # Conditions to check. SCOPE: Full execution context
-    # You can access:
-    #   - Captured values: reconciledConditionStatus, clusterName, etc.
-    #   - Full API response: clusterStatus.status.conditions, clusterStatus.spec.nodeCount
-    #   - Params: clusterId, hyperfleetApiBaseUrl, etc.
+    # Conditions to check using params resolved above
     conditions:
-      # Using captured value
+      # Using param derived from clusterData
       - field: "reconciledConditionStatus"
         operator: "equals"
         value: "True"
 
-      # Or dig directly into API response using precondition name
-      # - field: "clusterStatus.status.nodeCount"
+      # Or check a numeric field
+      # - field: "clusterData.generation"
       #   operator: "greaterThan"
       #   value: 0
 
-    # Alternative: CEL expression with full access
+    # Alternative: CEL expression with full access to all params
     # expression: |
-    #   clusterStatus.status.conditions.filter(c, c.type == "Reconciled")[0].status == "True" &&
-    #   clusterStatus.spec.nodeCount > 0
+    #   reconciledConditionStatus == "True" && clusterData.generation > 0
 
 # ============================================================================
 # Resources (Create/Update Resources)

--- a/docs/adapter-authoring-guide.md
+++ b/docs/adapter-authoring-guide.md
@@ -104,7 +104,7 @@ The format of the event is CloudEvents.
 }
 ```
 
-The adapter fetches the full resource from the API during preconditions phase.
+The adapter fetches the full resource from the API during the params phase.
 This keeps the event schema stable and ensures the adapter always works with fresh data.
 
 ### Configuration languages
@@ -127,7 +127,7 @@ Three languages appear in adapter configs, each for a different purpose:
 
 ```yaml
 params: []            # Phase 1: Extract variables from event and environment
-preconditions: []     # Phase 2: Validate state via API calls
+preconditions: []     # Phase 2: Evaluate conditions against extracted params
 resources: []         # Phase 3: Create/update Kubernetes resources
 post:                 # Phase 4: Report status
   payloads: []        #   Build status JSON
@@ -142,7 +142,7 @@ flowchart TD
     PARAMS -->|required param missing| FAIL_PARAMS[Set adapter.executionError]
     FAIL_PARAMS --> POST
     PARAMS -->|success| PRECOND[Phase 2: Preconditions]
-    PRECOND -->|API call fails| FAIL_PRECOND[Set adapter.executionError]
+    PRECOND -->|condition error| FAIL_PRECOND[Set adapter.executionError]
     FAIL_PRECOND --> POST
     PRECOND -->|conditions not met| SKIP[Set adapter.resourcesSkipped=true]
     SKIP --> POST
@@ -173,7 +173,7 @@ The `adapter.*` context is populated automatically and available in your post-ac
 
 ## 4. Parameter Extraction
 
-Parameters are variables extracted from the incoming CloudEvent and the runtime environment. They become available as Go Template variables (`{{ .paramName }}`) and CEL variables throughout the rest of the config.
+Parameters are variables extracted from the CloudEvent, the environment, or the HyperFleet API. They become available as Go Template variables (`{{ .paramName }}`) and CEL variables throughout the rest of the config. Params are resolved in order, a param can reference the value of any param defined before it.
 
 ```yaml
 params:
@@ -193,6 +193,28 @@ params:
     source: "env.REGION"
     type: "string"
     default: "us-east-1"
+
+  # From the HyperFleet API — stores the full JSON response
+  - name: "clusterData"
+    source:
+      api_call:
+        method: "GET"
+        url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}"
+        timeout: 10s
+        retry_attempts: 3
+        retry_backoff: "exponential"
+
+  # Dot-notation derivation from an api_call param
+  - name: "generationId"
+    source: "clusterData.generation"
+
+  # CEL expression over previously resolved params
+  - name: "reconciledStatus"
+    source:
+      expression: |
+        clusterData.status.conditions.filter(c, c.type == "Reconciled").size() > 0
+          ? clusterData.status.conditions.filter(c, c.type == "Reconciled")[0].status
+          : "False"
 ```
 
 ### Sources
@@ -203,6 +225,33 @@ params:
 | `env.` | Environment variables | `env.REGION`, `env.NAMESPACE` |
 | `secret.` | Kubernetes Secret | `secret.my-ns.my-secret.api-key` |
 | `configmap.` | Kubernetes ConfigMap | `configmap.my-ns.my-config.setting` |
+| `<param>.` | Dot-notation into an earlier api_call param | `clusterData.generation`, `clusterData.status.phase` |
+
+**Structured sources** - use a mapping value under `source:`:
+
+`api_call` - fetches data from the HyperFleet API and stores the full JSON response as a `map` under the param name. The URL is a Go Template rendered against all params resolved so far.
+
+```yaml
+- name: "clusterData"
+  source:
+    api_call:
+      method: "GET"
+      url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}"
+      timeout: 10s
+      retry_attempts: 3
+      retry_backoff: "exponential"   # also: linear, constant
+```
+
+`expression` - evaluates a CEL expression over all params resolved so far. Useful for computed values and transformations.
+
+```yaml
+- name: "reconciledStatus"
+  source:
+    expression: |
+      clusterData.status.conditions.filter(c, c.type == "Reconciled").size() > 0
+        ? clusterData.status.conditions.filter(c, c.type == "Reconciled")[0].status
+        : "False"
+```
 
 ### Types and conversion
 
@@ -213,66 +262,24 @@ params:
 | `float`, `float64` | Numeric values |
 | `bool` | `true/false`, `yes/no`, `on/off`, `1/0` |
 
+Type conversion applies to string sources only. `api_call` params hold a structured map and `expression` params hold whatever the CEL expression returns — no conversion is applied.
+
 If type conversion fails on a **required** param, execution stops. On an optional param, the `default` value is used.
 
 ### Common parameters
 
-Most adapters need at least `clusterId` and `generation` from the event. These are the minimum to identify what cluster changed and at what generation.
+Most adapters need at least `clusterId` from the event and a `clusterData` api_call param to fetch the current cluster state. From `clusterData`, derive any fields you need as separate params using dot-notation or expression sources.
 
 ---
 
 ## 5. Preconditions
 
-A precondition is used to decide if the Resource phase executes or not.
+Preconditions decide whether the Resources phase executes. They run sequentially and evaluate params resolved in the previous phase.
 
-Preconditions validate cluster state before the adapter creates resources. They run **sequentially** — each precondition can use data captured by previous ones.
-
-Usually an API call to the HyperFleet API will be the first action of the Precondition phase, to extract values from the current state of the cluster.
-
-The state of the cluster contains information about all adapters in the form of `conditions[]`, so it can be used to make one adapter depend on the results of another adapter.
-
-### Making an API call
-
-```yaml
-preconditions:
-  - name: "clusterStatus"
-    api_call:
-      method: "GET"
-      url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}"
-      timeout: 10s
-      retry_attempts: 3
-      retry_backoff: "exponential"    # also: linear, constant
-```
-
-URLs are **relative** — the base URL comes from the `AdapterConfig` `clients.hyperfleet_api.base_url` setting. You only write the path.
-
-### Capturing fields
-
-After the API call, capture values from the response for use in later phases. Two extraction modes are available (`field` or `expression`)— use one per capture, not both:
-
-```yaml
-    capture:
-      # Simple field extraction (dot notation or JSONPath)
-      - name: "clusterName"
-        field: "name"
-
-      # CEL expression for computed values
-      - name: "reconciledStatus"
-        expression: |
-          status.conditions.filter(c, c.type == "Reconciled").size() > 0
-            ? status.conditions.filter(c, c.type == "Reconciled")[0].status
-            : "False"
-
-      # JSONPath with filter
-      - name: "lzNamespaceStatus"
-        field: "{.items[?(@.adapter=='landing-zone')].data.namespace.status}"
-```
-
-> **Scope:** Capture expressions can only see the current API response. They cannot reference params or other captured values.
 
 ### Evaluating conditions
 
-After captures, evaluate conditions to decide whether to proceed. Two syntaxes are available:
+Two syntaxes are available:
 
 **Structured conditions** — declarative, readable for simple checks:
 
@@ -287,10 +294,10 @@ After captures, evaluate conditions to decide whether to proceed. Two syntaxes a
 
 ```yaml
     expression: |
-      reconciledStatus == "False" && clusterStatus.spec.nodeCount > 0
+      reconciledStatus == "False" && clusterData.generation > 0
 ```
 
-> **Scope:** Conditions see the **full execution context**: all params, all captured fields, and the full API response accessible via the precondition name (e.g., `clusterStatus.status.conditions`).
+> **Scope:** Conditions see all resolved params and adapter metadata.
 
 ### Supported operators
 
@@ -310,23 +317,29 @@ After captures, evaluate conditions to decide whether to proceed. Two syntaxes a
 
 ### Chaining preconditions
 
-Preconditions execute in order. Data flows forward — a captured field from precondition 1 is available in precondition 2's conditions:
+Preconditions execute in order. All params (including those from api_call sources) are available to every precondition's conditions and expression:
 
 ```yaml
-preconditions:
-  - name: "getCluster"
-    api_call:
-      url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}"
-    capture:
-      - name: "clusterName"
-        field: "name"
+params:
+  - name: "clusterId"
+    source: "event.id"
+  - name: "clusterData"
+    source:
+      api_call:
+        url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}"
+  - name: "clusterName"
+    source: "clusterData.name"
+  - name: "statusesData"
+    source:
+      api_call:
+        url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}/statuses"
+  - name: "lzReconciled"
+    source:
+      expression: |
+        statusesData.items.filter(i, i.adapter == "landing-zone")[0].data.namespace.status
 
-  - name: "getStatuses"
-    api_call:
-      url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}/statuses"
-    capture:
-      - name: "lzReconciled"
-        field: "{.items[?(@.adapter=='landing-zone')].data.namespace.status}"
+preconditions:
+  - name: "clusterReady"
     conditions:
       - field: "lzReconciled"
         operator: "equals"
@@ -348,16 +361,22 @@ A condition-only precondition (e.g., "only run when cluster is NOT Reconciled") 
 
 ```yaml
 # Condition-only pattern - INCOMPLETE
+params:
+  - name: "clusterId"
+    source: "event.id"
+  - name: "clusterData"
+    source:
+      api_call:
+        url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}"
+  - name: "reconciledStatus"
+    source:
+      expression: |
+        clusterData.status.conditions.filter(c, c.type == "Reconciled").size() > 0
+          ? clusterData.status.conditions.filter(c, c.type == "Reconciled")[0].status
+          : "False"
+
 preconditions:
-  - name: "getCluster"
-    api_call:
-      url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}"
-    capture:
-      - name: "reconciledStatus"
-        expression: |
-          status.conditions.filter(c, c.type == "Reconciled").size() > 0
-            ? status.conditions.filter(c, c.type == "Reconciled")[0].status
-            : "False"
+  - name: "checkCluster"
     conditions:
       - field: "reconciledStatus"
         operator: "equals"
@@ -385,24 +404,29 @@ To implement time-based stability checks, you need to know how long a cluster ha
 #### Correct pattern: Time-based stability precondition
 
 ```yaml
-preconditions:
-  - name: "checkClusterState"
-    api_call:
-      url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}"
-    capture:
-      - name: "clusterNotReconciled"
-        expression: |
-          status.conditions.filter(c, c.type == "Reconciled").size() > 0
-            ? status.conditions.filter(c, c.type == "Reconciled")[0].status != "True"
-            : true
-      - name: "clusterReconciledTTL"
-        expression: |
-          (timestamp(now()) - timestamp(
-            status.conditions.filter(c, c.type == "Reconciled").size() > 0
-              ? status.conditions.filter(c, c.type == "Reconciled")[0].last_transition_time
-              : now()
-          )).getSeconds() > 300
+params:
+  - name: "clusterId"
+    source: "event.id"
+  - name: "clusterData"
+    source:
+      api_call:
+        url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}"
+  - name: "clusterNotReconciled"
+    source:
+      expression: |
+        clusterData.status.conditions.filter(c, c.type == "Reconciled").size() > 0
+          ? clusterData.status.conditions.filter(c, c.type == "Reconciled")[0].status != "True"
+          : true
+  - name: "clusterReconciledTTL"
+    source:
+      expression: |
+        (timestamp(now()) - timestamp(
+          clusterData.status.conditions.filter(c, c.type == "Reconciled").size() > 0
+            ? clusterData.status.conditions.filter(c, c.type == "Reconciled")[0].last_transition_time
+            : now()
+        )).getSeconds() > 300
 
+preconditions:
   - name: "validationCheck"
     # Precondition passes if cluster is NOT Reconciled OR if cluster is Reconciled and stable for >300 seconds since last transition (enables self-healing)
     expression: |
@@ -497,7 +521,7 @@ resources:
 
 Note that the location of the referenced file is a path of the adapter pod, so it has to be mounted from a ConfigMap in the adapter deployment.
 
-The referenced file is a Go template and has access to all params and captured fields.
+The referenced file is a Go template and has access to all resolved params.
 
 ### Resource lifecycle
 
@@ -697,21 +721,23 @@ resources:
 
 #### The is_deleting pattern
 
-The standard way to detect pending deletion is to derive a boolean from the precondition response using the named-map-variable approach. The precondition name (e.g. `getCluster`) is automatically injected as a map variable in the capture CEL context, enabling safe optional-field access:
+The standard way to detect pending deletion is to derive a boolean from the cluster API response in the params phase using an `expression` source:
 
 ```yaml
-preconditions:
-  - name: "getCluster"
-    api_call:
-      url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}"
-    capture:
-      - name: "is_deleting"
-        expression: "has(getCluster.deleted_time)"
+params:
+  - name: "clusterData"
+    source:
+      api_call:
+        method: "GET"
+        url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}"
+  - name: "is_deleting"
+    source:
+      expression: "clusterData.?deleted_time.hasValue()"
 ```
 
 Then reference `is_deleting` in `lifecycle.delete.when.expression`.
 
-> **Why not `field: deleted_time`?** Capturing `deleted_time` as a `field:` capture without a default logs a `WARN` on every reconciliation where the field is absent — which is ~99% of the time when the cluster is not being deleted. The `has()` expression approach reads the field directly from the named response map and returns `false` cleanly when absent, with no log noise.
+> **Why not `source: "clusterData.deleted_time"`?** The dot-notation string source logs a `WARN` when the field is absent — which is ~99% of the time when the cluster is not being deleted. The `expression` source with `hasValue()` returns `false` cleanly when the field is absent, with no log noise.
 
 #### Dependency ordering
 
@@ -787,7 +813,7 @@ This means a list containing both apply and delete operations behaves predictabl
 
 ### Resource not found (404 handling)
 
-When a precondition API call returns `404 Not Found`, it can mean the resource no longer exists (e.g., deleted externally, incorrect ID in the event, direct DB removal) or that the precondition URL itself is misconfigured. The adapter distinguishes between two types of 404:
+When a params-phase API call returns `404 Not Found`, it can mean the resource no longer exists (e.g., deleted externally, incorrect ID in the event, direct DB removal) or that the API call URL itself is misconfigured. The adapter distinguishes between two types of 404:
 
 - **Resource not found** (default): any 404 is treated as a legitimate "resource does not exist" unless proven otherwise. This includes responses with specific error codes (`HYPERFLEET-NTF-001`, `HYPERFLEET-NTF-002`, `HYPERFLEET-NTF-003`), as well as 404s where the response body was stripped by a proxy or gateway. The adapter handles this gracefully — resources are skipped and post-actions still execute.
 - **Broken endpoint** (error code `HYPERFLEET-NTF-000`): the catch-all 404 handler confirms no route matched the URL. The adapter treats this as a configuration error and reports failure status.
@@ -946,7 +972,7 @@ The `Unknown` value is used when there the condition value is still pending and 
 
 When the HyperFleet API receives an status update with any of the mandatory condition's status to `Unknown` value, the API will not update the internal state. Therefore, Sentinel will keep emitting reconciliation events for status updates.
 
-**Applied** and **Available** are derived from your K8s object's status. **Health** reflects the adapter framework's own execution and uses the standard boilerplate (see section 8).
+**Applied** and **Available** are derived from your K8s object's status. **Health** reflects the adapter framework's own execution and uses the standard boilerplate (see section 9).
 
 ### Status patterns by resource type
 
@@ -1391,15 +1417,15 @@ Dry-Run Execution Trace
 Event: id=abc123 type=io.hyperfleet.cluster.updated
 
 Phase 1: Parameter Extraction .............. SUCCESS
-  clusterId        = "abc123"
-  generation       = 5
-  region           = "us-east-1"
+  clusterId             = "abc123"
+  generation            = 5
+  region                = "us-east-1"
+  clusterData           = {...}  (API Call: GET /api/hyperfleet/v1/clusters/abc123 -> 200)
+  clusterName           = "my-cluster"
+  reconciledStatus      = "False"
 
 Phase 2: Preconditions ..................... SUCCESS (MET)
-  [1/1] fetch-cluster                      PASS
-    API Call: GET /api/hyperfleet/v1/clusters/abc123 -> 200
-    Captured: clusterName = "my-cluster"
-    Captured: reconciledStatus = "False"
+  [1/1] clusterStatus                      PASS
 
 Phase 3: Resources ........................ SUCCESS
   [1/2] namespace0                         CREATE
@@ -1456,34 +1482,45 @@ params:
 
 ### Checking parent cluster readiness
 
-NodePool adapters typically wait for the parent cluster to be fully set up. Query the parent cluster's adapter statuses as a precondition:
+NodePool adapters typically wait for the parent cluster to be fully set up. Fetch data in the params phase and evaluate in preconditions:
 
-<details><summary>NodePool precondition example</summary>
+<details><summary>NodePool params and preconditions example</summary>
 
 ```yaml
+params:
+  - name: "clusterId"
+    source: "event.owner_references.id"
+  - name: "nodepoolId"
+    source: "event.id"
+  - name: "nodepoolData"
+    source:
+      api_call:
+        url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}/nodepools/{{ .nodepoolId }}"
+  - name: "generation"
+    source: "nodepoolData.generation"
+  - name: "reconciledStatus"
+    source:
+      expression: |
+        nodepoolData.status.conditions.filter(c, c.type == "Reconciled").size() > 0
+          ? nodepoolData.status.conditions.filter(c, c.type == "Reconciled")[0].status
+          : "False"
+  - name: "clusterStatuses"
+    source:
+      api_call:
+        url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}/statuses"
+  - name: "clusterNamespaceStatus"
+    source:
+      expression: |
+        clusterStatuses.items.filter(i, i.adapter == "landing-zone")[0].data.namespace.status
+
 preconditions:
-  - name: "nodepoolStatus"
-    api_call:
-      url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}/nodepools/{{ .nodepoolId }}"
-    capture:
-      - name: "generation"
-        field: "generation"
-      - name: "reconciledStatus"
-        expression: |
-          status.conditions.filter(c, c.type == "Reconciled").size() > 0
-            ? status.conditions.filter(c, c.type == "Reconciled")[0].status
-            : "False"
+  - name: "nodepoolReady"
     conditions:
       - field: "reconciledStatus"
         operator: "equals"
         value: "False"
 
-  - name: "clusterAdapterStatus"
-    api_call:
-      url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}/statuses"
-    capture:
-      - name: "clusterNamespaceStatus"
-        field: "{.items[?(@.adapter=='landing-zone')].data.namespace.status}"
+  - name: "clusterReady"
     conditions:
       - field: "clusterNamespaceStatus"
         operator: "equals"
@@ -1547,9 +1584,9 @@ The adapter will run preconditions, skip straight to post-actions, and report st
 | Error | Cause | Fix |
 |-------|-------|-----|
 | `required field missing` | Param without `name` or `source` | Add the required field |
-| `mutually exclusive` | Both `field` and `expression` on a capture | Use only one |
+| `mutually exclusive` | Both `field` and `expression` on a condition | Use only one |
 | `CEL parse error` | Invalid CEL syntax | Check parentheses, string escaping |
-| `template variable not found` | `{{ .foo }}` where `foo` is not a param or capture | Define it in params or captures |
+| `template variable not found` | `{{ .foo }}` where `foo` is not a defined param | Define it in params |
 | `invalid operator` | Typo in operator name | Use one from the supported list |
 
 ---
@@ -1741,7 +1778,7 @@ Structural directives do **not** work in plain inline manifests (without `|`) be
 
 **Iteration (`range`)**
 
-Use `range` to iterate over list-type values captured via CEL expressions:
+Use `range` to iterate over list-type params resolved via CEL expressions:
 
 ```yaml
 {{ range $i, $subnet := .subnets }}
@@ -1750,15 +1787,16 @@ Use `range` to iterate over list-type values captured via CEL expressions:
 {{ end }}
 ```
 
-> **Note:** To iterate over a list, the corresponding precondition capture must use a CEL expression that returns the list directly (not a string). For example:
+> **Note:** To iterate over a list, the corresponding param must use a CEL expression that returns the list directly (not a string). For example:
 >
 > ```yaml
-> captures:
+> params:
 >   - name: "subnets"
->     expression: |
->       has(spec.platform) && has(spec.platform.gcp) && has(spec.platform.gcp.subnets)
->         ? spec.platform.gcp.subnets
->         : []
+>     source:
+>       expression: |
+>         has(clusterData.spec.platform.gcp.subnets)
+>           ? clusterData.spec.platform.gcp.subnets
+>           : []
 > ```
 
 Go Templates are used in: URLs, manifest field values, direct string values in payloads, external template files (`manifest.ref`), and inline block scalars (`manifest: |`).
@@ -1793,7 +1831,7 @@ See also [Preconditions — Supported operators](#supported-operators).
 |---------|-------------|----------|
 | Resources skipped, Health=False with "ResourcesSkipped" | Precondition not met | Check precondition conditions — the cluster may not be in the expected state yet. This is often normal; the Sentinel will retry. |
 | Status update rejected by API | Stale `observed_generation` | Your adapter is reporting an older generation than what's already stored. Ensure `observed_generation` uses the generation from the API response, not the event. |
-| `template variable not found` | Variable referenced in `{{ .foo }}` but never defined | Add `foo` to params or captures. Check spelling. |
+| `template variable not found` | Variable referenced in `{{ .foo }}` but never defined | Add `foo` to params. Check spelling. |
 | `CEL expression parse error` | Invalid CEL syntax | Verify parentheses, string quoting, and optional chaining syntax (`?.` for safe field access). |
 | Discovery returns empty | Labels don't match or wrong namespace | Verify `discovery.namespace` is correct. Use `by_name` for a simpler lookup. Check resource labels match the selector exactly. |
 | `observed_generation` is a string | Using Go Template instead of CEL expression | Use `expression: "generation"` instead of `"{{ .generation }}"`. |

--- a/internal/configloader/loader_test.go
+++ b/internal/configloader/loader_test.go
@@ -451,7 +451,7 @@ func TestMergeConfigs(t *testing.T) {
 
 	taskCfg := &AdapterTaskConfig{
 		Params: []Parameter{
-			{Name: "clusterId", Source: "event.id", Required: true},
+			{Name: "clusterId", Source: StringSource("event.id"), Required: true},
 		},
 		Preconditions: []Precondition{
 			{ActionBase: ActionBase{Name: "checkStatus"}},
@@ -482,8 +482,8 @@ func TestMergeConfigs(t *testing.T) {
 func TestGetRequiredParams(t *testing.T) {
 	config := &Config{
 		Params: []Parameter{
-			{Name: "clusterId", Source: "event.id", Required: true},
-			{Name: "optional", Source: "event.optional", Required: false},
+			{Name: "clusterId", Source: StringSource("event.id"), Required: true},
+			{Name: "optional", Source: StringSource("event.optional"), Required: false},
 		},
 	}
 
@@ -743,7 +743,7 @@ func TestValidateFileReferencesInTaskConfig(t *testing.T) {
 			name: "no file references - should pass",
 			config: &AdapterTaskConfig{
 				Params: []Parameter{
-					{Name: "test", Source: "event.test"},
+					{Name: "test", Source: StringSource("event.test")},
 				},
 			},
 			baseDir: tmpDir,
@@ -1686,4 +1686,88 @@ resources:
 	require.True(t, ok, "Manifest ref should be stored as raw string")
 	assert.Contains(t, manifestStr, "apiVersion: v1")
 	assert.Contains(t, manifestStr, "name: \"my-config\"")
+}
+
+func TestParameterSourceUnmarshal(t *testing.T) {
+	t.Run("string scalar source", func(t *testing.T) {
+		var cfg AdapterTaskConfig
+		err := yaml.Unmarshal([]byte(`
+params:
+  - name: clusterId
+    source: "event.id"
+`), &cfg)
+		require.NoError(t, err)
+		require.Len(t, cfg.Params, 1)
+		p := cfg.Params[0]
+		assert.True(t, p.Source.IsString())
+		assert.Equal(t, "event.id", p.Source.StringVal)
+		assert.False(t, p.Source.IsAPICall())
+		assert.False(t, p.Source.IsExpression())
+	})
+
+	t.Run("api_call mapping source", func(t *testing.T) {
+		var cfg AdapterTaskConfig
+		err := yaml.Unmarshal([]byte(`
+params:
+  - name: clusterData
+    source:
+      api_call:
+        method: GET
+        url: /clusters/abc
+        timeout: 10s
+`), &cfg)
+		require.NoError(t, err)
+		require.Len(t, cfg.Params, 1)
+		p := cfg.Params[0]
+		assert.True(t, p.Source.IsAPICall())
+		require.NotNil(t, p.Source.APICall)
+		assert.Equal(t, "GET", p.Source.APICall.Method)
+		assert.Equal(t, "/clusters/abc", p.Source.APICall.URL)
+		assert.False(t, p.Source.IsString())
+		assert.False(t, p.Source.IsExpression())
+	})
+
+	t.Run("expression mapping source", func(t *testing.T) {
+		var cfg AdapterTaskConfig
+		err := yaml.Unmarshal([]byte(`
+params:
+  - name: isActive
+    source:
+      expression: "clusterData.status == \"Active\""
+`), &cfg)
+		require.NoError(t, err)
+		require.Len(t, cfg.Params, 1)
+		p := cfg.Params[0]
+		assert.True(t, p.Source.IsExpression())
+		assert.Contains(t, p.Source.Expression, "clusterData.status")
+		assert.False(t, p.Source.IsString())
+		assert.False(t, p.Source.IsAPICall())
+	})
+
+	t.Run("both api_call and expression in mapping is an error", func(t *testing.T) {
+		var cfg AdapterTaskConfig
+		err := yaml.Unmarshal([]byte(`
+params:
+  - name: bad
+    source:
+      api_call:
+        method: GET
+        url: /clusters
+      expression: "true"
+`), &cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "mutually exclusive")
+	})
+
+	t.Run("mapping with neither api_call nor expression is an error", func(t *testing.T) {
+		var cfg AdapterTaskConfig
+		err := yaml.Unmarshal([]byte(`
+params:
+  - name: bad
+    source:
+      unknown_key: value
+`), &cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "mapping must contain either")
+	})
 }

--- a/internal/configloader/struct_validator.go
+++ b/internal/configloader/struct_validator.go
@@ -103,18 +103,23 @@ func validateOperator(fl validator.FieldLevel) bool {
 }
 
 // validateParameterEnvRequired is a struct-level validator for Parameter.
-// Checks that required env params have their environment variables set.
+// Checks that source is set and, for required env params, that the env var exists.
 func validateParameterEnvRequired(sl validator.StructLevel) {
 	// type is guaranteed by RegisterStructValidation
 	//nolint:errcheck
 	param := sl.Current().Interface().(Parameter)
 
-	// Only validate if Required=true and Source starts with "env."
-	if !param.Required || !strings.HasPrefix(param.Source, "env.") {
+	if param.Source.IsZero() || (param.Source.IsString() && strings.TrimSpace(param.Source.StringVal) == "") {
+		sl.ReportError(param.Source, "source", "Source", "required", "")
 		return
 	}
 
-	envName := strings.TrimPrefix(param.Source, "env.")
+	if !param.Required || !param.Source.IsString() ||
+		!strings.HasPrefix(param.Source.StringVal, "env.") {
+		return
+	}
+
+	envName := strings.TrimPrefix(param.Source.StringVal, "env.")
 	envValue := os.Getenv(envName)
 
 	// Error if env var is not set and no default provided

--- a/internal/configloader/types.go
+++ b/internal/configloader/types.go
@@ -172,15 +172,114 @@ type KubernetesConfig struct {
 	Burst int `yaml:"burst,omitempty" mapstructure:"burst"`
 }
 
-// Parameter represents a parameter extraction configuration.
-// Parameters are extracted from external sources (event data, env vars) using Source.
+// ParameterSource is the source field on Parameter
+// It unmarshals from either a YAML scalar (string) or a YAML mapping (api_call / expression)
+type ParameterSource struct {
+	// Kind is one of "string", "api_call", or "expression".
+	Kind       string   `yaml:"-"`
+	StringVal  string   `yaml:"-"`
+	APICall    *APICall `yaml:"api_call"`
+	Expression string   `yaml:"expression"`
+}
+
+const (
+	paramSourceKindString     = "string"
+	paramSourceKindAPICall    = "api_call"
+	paramSourceKindExpression = "expression"
+)
+
+// StringSource constructs a string-literal ParameterSource.
+func StringSource(s string) ParameterSource {
+	return ParameterSource{Kind: paramSourceKindString, StringVal: s}
+}
+
+// APICallSource constructs an api_call ParameterSource.
+func APICallSource(ac *APICall) ParameterSource {
+	return ParameterSource{Kind: paramSourceKindAPICall, APICall: ac}
+}
+
+// ExpressionSource constructs a CEL-expression ParameterSource.
+func ExpressionSource(expr string) ParameterSource {
+	return ParameterSource{Kind: paramSourceKindExpression, Expression: expr}
+}
+
+func (ps ParameterSource) IsZero() bool { return ps.Kind == "" }
+
+func (ps ParameterSource) IsString() bool { return ps.Kind == paramSourceKindString }
+
+func (ps ParameterSource) IsAPICall() bool { return ps.Kind == paramSourceKindAPICall }
+
+func (ps ParameterSource) IsExpression() bool { return ps.Kind == paramSourceKindExpression }
+
+// Describe returns a human-readable description for use in error messages
+func (ps ParameterSource) Describe() string {
+	switch ps.Kind {
+	case paramSourceKindAPICall:
+		if ps.APICall != nil {
+			return fmt.Sprintf("api_call(%s %s)", ps.APICall.Method, ps.APICall.URL)
+		}
+		return "api_call"
+	case paramSourceKindExpression:
+		return fmt.Sprintf("expression(%q)", strings.TrimSpace(ps.Expression))
+	default:
+		return ps.StringVal
+	}
+}
+
+func (ps ParameterSource) MarshalYAML() (interface{}, error) {
+	switch ps.Kind {
+	case paramSourceKindString:
+		return ps.StringVal, nil
+	case paramSourceKindAPICall:
+		return map[string]interface{}{"api_call": ps.APICall}, nil
+	case paramSourceKindExpression:
+		return map[string]interface{}{"expression": ps.Expression}, nil
+	default:
+		return nil, nil
+	}
+}
+
+func (ps *ParameterSource) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		ps.Kind = paramSourceKindString
+		ps.StringVal = node.Value
+		return nil
+	case yaml.MappingNode:
+		var raw struct {
+			APICall    *APICall `yaml:"api_call"`
+			Expression string   `yaml:"expression"`
+		}
+		if err := node.Decode(&raw); err != nil {
+			return fmt.Errorf("source: %w", err)
+		}
+		if raw.APICall != nil && raw.Expression != "" {
+			return fmt.Errorf("source: 'api_call' and 'expression' are mutually exclusive")
+		}
+		if raw.APICall != nil {
+			ps.Kind = paramSourceKindAPICall
+			ps.APICall = raw.APICall
+			return nil
+		}
+		if raw.Expression != "" {
+			ps.Kind = paramSourceKindExpression
+			ps.Expression = raw.Expression
+			return nil
+		}
+		return fmt.Errorf("source: mapping must contain either 'api_call' or 'expression'")
+	default:
+		return fmt.Errorf("source: expected string or mapping, got %v", node.Tag)
+	}
+}
+
+// Parameter represents a parameter extraction configuration
 type Parameter struct {
-	Default     interface{} `yaml:"default,omitempty"`
-	Name        string      `yaml:"name" validate:"required"`
-	Source      string      `yaml:"source,omitempty" validate:"required"`
-	Type        string      `yaml:"type,omitempty"`
-	Description string      `yaml:"description,omitempty"`
-	Required    bool        `yaml:"required,omitempty"`
+	Default     interface{}     `yaml:"default,omitempty"`
+	Name        string          `yaml:"name" validate:"required"`
+	Source      ParameterSource `yaml:"source,omitempty"`
+	Type        string          `yaml:"type,omitempty"`
+	Description string          `yaml:"description,omitempty"`
+	Required    bool            `yaml:"required,omitempty"`
 }
 
 // Payload represents a dynamically built payload for post-processing.

--- a/internal/configloader/validator.go
+++ b/internal/configloader/validator.go
@@ -161,6 +161,9 @@ func (v *TaskConfigValidator) ValidateSemantic() error {
 	}
 
 	// Run all semantic validators
+	v.validatePreconditionAPICallForbidden()
+	v.validateParamSources()
+	v.validateParamAPICallTemplates()
 	v.validateTransportConfig()
 	v.validateConditionValues()
 	v.validateCaptureFieldExpressions()
@@ -173,6 +176,80 @@ func (v *TaskConfigValidator) ValidateSemantic() error {
 		return v.errors
 	}
 	return nil
+}
+
+func (v *TaskConfigValidator) validatePreconditionAPICallForbidden() {
+	for i, precond := range v.config.Preconditions {
+		if precond.APICall != nil {
+			path := fmt.Sprintf("%s[%d].%s", FieldPreconditions, i, FieldAPICall)
+			v.errors.Add(path, fmt.Sprintf(
+				"precondition %q contains api_call. api_call is no longer valid in the precondition phase.\n"+
+					"Move the api_call block to a params entry:\n"+
+					"  params:\n"+
+					"    - name: %q\n"+
+					"      source:\n"+
+					"        api_call:\n"+
+					"          ...",
+				precond.Name, precond.Name))
+		}
+	}
+}
+
+func (v *TaskConfigValidator) validateParamSources() {
+	for i, param := range v.config.Params {
+		if param.Source.IsZero() || (param.Source.IsString() && strings.TrimSpace(param.Source.StringVal) == "") {
+			v.errors.Add(fmt.Sprintf("%s[%d].%s", FieldParams, i, FieldSource), "source is required")
+		}
+	}
+}
+
+func (v *TaskConfigValidator) validateParamAPICallTemplates() {
+	available := make(map[string]bool)
+	for _, b := range BuiltinVariables() {
+		available[b] = true
+	}
+
+	for i, param := range v.config.Params {
+		if param.Source.IsAPICall() && param.Source.APICall != nil {
+			ac := param.Source.APICall
+			base := fmt.Sprintf("%s[%d].%s.%s", FieldParams, i, FieldSource, FieldAPICall)
+			v.validateTemplateStringWithVars(ac.URL, base+"."+FieldURL, available)
+			v.validateTemplateStringWithVars(ac.Body, base+"."+FieldBody, available)
+			for j, h := range ac.Headers {
+				v.validateTemplateStringWithVars(h.Value,
+					fmt.Sprintf("%s.%s[%d].%s", base, FieldHeaders, j, FieldHeaderValue), available)
+			}
+		}
+		if param.Name != "" {
+			available[param.Name] = true
+		}
+	}
+}
+
+func (v *TaskConfigValidator) validateTemplateStringWithVars(s, path string, vars map[string]bool) {
+	if s == "" {
+		return
+	}
+	matches := templateVarRegex.FindAllStringSubmatch(s, -1)
+	for _, match := range matches {
+		if len(match) > 1 {
+			varName := match[1]
+			if !v.isVariableDefinedIn(varName, vars) {
+				v.errors.Add(path, fmt.Sprintf("undefined template variable %q", varName))
+			}
+		}
+	}
+}
+
+func (v *TaskConfigValidator) isVariableDefinedIn(varName string, vars map[string]bool) bool {
+	if vars[varName] {
+		return true
+	}
+	parts := strings.Split(varName, ".")
+	if len(parts) > 0 && vars[parts[0]] {
+		return true
+	}
+	return false
 }
 
 func (v *TaskConfigValidator) collectDefinedVariables() {
@@ -499,6 +576,13 @@ func (v *TaskConfigValidator) validateTemplateMap(m map[string]interface{}, path
 func (v *TaskConfigValidator) validateCELExpressions() {
 	if v.celEnv == nil {
 		return
+	}
+
+	for i, param := range v.config.Params {
+		if param.Source.IsExpression() && param.Source.Expression != "" {
+			path := fmt.Sprintf("%s[%d].%s.%s", FieldParams, i, FieldSource, FieldExpression)
+			v.validateCELExpression(param.Source.Expression, path)
+		}
 	}
 
 	for i, precond := range v.config.Preconditions {

--- a/internal/configloader/validator_test.go
+++ b/internal/configloader/validator_test.go
@@ -185,18 +185,13 @@ func TestValidateTemplateVariables(t *testing.T) {
 	t.Run("defined variables", func(t *testing.T) {
 		cfg := baseTaskConfig()
 		cfg.Params = []Parameter{
-			{Name: "clusterId", Source: "event.id"},
-			{Name: "apiUrl", Source: "env.API_URL"},
+			{Name: "clusterId", Source: StringSource("event.id")},
+			{Name: "apiUrl", Source: StringSource("env.API_URL")},
+			{Name: "clusterData", Source: APICallSource(&APICall{
+				Method: "GET",
+				URL:    "{{ .apiUrl }}/clusters/{{ .clusterId }}",
+			})},
 		}
-		cfg.Preconditions = []Precondition{{
-			ActionBase: ActionBase{
-				Name: "checkCluster",
-				APICall: &APICall{
-					Method: "GET",
-					URL:    "{{ .apiUrl }}/clusters/{{ .clusterId }}",
-				},
-			},
-		}}
 		v := newTaskValidator(cfg)
 		require.NoError(t, v.ValidateStructure())
 		require.NoError(t, v.ValidateSemantic())
@@ -204,16 +199,13 @@ func TestValidateTemplateVariables(t *testing.T) {
 
 	t.Run("undefined variable in URL", func(t *testing.T) {
 		cfg := baseTaskConfig()
-		cfg.Params = []Parameter{{Name: "clusterId", Source: "event.id"}}
-		cfg.Preconditions = []Precondition{{
-			ActionBase: ActionBase{
-				Name: "checkCluster",
-				APICall: &APICall{
-					Method: "GET",
-					URL:    "{{ .undefinedVar }}/clusters/{{ .clusterId }}",
-				},
-			},
-		}}
+		cfg.Params = []Parameter{
+			{Name: "clusterId", Source: StringSource("event.id")},
+			{Name: "clusterData", Source: APICallSource(&APICall{
+				Method: "GET",
+				URL:    "{{ .undefinedVar }}/clusters/{{ .clusterId }}",
+			})},
+		}
 		v := newTaskValidator(cfg)
 		_ = v.ValidateStructure()
 		err := v.ValidateSemantic()
@@ -223,7 +215,7 @@ func TestValidateTemplateVariables(t *testing.T) {
 
 	t.Run("undefined variable in resource manifest", func(t *testing.T) {
 		cfg := baseTaskConfig()
-		cfg.Params = []Parameter{{Name: "clusterId", Source: "event.id"}}
+		cfg.Params = []Parameter{{Name: "clusterId", Source: StringSource("event.id")}}
 		cfg.Resources = []Resource{{
 			Name: "testNs",
 			Manifest: map[string]interface{}{
@@ -240,19 +232,13 @@ func TestValidateTemplateVariables(t *testing.T) {
 		assert.Contains(t, err.Error(), "undefined template variable \"undefinedVar\"")
 	})
 
-	t.Run("captured variable is available for resources", func(t *testing.T) {
+	t.Run("derived param variable is available for resources", func(t *testing.T) {
 		cfg := baseTaskConfig()
-		cfg.Params = []Parameter{{Name: "apiUrl", Source: "env.API_URL"}}
-		cfg.Preconditions = []Precondition{{
-			ActionBase: ActionBase{
-				Name:    "getCluster",
-				APICall: &APICall{Method: "GET", URL: "{{ .apiUrl }}/clusters"},
-			},
-			Capture: []CaptureField{{
-				Name:               "clusterName",
-				FieldExpressionDef: FieldExpressionDef{Field: "name"},
-			}},
-		}}
+		cfg.Params = []Parameter{
+			{Name: "apiUrl", Source: StringSource("env.API_URL")},
+			{Name: "clusterData", Source: APICallSource(&APICall{Method: "GET", URL: "{{ .apiUrl }}/clusters"})},
+			{Name: "clusterName", Source: StringSource("clusterData.name")},
+		}
 		cfg.Resources = []Resource{{
 			Name: "testNs",
 			Manifest: map[string]interface{}{
@@ -440,9 +426,9 @@ func TestValidateK8sManifests(t *testing.T) {
 		// until template rendering at execution time
 		cfg := baseTaskConfig()
 		cfg.Params = []Parameter{
-			{Name: "name", Source: "event.name", Type: "string"},
-			{Name: "addLabels", Source: "event.addLabels", Type: "bool"},
-			{Name: "appName", Source: "event.appName", Type: "string"},
+			{Name: "name", Source: StringSource("event.name"), Type: "string"},
+			{Name: "addLabels", Source: StringSource("event.addLabels"), Type: "bool"},
+			{Name: "appName", Source: StringSource("event.appName"), Type: "string"},
 		}
 		cfg.Resources = []Resource{{
 			Name: "testResource",
@@ -616,15 +602,13 @@ func TestPayloadValidate(t *testing.T) {
 }
 
 func TestValidateCaptureFields(t *testing.T) {
-	// Helper to create config with capture fields
+	// Helper to create config with capture fields on a precondition (legacy path)
 	withCapture := func(captures []CaptureField) *AdapterTaskConfig {
 		cfg := baseTaskConfig()
 		cfg.Preconditions = []Precondition{{
-			ActionBase: ActionBase{
-				Name:    "getStatus",
-				APICall: &APICall{Method: "GET", URL: "http://example.com/api"},
-			},
-			Capture: captures,
+			ActionBase: ActionBase{Name: "getStatus"},
+			Expression: "true",
+			Capture:    captures,
 		}}
 		return cfg
 	}
@@ -898,7 +882,7 @@ func TestValidateTransportConfig(t *testing.T) {
 
 	t.Run("maestro transport with template variable in targetCluster", func(t *testing.T) {
 		cfg := baseTaskConfig()
-		cfg.Params = []Parameter{{Name: "clusterName", Source: "event.name"}}
+		cfg.Params = []Parameter{{Name: "clusterName", Source: StringSource("event.name")}}
 		cfg.Resources = []Resource{{
 			Name: "testMW",
 			Transport: &TransportConfig{
@@ -1162,6 +1146,110 @@ func TestValidateLifecycleConfig(t *testing.T) {
 	t.Run("no lifecycle config is valid", func(t *testing.T) {
 		cfg := baseTaskConfig()
 		cfg.Resources = []Resource{{Name: "myResource", Discovery: minDiscovery, Manifest: minManifest}}
+		v := newTaskValidator(cfg)
+		require.NoError(t, v.ValidateStructure())
+		require.NoError(t, v.ValidateSemantic())
+	})
+}
+
+func TestValidateParamsAPICallSource(t *testing.T) {
+	t.Run("api_call source passes validation", func(t *testing.T) {
+		cfg := baseTaskConfig()
+		cfg.Params = []Parameter{
+			{Name: "clusterId", Source: StringSource("event.id")},
+			{Name: "clusterData", Source: APICallSource(&APICall{Method: "GET", URL: "/clusters/{{ .clusterId }}"})},
+		}
+		v := newTaskValidator(cfg)
+		require.NoError(t, v.ValidateStructure())
+		require.NoError(t, v.ValidateSemantic())
+	})
+
+	t.Run("api_call source URL can reference param defined before it", func(t *testing.T) {
+		cfg := baseTaskConfig()
+		cfg.Params = []Parameter{
+			{Name: "clusterId", Source: StringSource("event.id")},
+			{Name: "clusterData", Source: APICallSource(&APICall{Method: "GET", URL: "/clusters/{{ .clusterId }}"})},
+			{Name: "nodePoolData", Source: APICallSource(&APICall{Method: "GET", URL: "/clusters/{{ .clusterId }}/nodepools"})},
+		}
+		v := newTaskValidator(cfg)
+		require.NoError(t, v.ValidateStructure())
+		require.NoError(t, v.ValidateSemantic())
+	})
+
+	t.Run("api_call source URL cannot reference param defined after it", func(t *testing.T) {
+		cfg := baseTaskConfig()
+		cfg.Params = []Parameter{
+			// nodePoolName is defined AFTER nodePoolData uses it (order violation)
+			{Name: "nodePoolData", Source: APICallSource(&APICall{Method: "GET", URL: "/nodepools/{{ .nodePoolName }}"})},
+			{Name: "nodePoolName", Source: StringSource("event.nodePool")},
+		}
+		v := newTaskValidator(cfg)
+		_ = v.ValidateStructure()
+		err := v.ValidateSemantic()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "undefined template variable \"nodePoolName\"")
+	})
+
+	t.Run("expression source passes CEL validation", func(t *testing.T) {
+		cfg := baseTaskConfig()
+		cfg.Params = []Parameter{
+			{Name: "clusterId", Source: StringSource("event.id")},
+			{Name: "clusterData", Source: APICallSource(&APICall{Method: "GET", URL: "/clusters/{{ .clusterId }}"})},
+			{Name: "isActive", Source: ExpressionSource(`clusterData.status == "Active"`)},
+		}
+		v := newTaskValidator(cfg)
+		require.NoError(t, v.ValidateStructure())
+		require.NoError(t, v.ValidateSemantic())
+	})
+
+	t.Run("expression source with invalid CEL fails validation", func(t *testing.T) {
+		cfg := baseTaskConfig()
+		cfg.Params = []Parameter{
+			{Name: "bad", Source: ExpressionSource(`====invalid`)},
+		}
+		v := newTaskValidator(cfg)
+		_ = v.ValidateStructure()
+		err := v.ValidateSemantic()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "CEL parse error")
+	})
+
+	t.Run("empty string source fails validation", func(t *testing.T) {
+		cfg := baseTaskConfig()
+		cfg.Params = []Parameter{
+			{Name: "bad", Source: StringSource("")},
+		}
+		v := newTaskValidator(cfg)
+		_ = v.ValidateStructure()
+		err := v.ValidateSemantic()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "source is required")
+	})
+}
+
+func TestValidatePreconditionAPICallForbidden(t *testing.T) {
+	t.Run("precondition with api_call produces migration error", func(t *testing.T) {
+		cfg := baseTaskConfig()
+		cfg.Preconditions = []Precondition{{
+			ActionBase: ActionBase{
+				Name:    "fetchCluster",
+				APICall: &APICall{Method: "GET", URL: "/clusters/x"},
+			},
+		}}
+		v := newTaskValidator(cfg)
+		_ = v.ValidateStructure()
+		err := v.ValidateSemantic()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "api_call is no longer valid in the precondition phase")
+		assert.Contains(t, err.Error(), "fetchCluster")
+	})
+
+	t.Run("precondition without api_call passes", func(t *testing.T) {
+		cfg := baseTaskConfig()
+		cfg.Preconditions = []Precondition{{
+			ActionBase: ActionBase{Name: "check"},
+			Expression: "true",
+		}}
 		v := newTaskValidator(cfg)
 		require.NoError(t, v.ValidateStructure())
 		require.NoError(t, v.ValidateSemantic())

--- a/internal/dryrun/trace.go
+++ b/internal/dryrun/trace.go
@@ -100,6 +100,21 @@ func (t *ExecutionTrace) FormatText() string {
 	b.WriteString("========================\n")
 	fmt.Fprintf(&b, "Event: id=%s type=%s\n\n", t.EventID, t.EventType)
 
+	// Compute how many API requests belong to each phase
+	precondAPICallCount := 0
+	for _, pr := range result.PreconditionResults {
+		if pr.APICallMade {
+			precondAPICallCount++
+		}
+	}
+	postActionAPICallCount := 0
+	for _, pa := range result.PostActionResults {
+		if pa.APICallMade {
+			postActionAPICallCount++
+		}
+	}
+	paramAPICallCount := max(0, len(t.APIClient.Requests)-precondAPICallCount-postActionAPICallCount)
+
 	// Phase 1: Parameter Extraction
 	paramStatus := statusSuccess
 	if _, ok := result.Errors[executor.PhaseParamExtraction]; ok {
@@ -109,6 +124,18 @@ func (t *ExecutionTrace) FormatText() string {
 	if paramStatus == statusSuccess {
 		for name, val := range result.Params {
 			fmt.Fprintf(&b, "  %-16s = %v\n", name, formatValue(val))
+		}
+		for i := range paramAPICallCount {
+			req := t.APIClient.Requests[i]
+			fmt.Fprintf(&b, "  API Call: %s %s -> %d\n", req.Method, req.URL, req.StatusCode)
+			if t.Verbose {
+				if len(req.Body) > 0 {
+					fmt.Fprintf(&b, "    [verbose] Request body:\n      %s\n", prettyJSON(req.Body))
+				}
+				if len(req.Response) > 0 {
+					fmt.Fprintf(&b, "    [verbose] Response body:\n      %s\n", prettyJSON(req.Response))
+				}
+			}
 		}
 	} else {
 		fmt.Fprintf(&b, "  Error: %v\n", result.Errors[executor.PhaseParamExtraction])
@@ -132,7 +159,7 @@ func (t *ExecutionTrace) FormatText() string {
 	}
 	fmt.Fprintf(&b, "Phase 2: Preconditions ..................... %s%s\n", precondStatus, precondDetail)
 
-	apiReqIdx := 0
+	apiReqIdx := paramAPICallCount
 	for i, pr := range result.PreconditionResults {
 		status := "PASS"
 		if pr.Status == executor.StatusFailed {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -274,7 +274,7 @@ func (e *Executor) executeParamExtraction(execCtx *ExecutionContext) error {
 
 	// config.* param sources resolve against the real (unredacted) config so that
 	// sensitive fields like cert paths can still be explicitly extracted when needed.
-	return extractConfigParams(e.config.Config, execCtx, configMap)
+	return extractConfigParams(execCtx.Ctx, e.config.Config, execCtx, configMap, e.config.APIClient, e.log)
 }
 
 // startTracedExecution creates an OTel span and adds trace context to logs.

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -319,12 +319,12 @@ func TestExecute_ParamExtraction(t *testing.T) {
 		Params: []configloader.Parameter{
 			{
 				Name:     "testParam",
-				Source:   "env.TEST_VAR",
+				Source:   configloader.StringSource("env.TEST_VAR"),
 				Required: true,
 			},
 			{
 				Name:     "eventParam",
-				Source:   "event.id",
+				Source:   configloader.StringSource("event.id"),
 				Required: true,
 			},
 		},
@@ -361,6 +361,101 @@ func TestExecute_ParamExtraction(t *testing.T) {
 	}
 }
 
+// TestExecute_ParamsAPICallSource verifies the full executor pipeline when params use
+// api_call and expression sources
+func TestExecute_ParamsAPICallSource(t *testing.T) {
+	clusterBody := `{
+		"name": "unit-cluster",
+		"generation": 3,
+		"spec": {"region": "us-east-1"},
+		"status": {
+			"conditions": [{"type": "Reconciled", "status": "True"}]
+		}
+	}`
+
+	mockClient := newMockAPIClient()
+	mockClient.GetResponse = &hyperfleetapi.Response{StatusCode: 200, Body: []byte(clusterBody)}
+	mockClient.PutResponse = &hyperfleetapi.Response{StatusCode: 200, Body: []byte(`{}`)}
+
+	config := &configloader.Config{
+		Adapter: configloader.AdapterInfo{Name: "test-adapter", Version: "1.0.0"},
+		Params: []configloader.Parameter{
+			{Name: "clusterId", Source: configloader.StringSource("event.id"), Required: true},
+			{Name: "clusterData", Source: configloader.APICallSource(&configloader.APICall{
+				Method: "GET",
+				URL:    "/clusters/{{ .clusterId }}",
+			})},
+			{Name: "clusterName", Source: configloader.StringSource("clusterData.name")},
+			{Name: "clusterRegion", Source: configloader.StringSource("clusterData.spec.region")},
+			{Name: "isReconciled", Source: configloader.ExpressionSource(
+				`clusterData.status.conditions.filter(c, c.type == "Reconciled").size() > 0
+				  ? clusterData.status.conditions.filter(c, c.type == "Reconciled")[0].status == "True"
+				  : false`,
+			)},
+		},
+		// Precondition evaluates only params
+		Preconditions: []configloader.Precondition{
+			{
+				ActionBase: configloader.ActionBase{Name: "clusterReady"},
+				Expression: "isReconciled",
+			},
+		},
+		Resources: []configloader.Resource{},
+		Post: &configloader.PostConfig{
+			Payloads: []configloader.Payload{
+				{
+					Name: "statusPayload",
+					Build: map[string]interface{}{
+						"clusterName":   map[string]interface{}{"expression": "clusterName"},
+						"clusterRegion": map[string]interface{}{"expression": "clusterRegion"},
+						"isReconciled":  map[string]interface{}{"expression": "isReconciled"},
+					},
+				},
+			},
+			PostActions: []configloader.PostAction{
+				{
+					ActionBase: configloader.ActionBase{
+						Name: "reportStatus",
+						APICall: &configloader.APICall{
+							Method: "PUT",
+							URL:    "/clusters/{{ .clusterId }}/statuses",
+							Body:   "{{ .statusPayload }}",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	exec, err := NewBuilder().
+		WithConfig(config).
+		WithAPIClient(mockClient).
+		WithTransportClient(k8sclient.NewMockK8sClient()).
+		WithLogger(logger.NewTestLogger()).
+		Build()
+	require.NoError(t, err)
+
+	eventData := map[string]interface{}{"id": "cluster-unit"}
+	result := exec.Execute(context.Background(), eventData)
+
+	require.Equal(t, StatusSuccess, result.Status, "expected success; errors=%v", result.Errors)
+	assert.False(t, result.ResourcesSkipped, "precondition should match — resources not skipped")
+
+	// Derived params must be resolved
+	assert.Equal(t, "unit-cluster", result.Params["clusterName"])
+	assert.Equal(t, "us-east-1", result.Params["clusterRegion"])
+	assert.Equal(t, true, result.Params["isReconciled"])
+
+	// Precondition must have matched
+	require.Len(t, result.PreconditionResults, 1)
+	assert.True(t, result.PreconditionResults[0].Matched)
+
+	// Two API calls: one GET (params), one PUT (post-action)
+	require.Len(t, mockClient.Requests, 2)
+	assert.Equal(t, "GET", mockClient.Requests[0].Method)
+	assert.Equal(t, "PUT", mockClient.Requests[1].Method)
+}
+
 func TestParamExtractor(t *testing.T) {
 	t.Setenv("TEST_ENV", "env-value")
 
@@ -383,7 +478,7 @@ func TestParamExtractor(t *testing.T) {
 		{
 			name: "extract from env",
 			params: []configloader.Parameter{
-				{Name: "envVar", Source: "env.TEST_ENV"},
+				{Name: "envVar", Source: configloader.StringSource("env.TEST_ENV")},
 			},
 			expectKey:   "envVar",
 			expectValue: "env-value",
@@ -391,7 +486,7 @@ func TestParamExtractor(t *testing.T) {
 		{
 			name: "extract from event",
 			params: []configloader.Parameter{
-				{Name: "clusterId", Source: "event.id"},
+				{Name: "clusterId", Source: configloader.StringSource("event.id")},
 			},
 			expectKey:   "clusterId",
 			expectValue: "test-cluster",
@@ -399,7 +494,7 @@ func TestParamExtractor(t *testing.T) {
 		{
 			name: "extract nested from event",
 			params: []configloader.Parameter{
-				{Name: "nestedVal", Source: "event.nested.value"},
+				{Name: "nestedVal", Source: configloader.StringSource("event.nested.value")},
 			},
 			expectKey:   "nestedVal",
 			expectValue: "nested-value",
@@ -407,7 +502,7 @@ func TestParamExtractor(t *testing.T) {
 		{
 			name: "use default for missing optional",
 			params: []configloader.Parameter{
-				{Name: "optional", Source: "env.MISSING", Default: "default-val"},
+				{Name: "optional", Source: configloader.StringSource("env.MISSING"), Default: "default-val"},
 			},
 			expectKey:   "optional",
 			expectValue: "default-val",
@@ -415,14 +510,14 @@ func TestParamExtractor(t *testing.T) {
 		{
 			name: "fail on missing required",
 			params: []configloader.Parameter{
-				{Name: "required", Source: "env.MISSING", Required: true},
+				{Name: "required", Source: configloader.StringSource("env.MISSING"), Required: true},
 			},
 			expectError: true,
 		},
 		{
 			name: "extract from config",
 			params: []configloader.Parameter{
-				{Name: "adapterName", Source: "config.adapter.name"},
+				{Name: "adapterName", Source: configloader.StringSource("config.adapter.name")},
 			},
 			expectKey:   "adapterName",
 			expectValue: "test",
@@ -430,7 +525,7 @@ func TestParamExtractor(t *testing.T) {
 		{
 			name: "extract nested from config",
 			params: []configloader.Parameter{
-				{Name: "adapterVersion", Source: "config.adapter.version"},
+				{Name: "adapterVersion", Source: configloader.StringSource("config.adapter.version")},
 			},
 			expectKey:   "adapterVersion",
 			expectValue: "1.0.0",
@@ -438,7 +533,7 @@ func TestParamExtractor(t *testing.T) {
 		{
 			name: "use default for missing optional config field",
 			params: []configloader.Parameter{
-				{Name: "optional", Source: "config.nonexistent", Default: "fallback"},
+				{Name: "optional", Source: configloader.StringSource("config.nonexistent"), Default: "fallback"},
 			},
 			expectKey:   "optional",
 			expectValue: "fallback",
@@ -446,7 +541,7 @@ func TestParamExtractor(t *testing.T) {
 		{
 			name: "fail on missing required config field",
 			params: []configloader.Parameter{
-				{Name: "required", Source: "config.nonexistent", Required: true},
+				{Name: "required", Source: configloader.StringSource("config.nonexistent"), Required: true},
 			},
 			expectError: true,
 		},
@@ -469,7 +564,7 @@ func TestParamExtractor(t *testing.T) {
 			// Extract params using pure function
 			configMap, err := configToMap(config)
 			require.NoError(t, err)
-			err = extractConfigParams(config, execCtx, configMap)
+			err = extractConfigParams(context.Background(), config, execCtx, configMap, nil, logger.NewTestLogger())
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -485,6 +580,184 @@ func TestParamExtractor(t *testing.T) {
 			}
 		})
 	}
+}
+
+// runParamExtraction is a test helper that wires up the full param extraction
+// pipeline
+func runParamExtraction(
+	t *testing.T, config *configloader.Config, mockClient hyperfleetapi.Client, eventData map[string]interface{},
+) (*ExecutionContext, error) {
+	t.Helper()
+	execCtx := NewExecutionContext(context.Background(), eventData, nil)
+	configMap, err := configToMap(config)
+	require.NoError(t, err)
+	addAdapterParams(config, execCtx, configMap)
+	err = extractConfigParams(context.Background(), config, execCtx, configMap, mockClient, logger.NewTestLogger())
+	return execCtx, err
+}
+
+// TestParamExtractor_APICallSource tests params with source: api_call
+func TestParamExtractor_APICallSource(t *testing.T) {
+	eventData := map[string]interface{}{"id": "cluster-123"}
+
+	responseBody := `{"name":"my-cluster","generation":5,"status":{"phase":"Active"}}`
+
+	t.Run("single api_call stores full response map", func(t *testing.T) {
+		mockClient := newMockAPIClient()
+		mockClient.GetResponse = &hyperfleetapi.Response{StatusCode: 200, Body: []byte(responseBody)}
+
+		config := &configloader.Config{
+			Params: []configloader.Parameter{
+				{Name: "clusterId", Source: configloader.StringSource("event.id")},
+				{Name: "clusterData", Source: configloader.APICallSource(&configloader.APICall{
+					Method: "GET", URL: "/clusters/{{ .clusterId }}",
+				})},
+			},
+		}
+		execCtx, err := runParamExtraction(t, config, mockClient, eventData)
+		require.NoError(t, err)
+
+		val, ok := execCtx.Params["clusterData"]
+		require.True(t, ok, "clusterData should be in params")
+		m, ok := val.(map[string]interface{})
+		require.True(t, ok, "clusterData should be a map")
+		assert.Equal(t, "my-cluster", m["name"])
+	})
+
+	t.Run("dot-notation derivation extracts field from api_call param", func(t *testing.T) {
+		mockClient := newMockAPIClient()
+		mockClient.GetResponse = &hyperfleetapi.Response{StatusCode: 200, Body: []byte(responseBody)}
+
+		config := &configloader.Config{
+			Params: []configloader.Parameter{
+				{Name: "clusterId", Source: configloader.StringSource("event.id")},
+				{Name: "clusterData", Source: configloader.APICallSource(&configloader.APICall{
+					Method: "GET", URL: "/clusters/{{ .clusterId }}",
+				})},
+				{Name: "clusterName", Source: configloader.StringSource("clusterData.name"), Type: "string"},
+				{Name: "generationId", Source: configloader.StringSource("clusterData.generation"), Type: "int"},
+				{Name: "clusterPhase", Source: configloader.StringSource("clusterData.status.phase")},
+			},
+		}
+		execCtx, err := runParamExtraction(t, config, mockClient, eventData)
+		require.NoError(t, err)
+
+		assert.Equal(t, "my-cluster", execCtx.Params["clusterName"])
+		assert.Equal(t, int64(5), execCtx.Params["generationId"])
+		assert.Equal(t, "Active", execCtx.Params["clusterPhase"])
+	})
+
+	t.Run("chained api_calls — second URL uses first param", func(t *testing.T) {
+		mockClient := newMockAPIClient()
+		mockClient.GetResponse = &hyperfleetapi.Response{
+			StatusCode: 200,
+			Body:       []byte(`{"defaultNodePool":"np-primary","replicas":3}`),
+		}
+
+		config := &configloader.Config{
+			Params: []configloader.Parameter{
+				{Name: "clusterId", Source: configloader.StringSource("event.id")},
+				{Name: "clusterData", Source: configloader.APICallSource(&configloader.APICall{
+					Method: "GET", URL: "/clusters/{{ .clusterId }}",
+				})},
+				{Name: "defaultNodePool", Source: configloader.StringSource("clusterData.defaultNodePool")},
+				{Name: "nodePoolData", Source: configloader.APICallSource(&configloader.APICall{
+					Method: "GET", URL: "/clusters/{{ .clusterId }}/nodepools/{{ .defaultNodePool }}",
+				})},
+				{Name: "nodeCount", Source: configloader.StringSource("nodePoolData.replicas"), Type: "int"},
+			},
+		}
+		execCtx, err := runParamExtraction(t, config, mockClient, eventData)
+		require.NoError(t, err)
+
+		assert.Equal(t, "np-primary", execCtx.Params["defaultNodePool"])
+		assert.Equal(t, int64(3), execCtx.Params["nodeCount"])
+		require.Len(t, mockClient.Requests, 2)
+		assert.Contains(t, mockClient.Requests[1].URL, "np-primary")
+	})
+
+	t.Run("CEL expression source over resolved params", func(t *testing.T) {
+		mockClient := newMockAPIClient()
+		mockClient.GetResponse = &hyperfleetapi.Response{StatusCode: 200, Body: []byte(responseBody)}
+
+		config := &configloader.Config{
+			Params: []configloader.Parameter{
+				{Name: "clusterId", Source: configloader.StringSource("event.id")},
+				{Name: "clusterData", Source: configloader.APICallSource(&configloader.APICall{
+					Method: "GET", URL: "/clusters/{{ .clusterId }}",
+				})},
+				{Name: "isActive", Source: configloader.ExpressionSource(`clusterData.status.phase == "Active"`)},
+			},
+		}
+		execCtx, err := runParamExtraction(t, config, mockClient, eventData)
+		require.NoError(t, err)
+
+		assert.Equal(t, true, execCtx.Params["isActive"])
+	})
+
+	t.Run("required api_call failure returns error", func(t *testing.T) {
+		mockClient := newMockAPIClient()
+		mockClient.GetError = fmt.Errorf("connection refused")
+
+		config := &configloader.Config{
+			Params: []configloader.Parameter{
+				{Name: "clusterData", Source: configloader.APICallSource(&configloader.APICall{
+					Method: "GET", URL: "/clusters/x",
+				}), Required: true},
+			},
+		}
+		_, err := runParamExtraction(t, config, mockClient, eventData)
+		require.Error(t, err)
+	})
+
+	t.Run("non-required api_call failure falls back to default", func(t *testing.T) {
+		mockClient := newMockAPIClient()
+		mockClient.GetError = fmt.Errorf("connection refused")
+
+		config := &configloader.Config{
+			Params: []configloader.Parameter{
+				{Name: "clusterData", Source: configloader.APICallSource(&configloader.APICall{
+					Method: "GET", URL: "/clusters/x",
+				}), Default: map[string]interface{}{"name": "fallback"}},
+			},
+		}
+		execCtx, err := runParamExtraction(t, config, mockClient, eventData)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]interface{}{"name": "fallback"}, execCtx.Params["clusterData"])
+	})
+
+	t.Run("api_call 200 with non-JSON body returns error", func(t *testing.T) {
+		mockClient := newMockAPIClient()
+		mockClient.GetResponse = &hyperfleetapi.Response{
+			StatusCode: 200,
+			Body:       []byte("not json at all"),
+		}
+
+		config := &configloader.Config{
+			Params: []configloader.Parameter{
+				{Name: "clusterData", Source: configloader.APICallSource(&configloader.APICall{
+					Method: "GET", URL: "/clusters/x",
+				}), Required: true},
+			},
+		}
+		_, err := runParamExtraction(t, config, mockClient, eventData)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse API response as JSON")
+	})
+
+	t.Run("dot-notation on non-map param returns error", func(t *testing.T) {
+		mockClient := newMockAPIClient()
+
+		config := &configloader.Config{
+			Params: []configloader.Parameter{
+				{Name: "clusterId", Source: configloader.StringSource("event.id")},
+				{Name: "clusterIdField", Source: configloader.StringSource("clusterId.nested"), Required: true},
+			},
+		}
+		_, err := runParamExtraction(t, config, mockClient, eventData)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "is not a map")
+	})
 }
 
 // TestSequentialExecution_Preconditions tests that preconditions stop on first failure
@@ -962,7 +1235,7 @@ func TestCreateHandler_MetricsRecording_Failed(t *testing.T) {
 	config := &configloader.Config{
 		Adapter: configloader.AdapterInfo{Name: "test-adapter", Version: "v0.1.0"},
 		Params: []configloader.Parameter{
-			{Name: "required", Source: "env.MISSING_VAR", Required: true},
+			{Name: "required", Source: configloader.StringSource("env.MISSING_VAR"), Required: true},
 		},
 	}
 
@@ -1207,7 +1480,7 @@ func TestPreconditionAPIFailure_ExecutionStatusRemainsFailed(t *testing.T) {
 			},
 		},
 		Params: []configloader.Parameter{
-			{Name: "clusterId", Source: "event.id", Required: true},
+			{Name: "clusterId", Source: configloader.StringSource("event.id"), Required: true},
 		},
 		Preconditions: []configloader.Precondition{
 			{
@@ -1497,7 +1770,7 @@ func new404PreconditionConfig() *configloader.Config {
 			},
 		},
 		Params: []configloader.Parameter{
-			{Name: "clusterId", Source: "event.id", Required: true},
+			{Name: "clusterId", Source: configloader.StringSource("event.id"), Required: true},
 		},
 		Preconditions: []configloader.Precondition{
 			{

--- a/internal/executor/param_extractor.go
+++ b/internal/executor/param_extractor.go
@@ -1,30 +1,37 @@
 package executor
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/configloader"
+	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/criteria"
+	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/hyperfleetapi"
+	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/logger"
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/pkg/utils"
 )
 
 // extractConfigParams extracts all configured parameters and populates execCtx.Params
-// This is a pure function that directly modifies execCtx for simplicity
 func extractConfigParams(
+	ctx context.Context,
 	config *configloader.Config,
 	execCtx *ExecutionContext,
 	configMap map[string]interface{},
+	apiClient hyperfleetapi.Client,
+	log logger.Logger,
 ) error {
 	for _, param := range config.Params {
-		value, err := extractParam(param, execCtx.EventData, configMap)
+		value, err := extractParam(ctx, param, execCtx, configMap, apiClient, log)
 		if err != nil {
 			if param.Required {
 				return NewExecutorError(PhaseParamExtraction, param.Name,
-					fmt.Sprintf("failed to extract required parameter '%s' from source '%s'", param.Name, param.Source), err)
+					fmt.Sprintf("failed to extract required parameter '%s' from source '%s'",
+						param.Name, param.Source.Describe()), err)
 			}
-			// Use default for non-required params if extraction fails
 			if param.Default != nil {
 				execCtx.Params[param.Name] = param.Default
 			}
@@ -40,15 +47,13 @@ func extractConfigParams(
 			value = param.Default
 		}
 
-		// Apply type conversion if specified
-		if value != nil && param.Type != "" {
+		if value != nil && param.Type != "" && param.Source.IsString() {
 			converted, convErr := convertParamType(value, param.Type)
 			if convErr != nil {
 				if param.Required {
 					return NewExecutorError(PhaseParamExtraction, param.Name,
 						fmt.Sprintf("failed to convert parameter '%s' to type '%s'", param.Name, param.Type), convErr)
 				}
-				// Use default for non-required params if conversion fails
 				if param.Default != nil {
 					execCtx.Params[param.Name] = param.Default
 				}
@@ -65,15 +70,35 @@ func extractConfigParams(
 	return nil
 }
 
-// extractParam extracts a single parameter based on its source
+// extractParam resolves a single parameter based on its source kind
 func extractParam(
+	ctx context.Context,
+	param configloader.Parameter,
+	execCtx *ExecutionContext,
+	configMap map[string]interface{},
+	apiClient hyperfleetapi.Client,
+	log logger.Logger,
+) (interface{}, error) {
+	switch {
+	case param.Source.IsAPICall():
+		return extractFromAPICall(ctx, param, execCtx, apiClient, log)
+	case param.Source.IsExpression():
+		return extractFromCELExpression(ctx, param, execCtx, log)
+	case param.Source.IsString():
+		return extractFromStringSource(param, execCtx.EventData, configMap, execCtx.Params)
+	default:
+		return param.Default, nil
+	}
+}
+
+// extractFromStringSource handles env.*, event.*, config.*, and dot-notation param derivation
+func extractFromStringSource(
 	param configloader.Parameter,
 	eventData map[string]interface{},
 	configMap map[string]interface{},
+	resolvedParams map[string]interface{},
 ) (interface{}, error) {
-	source := param.Source
-
-	// Handle different source types
+	source := param.Source.StringVal
 	switch {
 	case strings.HasPrefix(source, "env."):
 		return extractFromEnv(source[4:])
@@ -82,12 +107,70 @@ func extractParam(
 	case strings.HasPrefix(source, "config."):
 		return utils.GetNestedValue(configMap, source[7:])
 	case source == "":
-		// No source specified, return default or nil
 		return param.Default, nil
 	default:
-		// Try to extract from event data directly
+		// Check if the first path segment is a previously resolved param.
+		parts := strings.SplitN(source, ".", 2)
+		if baseVal, ok := resolvedParams[parts[0]]; ok {
+			if len(parts) == 1 {
+				return baseVal, nil
+			}
+			m, ok := baseVal.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("param %q is not a map (got %T), cannot derive %q from it",
+					parts[0], baseVal, source)
+			}
+			return utils.GetNestedValue(m, parts[1])
+		}
+		// Fallback: treat as bare event path (preserves old behavior for unqualified field names)
 		return utils.GetNestedValue(eventData, source)
 	}
+}
+
+// extractFromAPICall makes an HTTP call, stores the parsed JSON response map as the param value
+func extractFromAPICall(
+	ctx context.Context,
+	param configloader.Parameter,
+	execCtx *ExecutionContext,
+	apiClient hyperfleetapi.Client,
+	log logger.Logger,
+) (interface{}, error) {
+	ac := param.Source.APICall
+	if ac == nil {
+		return nil, fmt.Errorf("param %q: api_call source has nil configuration", param.Name)
+	}
+	resp, renderedURL, err := ExecuteAPICall(ctx, ac, execCtx, apiClient, log)
+	if validationErr := ValidateAPIResponse(resp, err, ac.Method, renderedURL); validationErr != nil {
+		return nil, validationErr
+	}
+	var responseData map[string]interface{}
+	if jsonErr := json.Unmarshal(resp.Body, &responseData); jsonErr != nil {
+		return nil, fmt.Errorf("param %q: failed to parse API response as JSON: %w", param.Name, jsonErr)
+	}
+	return responseData, nil
+}
+
+// extractFromCELExpression evaluates a CEL expression over already-resolved params
+func extractFromCELExpression(
+	ctx context.Context,
+	param configloader.Parameter,
+	execCtx *ExecutionContext,
+	log logger.Logger,
+) (interface{}, error) {
+	evalCtx := criteria.NewEvaluationContext()
+	evalCtx.SetVariablesFromMap(execCtx.GetCELVariables())
+	evaluator, err := criteria.NewEvaluator(ctx, evalCtx, log)
+	if err != nil {
+		return nil, fmt.Errorf("param %q: failed to create CEL evaluator: %w", param.Name, err)
+	}
+	result, err := evaluator.EvaluateCEL(strings.TrimSpace(param.Source.Expression))
+	if err != nil {
+		return nil, fmt.Errorf("param %q: CEL evaluation failed: %w", param.Name, err)
+	}
+	if result.Error != nil {
+		return nil, fmt.Errorf("param %q: CEL expression error: %w", param.Name, result.Error)
+	}
+	return result.Value, nil
 }
 
 // configToMap converts a Config to map[string]interface{} using the yaml struct tags for key names.

--- a/test/integration/config-loader/config_criteria_integration_test.go
+++ b/test/integration/config-loader/config_criteria_integration_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -390,7 +389,7 @@ func TestConfigParameterExtraction(t *testing.T) {
 		requiredNames := make(map[string]bool)
 		for _, p := range requiredParams {
 			requiredNames[p.Name] = true
-			t.Logf("Required param: %s (source: %s)", p.Name, p.Source)
+			t.Logf("Required param: %s (source: %s)", p.Name, p.Source.Describe())
 		}
 
 		assert.True(t, requiredNames["clusterId"], "clusterId should be required")
@@ -398,12 +397,8 @@ func TestConfigParameterExtraction(t *testing.T) {
 
 	t.Run("verify parameter sources", func(t *testing.T) {
 		for _, param := range config.Params {
-			if param.Source != "" {
-				// Check source format
-				assert.True(t,
-					strings.HasPrefix(param.Source, "env.") || strings.HasPrefix(param.Source, "event."),
-					"param %s source should start with env. or event., got: %s", param.Name, param.Source)
-			}
+			assert.False(t, param.Source.IsZero(),
+				"param %s should have a source set", param.Name)
 		}
 	})
 }

--- a/test/integration/config-loader/loader_template_test.go
+++ b/test/integration/config-loader/loader_template_test.go
@@ -71,8 +71,19 @@ func TestLoadSplitConfig(t *testing.T) {
 	// Check specific params (using accessor method)
 	clusterIDParam := config.GetParamByName("clusterId")
 	require.NotNil(t, clusterIDParam, "clusterId parameter should exist")
-	assert.Equal(t, "event.id", clusterIDParam.Source)
+	assert.Equal(t, configloader.StringSource("event.id"), clusterIDParam.Source)
 	assert.True(t, clusterIDParam.Required)
+
+	// Check api_call param
+	clusterDataParam := config.GetParamByName("clusterData")
+	require.NotNil(t, clusterDataParam, "clusterData parameter should exist")
+	assert.True(t, clusterDataParam.Source.IsAPICall())
+	assert.Equal(t, "GET", clusterDataParam.Source.APICall.Method)
+
+	// Check expression param
+	reconciledParam := config.GetParamByName("reconciledConditionStatus")
+	require.NotNil(t, reconciledParam, "reconciledConditionStatus parameter should exist")
+	assert.True(t, reconciledParam.Source.IsExpression())
 
 	// Verify preconditions (from task config)
 	assert.NotEmpty(t, config.Preconditions)
@@ -81,15 +92,8 @@ func TestLoadSplitConfig(t *testing.T) {
 	// Check first precondition
 	firstPrecond := config.Preconditions[0]
 	assert.Equal(t, "clusterStatus", firstPrecond.Name)
-	assert.NotNil(t, firstPrecond.APICall)
-	assert.Equal(t, "GET", firstPrecond.APICall.Method)
-	assert.NotEmpty(t, firstPrecond.Capture)
+	assert.Nil(t, firstPrecond.APICall)
 	assert.NotEmpty(t, firstPrecond.Conditions)
-
-	// Verify captured fields
-	clusterNameCapture := findCaptureByName(firstPrecond.Capture, "clusterName")
-	require.NotNil(t, clusterNameCapture)
-	assert.Equal(t, "name", clusterNameCapture.Field)
 
 	// Verify conditions in precondition
 	assert.GreaterOrEqual(t, len(firstPrecond.Conditions), 1)
@@ -145,14 +149,4 @@ func TestLoadSplitConfigWithResourceByName(t *testing.T) {
 	configMapResource := config.GetResourceByName("clusterConfigMap")
 	require.NotNil(t, configMapResource, "clusterConfigMap resource should exist")
 	assert.Equal(t, "clusterConfigMap", configMapResource.Name)
-}
-
-// Helper function to find a capture field by name
-func findCaptureByName(captures []configloader.CaptureField, name string) *configloader.CaptureField {
-	for i := range captures {
-		if captures[i].Name == name {
-			return &captures[i]
-		}
-	}
-	return nil
 }

--- a/test/integration/executor/executor_integration_test.go
+++ b/test/integration/executor/executor_integration_test.go
@@ -73,9 +73,10 @@ func createTestConfig(apiBaseURL string) *configloader.Config {
 			},
 		},
 		Params: []configloader.Parameter{
-			{Name: "hyperfleetApiBaseUrl", Source: "env.HYPERFLEET_API_BASE_URL", Required: true},
-			{Name: "hyperfleetApiVersion", Source: "env.HYPERFLEET_API_VERSION", Default: "v1", Required: false},
-			{Name: "clusterID", Source: "event.id", Required: true},
+			{Name: "hyperfleetApiBaseUrl", Source: configloader.StringSource("env.HYPERFLEET_API_BASE_URL"), Required: true},
+			{Name: "hyperfleetApiVersion", Source: configloader.StringSource("env.HYPERFLEET_API_VERSION"),
+				Default: "v1", Required: false},
+			{Name: "clusterID", Source: configloader.StringSource("event.id"), Required: true},
 		},
 		Preconditions: []configloader.Precondition{
 			{
@@ -1006,9 +1007,9 @@ func TestExecutor_LogAction(t *testing.T) {
 			},
 		},
 		Params: []configloader.Parameter{
-			{Name: "hyperfleetApiBaseUrl", Source: "env.HYPERFLEET_API_BASE_URL", Required: true},
+			{Name: "hyperfleetApiBaseUrl", Source: configloader.StringSource("env.HYPERFLEET_API_BASE_URL"), Required: true},
 			{Name: "hyperfleetApiVersion", Default: "v1"},
-			{Name: "clusterID", Source: "event.id", Required: true},
+			{Name: "clusterID", Source: configloader.StringSource("event.id"), Required: true},
 		},
 		Preconditions: []configloader.Precondition{
 			{
@@ -1254,9 +1255,9 @@ func TestExecutor_ExecutionError_CELAccess(t *testing.T) {
 			},
 		},
 		Params: []configloader.Parameter{
-			{Name: "hyperfleetApiBaseUrl", Source: "env.HYPERFLEET_API_BASE_URL", Required: true},
+			{Name: "hyperfleetApiBaseUrl", Source: configloader.StringSource("env.HYPERFLEET_API_BASE_URL"), Required: true},
 			{Name: "hyperfleetApiVersion", Default: "v1"},
-			{Name: "clusterID", Source: "event.id", Required: true},
+			{Name: "clusterID", Source: configloader.StringSource("event.id"), Required: true},
 		},
 		Preconditions: []configloader.Precondition{
 			{
@@ -1429,9 +1430,9 @@ func TestExecutor_PayloadBuildFailure(t *testing.T) {
 			},
 		},
 		Params: []configloader.Parameter{
-			{Name: "hyperfleetApiBaseUrl", Source: "env.HYPERFLEET_API_BASE_URL", Required: true},
+			{Name: "hyperfleetApiBaseUrl", Source: configloader.StringSource("env.HYPERFLEET_API_BASE_URL"), Required: true},
 			{Name: "hyperfleetApiVersion", Default: "v1"},
-			{Name: "clusterID", Source: "event.id", Required: true},
+			{Name: "clusterID", Source: configloader.StringSource("event.id"), Required: true},
 		},
 		Preconditions: []configloader.Precondition{
 			{
@@ -1557,9 +1558,10 @@ func TestExecutor_PayloadWhenCondition(t *testing.T) {
 			},
 		},
 		Params: []configloader.Parameter{
-			{Name: "hyperfleetApiBaseUrl", Source: "env.HYPERFLEET_API_BASE_URL", Required: true},
-			{Name: "hyperfleetApiVersion", Source: "env.HYPERFLEET_API_VERSION", Default: "v1", Required: false},
-			{Name: "clusterID", Source: "event.id", Required: true},
+			{Name: "hyperfleetApiBaseUrl", Source: configloader.StringSource("env.HYPERFLEET_API_BASE_URL"), Required: true},
+			{Name: "hyperfleetApiVersion", Source: configloader.StringSource("env.HYPERFLEET_API_VERSION"),
+				Default: "v1", Required: false},
+			{Name: "clusterID", Source: configloader.StringSource("event.id"), Required: true},
 		},
 		Preconditions: []configloader.Precondition{
 			{

--- a/test/integration/executor/executor_k8s_integration_test.go
+++ b/test/integration/executor/executor_k8s_integration_test.go
@@ -158,18 +158,18 @@ func createK8sTestConfig(testNamespace string) *configloader.Config {
 		Params: []configloader.Parameter{
 			{
 				Name:     "hyperfleetApiBaseUrl",
-				Source:   "env.HYPERFLEET_API_BASE_URL",
+				Source:   configloader.StringSource("env.HYPERFLEET_API_BASE_URL"),
 				Required: true,
 			},
 			{
 				Name:     "hyperfleetApiVersion",
-				Source:   "env.HYPERFLEET_API_VERSION",
+				Source:   configloader.StringSource("env.HYPERFLEET_API_VERSION"),
 				Default:  "v1",
 				Required: false,
 			},
 			{
 				Name:     "clusterID",
-				Source:   "event.id",
+				Source:   configloader.StringSource("event.id"),
 				Required: true,
 			},
 			{
@@ -892,9 +892,9 @@ func TestExecutor_K8s_MultipleMatchingResources(t *testing.T) {
 			},
 		},
 		Params: []configloader.Parameter{
-			{Name: "hyperfleetApiBaseUrl", Source: "env.HYPERFLEET_API_BASE_URL", Required: true},
+			{Name: "hyperfleetApiBaseUrl", Source: configloader.StringSource("env.HYPERFLEET_API_BASE_URL"), Required: true},
 			{Name: "hyperfleetApiVersion", Default: "v1"},
-			{Name: "clusterID", Source: "event.id", Required: true},
+			{Name: "clusterID", Source: configloader.StringSource("event.id"), Required: true},
 		},
 		// No preconditions - this test focuses on resource creation
 		Resources: []configloader.Resource{

--- a/test/testdata/dryrun/cel-showcase/dryrun-cel-showcase-task-config.yaml
+++ b/test/testdata/dryrun/cel-showcase/dryrun-cel-showcase-task-config.yaml
@@ -52,140 +52,139 @@ params:
     type: "string"
     default: "dry-run-adapter"
 
+  - name: "fetchCluster"
+    source:
+      api_call:
+        method: "GET"
+        url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}"
+        timeout: 10s
+
+  # ---------------------------------------------------------------
+  # Pattern 1: field — simple dot-notation extraction
+  # ---------------------------------------------------------------
+  - name: "clusterName"
+    source: "fetchCluster.name"
+
+  # ---------------------------------------------------------------
+  # Pattern 1b: field — nested dot-notation extraction
+  # ---------------------------------------------------------------
+  - name: "clusterRegion"
+    source: "fetchCluster.spec.region"
+
+  # ---------------------------------------------------------------
+  # Pattern 2: filter() + ternary — list filtering with fallback
+  # ---------------------------------------------------------------
+  - name: "clusterStatus"
+    source:
+      expression: |
+        fetchCluster.status.conditions.filter(c, c.type == "Reconciled").size() > 0
+          ? fetchCluster.status.conditions.filter(c, c.type == "Reconciled")[0].status
+          : "Unknown"
+
+  # ---------------------------------------------------------------
+  # Pattern 3: exists() — boolean check on list elements
+  # ---------------------------------------------------------------
+  - name: "isProduction"
+    source:
+      expression: |
+        fetchCluster.spec.tags.exists(t, t == "production")
+
+  # ---------------------------------------------------------------
+  # Pattern 4: size() — counting elements
+  # ---------------------------------------------------------------
+  - name: "nodePoolCount"
+    source:
+      expression: |
+        fetchCluster.spec.node_pools.size()
+
+  # ---------------------------------------------------------------
+  # Pattern 5: string concatenation — building derived values
+  # ---------------------------------------------------------------
+  - name: "resourcePrefix"
+    source:
+      expression: |
+        fetchCluster.spec.provider + "-" + fetchCluster.spec.region + "-" + fetchCluster.name
+
+  # ---------------------------------------------------------------
+  # Pattern 6: type coercion — string() and int()
+  # ---------------------------------------------------------------
+  - name: "computeNodesStr"
+    source:
+      expression: |
+        "compute=" + string(fetchCluster.nodes.compute)
+
+  # ---------------------------------------------------------------
+  # Pattern 7: in operator — membership check
+  # ---------------------------------------------------------------
+  - name: "isSupportedProvider"
+    source:
+      expression: |
+        fetchCluster.spec.provider in ["aws", "gcp", "azure"]
+
+  # ---------------------------------------------------------------
+  # Pattern 8: map() — list transformation
+  # ---------------------------------------------------------------
+  - name: "nodePoolNames"
+    source:
+      expression: |
+        fetchCluster.spec.node_pools.map(p, p.name)
+
+  # ---------------------------------------------------------------
+  # Pattern 4b: size() — counting with field extraction
+  # ---------------------------------------------------------------
+  - name: "computeNodes"
+    source: "fetchCluster.nodes.compute"
+
+  # Static timestamp for dry-run reproducibility
+  - name: "timestamp"
+    source:
+      expression: '"2006-01-02T15:04:05Z07:00"'
+
+  # ---------------------------------------------------------------
+  # Pattern 16: distinct() — deduplicate list elements
+  # ---------------------------------------------------------------
+  - name: "uniqueTags"
+    source:
+      expression: |
+        fetchCluster.spec.tags.distinct()
+
+  # ---------------------------------------------------------------
+  # Pattern 17: sort() — sort list elements alphabetically
+  # ---------------------------------------------------------------
+  - name: "sortedTags"
+    source:
+      expression: |
+        fetchCluster.spec.tags.distinct().sort()
+
+  # ---------------------------------------------------------------
+  # Pattern 18: slice() — extract a sub-list by index range
+  # ---------------------------------------------------------------
+  - name: "firstNodePoolName"
+    source:
+      expression: |
+        fetchCluster.spec.node_pools.map(p, p.name).slice(0, 1)
+
+  # ---------------------------------------------------------------
+  # Pattern 19: flatten() — collapse nested lists into one
+  # ---------------------------------------------------------------
+  - name: "conditionSummary"
+    source:
+      expression: |
+        fetchCluster.status.conditions.map(c, [c.type, c.status]).flatten()
+
+  # ---------------------------------------------------------------
+  # Pattern 20: sortBy() — sort objects by a derived key
+  # ---------------------------------------------------------------
+  - name: "nodePoolsByReplicas"
+    source:
+      expression: |
+        fetchCluster.spec.node_pools.sortBy(p, p.replicas).map(p, p.name)
+
 # ===========================================================================
-# Preconditions — CEL capture patterns
+# Preconditions
 # ===========================================================================
 preconditions:
   - name: "fetchCluster"
-    api_call:
-      method: "GET"
-      url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}"
-      timeout: 10s
-    capture:
-      # ---------------------------------------------------------------
-      # Pattern 1: field — simple dot-notation extraction
-      # Extracts a top-level field from the API response by name.
-      # ---------------------------------------------------------------
-      - name: "clusterName"
-        field: "name"
-
-      # ---------------------------------------------------------------
-      # Pattern 1b: field — nested dot-notation extraction
-      # Extracts a nested field using dot-separated path.
-      # ---------------------------------------------------------------
-      - name: "clusterRegion"
-        field: "spec.region"
-
-      # ---------------------------------------------------------------
-      # Pattern 2: filter() + ternary — list filtering with fallback
-      # Filters the conditions list for type=="Reconciled", returns status
-      # or "Unknown" if not found.
-      # ---------------------------------------------------------------
-      - name: "clusterStatus"
-        expression: |
-          status.conditions.filter(c, c.type == "Reconciled").size() > 0
-            ? status.conditions.filter(c, c.type == "Reconciled")[0].status
-            : "Unknown"
-
-      # ---------------------------------------------------------------
-      # Pattern 3: exists() — boolean check on list elements
-      # Returns true if any tag matches "production".
-      # ---------------------------------------------------------------
-      - name: "isProduction"
-        expression: |
-          spec.tags.exists(t, t == "production")
-
-      # ---------------------------------------------------------------
-      # Pattern 4: size() — counting elements
-      # Returns the number of node pools defined in spec.
-      # ---------------------------------------------------------------
-      - name: "nodePoolCount"
-        expression: |
-          spec.node_pools.size()
-
-      # ---------------------------------------------------------------
-      # Pattern 5: string concatenation — building derived values
-      # Constructs a composite identifier from multiple fields.
-      # ---------------------------------------------------------------
-      - name: "resourcePrefix"
-        expression: |
-          spec.provider + "-" + spec.region + "-" + name
-
-      # ---------------------------------------------------------------
-      # Pattern 6: type coercion — string() and int()
-      # Converts the numeric compute node count to string.
-      # ---------------------------------------------------------------
-      - name: "computeNodesStr"
-        expression: |
-          "compute=" + string(nodes.compute)
-
-      # ---------------------------------------------------------------
-      # Pattern 7: in operator — membership check
-      # Checks if the provider is one of the supported cloud providers.
-      # ---------------------------------------------------------------
-      - name: "isSupportedProvider"
-        expression: |
-          spec.provider in ["aws", "gcp", "azure"]
-
-      # ---------------------------------------------------------------
-      # Pattern 8: map() — list transformation
-      # Transforms the node_pools list to extract just the names.
-      # ---------------------------------------------------------------
-      - name: "nodePoolNames"
-        expression: |
-          spec.node_pools.map(p, p.name)
-
-      # ---------------------------------------------------------------
-      # Pattern 4b: size() — counting with field extraction
-      # Extracts compute node count for use in conditions.
-      # ---------------------------------------------------------------
-      - name: "computeNodes"
-        field: "nodes.compute"
-
-      # Static timestamp for dry-run reproducibility
-      - name: "timestamp"
-        expression: "\"2006-01-02T15:04:05Z07:00\""
-
-      # ---------------------------------------------------------------
-      # Pattern 16: distinct() — deduplicate list elements
-      # Removes duplicate entries from the tags list.
-      # ---------------------------------------------------------------
-      - name: "uniqueTags"
-        expression: |
-          spec.tags.distinct()
-
-      # ---------------------------------------------------------------
-      # Pattern 17: sort() — sort list elements alphabetically
-      # Sorts the deduplicated tags list in ascending order.
-      # ---------------------------------------------------------------
-      - name: "sortedTags"
-        expression: |
-          spec.tags.distinct().sort()
-
-      # ---------------------------------------------------------------
-      # Pattern 18: slice() — extract a sub-list by index range
-      # Returns the first node pool name only (indices 0..1 exclusive).
-      # ---------------------------------------------------------------
-      - name: "firstNodePoolName"
-        expression: |
-          spec.node_pools.map(p, p.name).slice(0, 1)
-
-      # ---------------------------------------------------------------
-      # Pattern 19: flatten() — collapse nested lists into one
-      # Extracts type and status from each condition into a flat list.
-      # ---------------------------------------------------------------
-      - name: "conditionSummary"
-        expression: |
-          status.conditions.map(c, [c.type, c.status]).flatten()
-
-      # ---------------------------------------------------------------
-      # Pattern 20: sortBy() — sort objects by a derived key
-      # Sorts node pools by replica count ascending, then extracts names.
-      # ---------------------------------------------------------------
-      - name: "nodePoolsByReplicas"
-        expression: |
-          spec.node_pools.sortBy(p, p.replicas).map(p, p.name)
-
     conditions:
       - field: "clusterStatus"
         operator: "notEquals"

--- a/test/testdata/dryrun/kubernetes-delete/dryrun-kubernetes-delete-task-config.yaml
+++ b/test/testdata/dryrun/kubernetes-delete/dryrun-kubernetes-delete-task-config.yaml
@@ -24,22 +24,23 @@ params:
     type: string
     default: dry-run-adapter
 
-preconditions:
   - name: fetchCluster
-    api_call:
-      method: GET
-      url: /api/hyperfleet/v1/clusters/{{ .clusterId }}
-      timeout: 10s
-    capture:
-      - name: clusterName
-        field: name
-      # is_deleting is the canonical deletion gate used throughout payload expressions.
-      # Capturing it here avoids repeating "has(fetchCluster.deleted_time)" everywhere and
-      # prevents false-positive Finalized=True when resources are absent for
-      # unrelated reasons (e.g., first reconciliation before provisioning).
-      # has() safely checks map key presence without requiring deleted_time to exist.
-      - name: is_deleting
-        expression: "has(fetchCluster.deleted_time)"
+    source:
+      api_call:
+        method: GET
+        url: /api/hyperfleet/v1/clusters/{{ .clusterId }}
+        timeout: 10s
+
+  - name: clusterName
+    source: fetchCluster.name
+
+  # is_deleting is the canonical deletion gate used throughout payload expressions.
+  # Using optional chaining avoids errors when deleted_time is absent and
+  # prevents false-positive Finalized=True when resources are absent for
+  # unrelated reasons (e.g., first reconciliation before provisioning).
+  - name: is_deleting
+    source:
+      expression: "fetchCluster.?deleted_time.hasValue()"
 
 resources:
   # Resource 0: ConfigMap — deleted first (no dependencies on other resources)

--- a/test/testdata/dryrun/kubernetes/dryrun-kubernetes-task-config.yaml
+++ b/test/testdata/dryrun/kubernetes/dryrun-kubernetes-task-config.yaml
@@ -27,28 +27,37 @@ params:
     type: "string"
     default: "dry-run-adapter"
 
+  - name: "fetchCluster"
+    source:
+      api_call:
+        method: "GET"
+        url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}"
+        timeout: 10s
+
+  - name: "clusterName"
+    source: "fetchCluster.name"
+
+  - name: "clusterStatus2"
+    source:
+      expression: |
+        non_existent
+
+  - name: "clusterStatus"
+    source:
+      expression: |
+        fetchCluster.status.conditions.filter(c, c.type == "Reconciled").size() > 0
+          ? fetchCluster.status.conditions.filter(c, c.type == "Reconciled")[0].status
+          : "False"
+
+  - name: "computeNodes"
+    source: "fetchCluster.nodes.compute"
+
+  - name: "timestamp"
+    source:
+      expression: '"2006-01-02T15:04:05Z07:00"'
+
 preconditions:
   - name: "fetchCluster"
-    api_call:
-      method: "GET"
-      url: "/api/hyperfleet/v1/clusters/{{ .clusterId }}"
-      timeout: 10s
-    capture:
-      - name: "clusterName"
-        field: "name"
-      - name: "clusterStatus2"
-        expression: |
-           non_existent
-      - name: "clusterStatus"
-        expression: |
-          status.conditions.filter(c, c.type == "Reconciled").size() > 0
-            ? status.conditions.filter(c, c.type == "Reconciled")[0].status
-            : "False"
-      - name: "computeNodes"
-        field: "nodes.compute"
-      - name: "timestamp"
-        expression:  "\"2006-01-02T15:04:05Z07:00\""
-
     conditions:
       - field: "clusterStatus"
         operator: "notEquals"

--- a/test/testdata/dryrun/maestro-delete/dryrun-maestro-delete-task-config.yaml
+++ b/test/testdata/dryrun/maestro-delete/dryrun-maestro-delete-task-config.yaml
@@ -27,22 +27,23 @@ params:
     type: string
     default: dry-run-adapter
 
-preconditions:
   - name: fetchCluster
-    api_call:
-      method: GET
-      url: /api/hyperfleet/v1/clusters/{{ .clusterId }}
-      timeout: 10s
-    capture:
-      - name: clusterName
-        field: name
-      # is_deleting is the canonical deletion gate used throughout payload expressions.
-      # Capturing it here avoids repeating "has(fetchCluster.deleted_time)" everywhere and
-      # prevents false-positive Finalized=True when resources are absent for
-      # unrelated reasons (e.g., first reconciliation before provisioning).
-      # has() safely checks map key presence without requiring deleted_time to exist.
-      - name: is_deleting
-        expression: "has(fetchCluster.deleted_time)"
+    source:
+      api_call:
+        method: GET
+        url: /api/hyperfleet/v1/clusters/{{ .clusterId }}
+        timeout: 10s
+
+  - name: clusterName
+    source: fetchCluster.name
+
+  # is_deleting is the canonical deletion gate used throughout payload expressions.
+  # Using optional chaining avoids errors when deleted_time is absent and
+  # prevents false-positive Finalized=True when resources are absent for
+  # unrelated reasons (e.g., first reconciliation before provisioning).
+  - name: is_deleting
+    source:
+      expression: "fetchCluster.?deleted_time.hasValue()"
 
 resources:
   # Single ManifestWork resource — bundles all cluster sub-resources.

--- a/test/testdata/dryrun/maestro/dryrun-maestro-adapter-task-config.yaml
+++ b/test/testdata/dryrun/maestro/dryrun-maestro-adapter-task-config.yaml
@@ -20,29 +20,37 @@ params:
     name: adapterName
     source: env.ADAPTER_NAME
     type: string
+
+  - name: fetchCluster
+    source:
+      api_call:
+        method: GET
+        timeout: 10s
+        url: /api/hyperfleet/v1/clusters/{{ .clusterId }}
+
+  - name: clusterName
+    source: fetchCluster.name
+
+  - name: clusterStatus
+    source:
+      expression: |
+        fetchCluster.status.conditions.filter(c, c.type == "Reconciled").size() > 0
+          ? fetchCluster.status.conditions.filter(c, c.type == "Reconciled")[0].status
+          : "False"
+
+  - name: computeNodes
+    source: fetchCluster.nodes.compute
+
+  - name: timestamp
+    source:
+      expression: '"2006-01-02T15:04:05Z07:00"'
+
 preconditions:
-  - api_call:
-      method: GET
-      timeout: 10s
-      url: /api/hyperfleet/v1/clusters/{{ .clusterId }}
-    capture:
-      - field: name
-        name: clusterName
-      - expression: |
-          status.conditions.filter(c, c.type == "Reconciled").size() > 0
-            ? status.conditions.filter(c, c.type == "Reconciled")[0].status
-            : "False"
-        name: clusterStatus
-      - field: nodes.compute
-        name: computeNodes
-      #TODO: research why we can not have {{ now }} as expression
-      - expression: '"2006-01-02T15:04:05Z07:00"'
-        name: timestamp
+  - name: fetchCluster
     conditions:
       - field: clusterStatus
         operator: notEquals
         value: "True"
-    name: fetchCluster
 resources:
   - discovery:
       #by_name: "cluster-{{ .clusterId }}-config"

--- a/test/testdata/task-config.yaml
+++ b/test/testdata/task-config.yaml
@@ -5,30 +5,34 @@ params:
     required: true
     source: event.id
     type: string
-# Preconditions with valid operators and CEL expressions
+  # Fetch full cluster state from the API as a named param
+  - name: clusterData
+    source:
+      api_call:
+        method: GET
+        retry_attempts: 3
+        retry_backoff: exponential
+        timeout: 10s
+        url: /clusters/{{ .clusterId }}
+  # Derived params from clusterData
+  - name: clusterName
+    source: "clusterData.name"
+  - name: reconciledConditionStatus
+    source:
+      expression: |
+        clusterData.status.conditions.filter(c, c.type == "Reconciled").size() > 0
+          ? clusterData.status.conditions.filter(c, c.type == "Reconciled")[0].status
+          : "False"
+  - name: generation
+    source: "clusterData.generation"
+# Preconditions evaluate state using the params extracted above
 preconditions:
-  - api_call:
-      method: GET
-      retry_attempts: 3
-      retry_backoff: exponential
-      timeout: 10s
-      url: /clusters/{{ .clusterId }}
-    capture:
-      - field: name
-        name: clusterName
-      - expression: |
-          status.conditions.filter(c, c.type == "Reconciled").size() > 0
-            ? status.conditions.filter(c, c.type == "Reconciled")[0].status
-            : "False"
-        name: reconciledConditionStatus
-      - field: generation
-        name: generation
+  - name: clusterStatus
     # Structured conditions with valid operators
     conditions:
       - field: reconciledConditionStatus
         operator: equals
         value: "False"
-    name: clusterStatus
 # Resources
 resources:
   - discovery:


### PR DESCRIPTION
## Summary

Moves `api_call` from the precondition phase to the params phase as a dedicated source type. 

Two new param source types are added: `source.api_call`, which fetches data from the HyperFleet API and stores the full JSON response as a named param, and `source.expression`, which evaluates a CEL expression over previously resolved params. 

All dryrun example configs, the adapter task config template, and the adapter authoring guide have been updated to the new pattern.

- Ticket: [HYPERFLEET-1290](https://redhat.atlassian.net/browse/HYPERFLEET-1290)

## Test Plan

- [x] Unit tests added/updated
- [x] `make test-all` passes
- [x] `make lint` passes
- [x]  All dry-run scenarios pass


[HYPERFLEET-1290]: https://redhat.atlassian.net/browse/HYPERFLEET-1290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ