### PR TITLE
HYPERFLEET-882 - docs: add pre-commit hooks setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,7 @@ This project follows the [Contributor Covenant Code of Conduct](https://www.cont
 - Docker (for building Docker images)
 - `golangci-lint` (for linting)
 - `make` (for running Makefile targets)
+- `pre-commit` (for local git hooks)
 
 ### Installing Dependencies
 
@@ -61,6 +62,14 @@ This project follows the [Contributor Covenant Code of Conduct](https://www.cont
    ```bash
    go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
    ```
+
+3. **Install git hooks**:
+
+   ```bash
+   make install-hooks
+   ```
+
+   This installs pre-commit hooks configured in `.pre-commit-config.yaml` for commit message and code quality validation on every commit.
 
 ### Building the Project
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ See [hyperfleet-infra](https://github.com/openshift-hyperfleet/hyperfleet-infra)
 
 ### For Developers
 
+**Prerequisites:** Go 1.26+, Docker/Podman, Make, [pre-commit](https://pre-commit.com/)
+
 - **[Development Guide](./docs/development.md)** - setup, build and test guidelines.
 - **[CONTRIBUTING.md](./CONTRIBUTING.md)** - code style, testing requirements, PR process, and commit guidelines
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -6,7 +6,8 @@
 git clone https://github.com/openshift-hyperfleet/hyperfleet-adapter.git
 cd hyperfleet-adapter
 make mod-tidy
-make build        # → bin/hyperfleet-adapter
+make build          # → bin/hyperfleet-adapter
+make install-hooks  # Install pre-commit hooks (commit message + code quality)
 ```
 
 ## Verification
@@ -24,6 +25,7 @@ make test-all         # All of the above + make test-helm
 | Target | Description |
 |--------|-------------|
 | `make build` | Build binary |
+| `make install-hooks` | Install pre-commit hooks |
 | `make test` | Run unit tests |
 | `make test-integration` | Run integration tests with envtest (unprivileged) |
 | `make test-integration-k3s` | Run integration tests with K3s (faster, may need privileges) |


### PR DESCRIPTION
## Summary
- Add `pre-commit` to prerequisites in CONTRIBUTING.md
- Add `make install-hooks` step in CONTRIBUTING.md setup instructions
- Add pre-commit prerequisite note in README.md for developers
- Add `make install-hooks` to development.md setup and Make Targets table

Pre-commit hooks (`.pre-commit-config.yaml`) and Makefile targets were already in place — this PR fills the documentation gap to match the pattern established in hyperfleet-sentinel ([#102](https://github.com/openshift-hyperfleet/hyperfleet-sentinel/pull/102)).

## Test plan
- [x] Verify `make install-hooks` runs successfully
- [x] Verify pre-commit hooks trigger on commit