### PR TITLE
HYPERFLEET-1295 - feat: Conditional creation of resources

### DIFF
--- a/configs/adapter-task-config-template.yaml
+++ b/configs/adapter-task-config-template.yaml
@@ -197,6 +197,16 @@ resources:
           hyperfleet.io/cluster-id: "{{ .clusterId }}"
           hyperfleet.io/managed-by: "{{ .adapter.name }}"
 
+    # OPTIONAL: Gate resource CREATION with a CEL expression
+    # If the expression evaluates to false, the resource is not created.
+    # Once created, this condition is ignored in subsequent reconciliations.
+    # While resource is not yet created, with each reconciliation, this expression is evaluated again.
+    #
+    # lifecycle:
+    #   create:
+    #     when:
+    #       expression: "params.?enableOptionalFeature.orValue(false)"
+
     # --------------------------------------------------------------------------
     # OPTIONAL: Deletion lifecycle
     # --------------------------------------------------------------------------

--- a/docs/adapter-authoring-guide.md
+++ b/docs/adapter-authoring-guide.md
@@ -159,7 +159,7 @@ The `adapter.*` context is populated automatically and available in your post-ac
 | Variable | Type | Description |
 |----------|------|-------------|
 | `adapter.executionStatus` | string | `"success"` or `"failed"` |
-| `adapter.resourcesSkipped` | bool | `true` if preconditions were not met |
+| `adapter.resourcesSkipped` | bool | `true` if preconditions were not met, or if any resource's `lifecycle.create.when` evaluated to `false` |
 | `adapter.skipReason` | string | Why resources were skipped |
 | `adapter.executionError.phase` | string | Phase where the first error occurred |
 | `adapter.executionError.step` | string | Specific step that first failed |
@@ -507,7 +507,7 @@ The framework determines the operation automatically:
 |-----------|------|----------|
 | `create` | Resource doesn't exist | Apply the manifest |
 | `update` | Resource exists, generation changed | Patch the resource |
-| `skip` | Resource exists, generation unchanged | No-op (idempotent) |
+| `skip` | Resource exists and generation unchanged, **or** resource doesn't exist and `lifecycle.create.when` evaluates to `false` | No-op; the latter case also sets `adapter.resourcesSkipped` to `true` |
 | `recreate` | `recreate_on_change: true` is set | Delete then create |
 | `delete` | `lifecycle.delete.when` expression evaluates to `true` | Delete the resource; remaining resources still processed |
 
@@ -666,6 +666,70 @@ status:
     resources.?namespace0.?status.?conditions.orValue([])
       .exists(c, c.type == "Ready" && c.status == "True")
     ? "True" : "False"
+```
+
+### Conditional creation (lifecycle.create)
+
+Resources can gate their **initial creation** on a CEL expression using the `lifecycle.create` block. This lets you apply a resource only once some runtime condition holds (a feature flag param, a sibling resource's discovered state, an event payload field) without blocking the rest of the resources phase — unlike preconditions, which are all-or-nothing for the entire phase.
+
+#### Configuring lifecycle.create
+
+```yaml
+resources:
+  - name: "optionalFeatureConfig"
+    transport:
+      client: "kubernetes"
+    manifest:
+      # ...
+    discovery:                              # required: needed to check whether the resource already exists
+      by_name: "{{ .clusterId }}-feature"
+    lifecycle:
+      create: # optional: Choose if you want to control creation with CEL
+        when:
+          expression: "params.?enableOptionalFeature.orValue(false)"  
+```
+
+**Requirements:**
+
+- `discovery` must be configured on the same resource — without it the executor cannot tell whether the resource already exists, and validation rejects the config.
+- `when.expression` is required when `when` is configured, and must be a valid CEL expression — config validation rejects anything else.
+
+#### Behavior
+
+- **Resource doesn't exist yet**: the `when` expression is evaluated. `false` skips creation (operation `skip`, `adapter.resourcesSkipped` set to `true`); `true` or absent `lifecycle.create` proceeds with the normal create flow.
+- **Resource already exists**: the `when` expression is **ignored** — the resource is applied normally (update flow). This makes `lifecycle.create.when` a one-time gate on initial creation, not a recurring condition; once created, the resource is reconciled like any other on subsequent events.
+- **CEL evaluation error**: the resource execution fails with a descriptive error (referencing the failing expression) and the resource is neither applied nor silently skipped — the same fail-closed behavior as `lifecycle.delete.when`.
+
+#### Skipping without blocking siblings
+
+Because the skip is scoped to a single resource, other resources in the list still execute. This lets you write dependency conditions the same way as with deletion:
+
+```yaml
+resources:
+  - name: "resourceA"
+    # ... no lifecycle.create — always applied
+
+  - name: "resourceB"
+    # ...
+    discovery:
+      by_name: "{{ .clusterId }}-b"
+    lifecycle:
+      create:
+        when:
+          # Only create resourceB once resourceA has been discovered
+          expression: "resources.?resourceA.hasValue()"
+```
+
+Resources are pre-discovered before any `lifecycle.create.when` or `lifecycle.delete.when` expression is evaluated, so `resources.?resourceA.hasValue()` reflects state from prior reconciliations regardless of list order.
+
+#### Reporting skipped resources in post-actions
+
+Because `adapter.resourcesSkipped` is shared with the precondition-level skip flag, a post-action `when` gate can react the same way regardless of which phase produced the skip:
+
+```cel
+adapter.?resourcesSkipped.orValue(false)
+  ? "Resources skipped: " + adapter.?skipReason.orValue("unknown")
+  : "All resources processed successfully"
 ```
 
 ### Conditional deletion (lifecycle.delete)

--- a/docs/adapter-authoring-guide.md
+++ b/docs/adapter-authoring-guide.md
@@ -684,7 +684,7 @@ resources:
     discovery:                              # required: needed to check whether the resource already exists
       by_name: "{{ .clusterId }}-feature"
     lifecycle:
-      create: # optional: Choose if you want to control creation with CEL
+      create: # optional block; when present, `when` is required
         when:
           expression: "params.?enableOptionalFeature.orValue(false)"  
 ```
@@ -692,11 +692,11 @@ resources:
 **Requirements:**
 
 - `discovery` must be configured on the same resource — without it the executor cannot tell whether the resource already exists, and validation rejects the config.
-- `when.expression` is required when `when` is configured, and must be a valid CEL expression — config validation rejects anything else.
+- `lifecycle.create` itself is optional. But when present, `when.expression` is required and must be a valid CEL expression — config validation rejects a `lifecycle.create` block with a missing or empty `when.expression`.
 
 #### Behavior
 
-- **Resource doesn't exist yet**: the `when` expression is evaluated. `false` skips creation (operation `skip`, `adapter.resourcesSkipped` set to `true`); `true` or absent `lifecycle.create` proceeds with the normal create flow.
+- **Resource doesn't exist yet**: the `when` expression is evaluated. `false` skips creation (operation `skip`, `adapter.resourcesSkipped` set to `true`); `true` proceeds with the normal create flow. Resources with no `lifecycle.create` configured at all are always created normally.
 - **Resource already exists**: the `when` expression is **ignored** — the resource is applied normally (update flow). This makes `lifecycle.create.when` a one-time gate on initial creation, not a recurring condition; once created, the resource is reconciled like any other on subsequent events.
 - **CEL evaluation error**: the resource execution fails with a descriptive error (referencing the failing expression) and the resource is neither applied nor silently skipped — the same fail-closed behavior as `lifecycle.delete.when`.
 

--- a/internal/configloader/constants.go
+++ b/internal/configloader/constants.go
@@ -92,6 +92,7 @@ const (
 
 // Lifecycle field names
 const (
+	FieldLifecycleCreate            = "create"
 	FieldLifecycleDelete            = "delete"
 	FieldLifecyclePropagationPolicy = "propagationPolicy"
 	FieldLifecycleWhen              = "when"

--- a/internal/configloader/types.go
+++ b/internal/configloader/types.go
@@ -352,6 +352,7 @@ type Resource struct {
 // ResourceLifecycle defines the lifecycle behavior for a resource.
 type ResourceLifecycle struct {
 	Delete *LifecycleDelete `yaml:"delete,omitempty"`
+	Create *LifecycleCreate `yaml:"create,omitempty"`
 }
 
 // LifecycleDelete defines the deletion behavior for a resource.
@@ -361,6 +362,11 @@ type LifecycleDelete struct {
 	// PropagationPolicy is the Kubernetes deletion propagation policy: Background (default), Foreground, Orphan.
 	// For Maestro transport, this is ignored — ManifestWork handles its own cleanup semantics.
 	PropagationPolicy string `yaml:"propagationPolicy,omitempty"`
+}
+
+type LifecycleCreate struct {
+	// When defines the CEL expression that determines when to create the resource.
+	When *LifecycleWhen `yaml:"when,omitempty"`
 }
 
 // LifecycleWhen defines the condition for when deletion should occur.

--- a/internal/configloader/validator.go
+++ b/internal/configloader/validator.go
@@ -593,44 +593,70 @@ func (v *TaskConfigValidator) validateLifecycleConfig() {
 		"Orphan":     true,
 	}
 	for i, resource := range v.config.Resources {
-		if resource.Lifecycle == nil || resource.Lifecycle.Delete == nil {
+		if resource.Lifecycle == nil {
 			continue
 		}
 
-		del := resource.Lifecycle.Delete
-		basePath := fmt.Sprintf("%s[%d].%s.%s", FieldResources, i, FieldLifecycle, FieldLifecycleDelete)
+		// NOTE: these are independent if/else-if chains (no continue) so that a validation
+		// failure in one lifecycle block (e.g. missing discovery for create) never skips
+		// validating the sibling block (e.g. delete) for the same resource.
+		if resource.Lifecycle.Create != nil {
+			create := resource.Lifecycle.Create
+			basePath := fmt.Sprintf("%s[%d].%s.%s", FieldResources, i, FieldLifecycle, FieldLifecycleCreate)
 
-		// discovery is required — without it executeResourceDelete cannot locate
-		// the resource and will silently declare it "already deleted" without calling DeleteResource.
-		if resource.Discovery == nil {
-			v.errors.Add(
-				basePath,
-				"lifecycle.delete requires a discovery config to locate the resource for deletion",
-			)
-			continue
+			// discovery is required — without it executeResource cannot determine whether
+			// the resource already exists, and will always evaluate the when condition.
+			switch {
+			case resource.Discovery == nil:
+				v.errors.Add(
+					basePath,
+					"lifecycle.create requires a discovery config to check if the resource already exists",
+				)
+			case create.When != nil && create.When.Expression == "":
+				v.errors.Add(
+					basePath+"."+FieldLifecycleWhen+"."+FieldExpression,
+					"lifecycle.create.when.expression is required when lifecycle.create.when is configured",
+				)
+			case create.When != nil:
+				path := basePath + "." + FieldLifecycleWhen + "." + FieldExpression
+				v.validateCELExpression(create.When.Expression, path)
+			}
 		}
 
-		// Validate propagationPolicy: must be a known K8s value if set
-		if del.PropagationPolicy != "" && !validPropagationPolicies[del.PropagationPolicy] {
-			v.errors.Add(
-				basePath+"."+FieldLifecyclePropagationPolicy,
-				fmt.Sprintf("invalid propagationPolicy %q: must be one of Background, Foreground, Orphan",
-					del.PropagationPolicy),
-			)
-		}
+		if resource.Lifecycle.Delete != nil {
+			del := resource.Lifecycle.Delete
+			basePath := fmt.Sprintf("%s[%d].%s.%s", FieldResources, i, FieldLifecycle, FieldLifecycleDelete)
 
-		// Validate when: required — without it the resource is never deleted
-		if del.When == nil || del.When.Expression == "" {
-			v.errors.Add(
-				basePath+"."+FieldLifecycleWhen+"."+FieldExpression,
-				"lifecycle.delete.when.expression is required: without it the resource will never be deleted",
-			)
-			continue
-		}
+			// discovery is required — without it executeResourceDelete cannot locate
+			// the resource and will silently declare it "already deleted" without calling DeleteResource.
+			if resource.Discovery == nil {
+				v.errors.Add(
+					basePath,
+					"lifecycle.delete requires a discovery config to locate the resource for deletion",
+				)
+			} else {
+				// Validate propagationPolicy: must be a known K8s value if set
+				if del.PropagationPolicy != "" && !validPropagationPolicies[del.PropagationPolicy] {
+					v.errors.Add(
+						basePath+"."+FieldLifecyclePropagationPolicy,
+						fmt.Sprintf("invalid propagationPolicy %q: must be one of Background, Foreground, Orphan",
+							del.PropagationPolicy),
+					)
+				}
 
-		// Validate when.expression: must be valid CEL
-		path := basePath + "." + FieldLifecycleWhen + "." + FieldExpression
-		v.validateCELExpression(del.When.Expression, path)
+				// Validate when: required — without it the resource is never deleted
+				if del.When == nil || del.When.Expression == "" {
+					v.errors.Add(
+						basePath+"."+FieldLifecycleWhen+"."+FieldExpression,
+						"lifecycle.delete.when.expression is required: without it the resource will never be deleted",
+					)
+				} else {
+					// Validate when.expression: must be valid CEL
+					path := basePath + "." + FieldLifecycleWhen + "." + FieldExpression
+					v.validateCELExpression(del.When.Expression, path)
+				}
+			}
+		}
 	}
 }
 

--- a/internal/configloader/validator.go
+++ b/internal/configloader/validator.go
@@ -612,12 +612,12 @@ func (v *TaskConfigValidator) validateLifecycleConfig() {
 					basePath,
 					"lifecycle.create requires a discovery config to check if the resource already exists",
 				)
-			case create.When != nil && create.When.Expression == "":
+			case create.When == nil || create.When.Expression == "":
 				v.errors.Add(
 					basePath+"."+FieldLifecycleWhen+"."+FieldExpression,
-					"lifecycle.create.when.expression is required when lifecycle.create.when is configured",
+					"lifecycle.create.when.expression is required when lifecycle.create is configured",
 				)
-			case create.When != nil:
+			default:
 				path := basePath + "." + FieldLifecycleWhen + "." + FieldExpression
 				v.validateCELExpression(create.When.Expression, path)
 			}

--- a/internal/configloader/validator_test.go
+++ b/internal/configloader/validator_test.go
@@ -1166,4 +1166,128 @@ func TestValidateLifecycleConfig(t *testing.T) {
 		require.NoError(t, v.ValidateStructure())
 		require.NoError(t, v.ValidateSemantic())
 	})
+
+	t.Run("valid lifecycle create with when expression", func(t *testing.T) {
+		cfg := baseTaskConfig()
+		cfg.Resources = []Resource{{
+			Name:      "myResource",
+			Discovery: minDiscovery,
+			Manifest:  minManifest,
+			Lifecycle: &ResourceLifecycle{
+				Create: &LifecycleCreate{
+					When: &LifecycleWhen{Expression: "clusterPhase == 'Provisioning'"},
+				},
+			},
+		}}
+		v := newTaskValidator(cfg)
+		require.NoError(t, v.ValidateStructure())
+		require.NoError(t, v.ValidateSemantic())
+	})
+
+	t.Run("lifecycle create without when is valid", func(t *testing.T) {
+		cfg := baseTaskConfig()
+		cfg.Resources = []Resource{{
+			Name:      "myResource",
+			Discovery: minDiscovery,
+			Manifest:  minManifest,
+			Lifecycle: &ResourceLifecycle{
+				Create: &LifecycleCreate{},
+			},
+		}}
+		v := newTaskValidator(cfg)
+		require.NoError(t, v.ValidateStructure())
+		require.NoError(t, v.ValidateSemantic())
+	})
+
+	t.Run("lifecycle create with when but empty expression", func(t *testing.T) {
+		cfg := baseTaskConfig()
+		cfg.Resources = []Resource{{
+			Name:      "myResource",
+			Discovery: minDiscovery,
+			Manifest:  minManifest,
+			Lifecycle: &ResourceLifecycle{
+				Create: &LifecycleCreate{
+					When: &LifecycleWhen{Expression: ""},
+				},
+			},
+		}}
+		err := newTaskValidator(cfg).ValidateSemantic()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(),
+			"lifecycle.create.when.expression is required when lifecycle.create.when is configured")
+	})
+
+	t.Run("lifecycle create with invalid CEL expression", func(t *testing.T) {
+		cfg := baseTaskConfig()
+		cfg.Resources = []Resource{{
+			Name:      "myResource",
+			Discovery: minDiscovery,
+			Manifest:  minManifest,
+			Lifecycle: &ResourceLifecycle{
+				Create: &LifecycleCreate{
+					When: &LifecycleWhen{Expression: "invalid &&& syntax"},
+				},
+			},
+		}}
+		err := newTaskValidator(cfg).ValidateSemantic()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "CEL parse error")
+	})
+
+	t.Run("lifecycle with both create and delete", func(t *testing.T) {
+		cfg := baseTaskConfig()
+		cfg.Resources = []Resource{{
+			Name:      "myResource",
+			Discovery: minDiscovery,
+			Manifest:  minManifest,
+			Lifecycle: &ResourceLifecycle{
+				Create: &LifecycleCreate{
+					When: &LifecycleWhen{Expression: "clusterPhase == 'Provisioning'"},
+				},
+				Delete: &LifecycleDelete{
+					When: &LifecycleWhen{Expression: "deletedTime != null"},
+				},
+			},
+		}}
+		v := newTaskValidator(cfg)
+		require.NoError(t, v.ValidateStructure())
+		require.NoError(t, v.ValidateSemantic())
+	})
+
+	t.Run("lifecycle create missing discovery", func(t *testing.T) {
+		cfg := baseTaskConfig()
+		cfg.Resources = []Resource{{
+			Name:     "myResource",
+			Manifest: minManifest,
+			// Discovery intentionally absent
+			Lifecycle: &ResourceLifecycle{Create: &LifecycleCreate{
+				When: &LifecycleWhen{Expression: "shouldCreate"},
+			}},
+		}}
+		err := newTaskValidator(cfg).ValidateSemantic()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "lifecycle.create requires a discovery config")
+	})
+
+	t.Run("lifecycle create and delete both missing discovery report both errors", func(t *testing.T) {
+		cfg := baseTaskConfig()
+		cfg.Resources = []Resource{{
+			Name:     "myResource",
+			Manifest: minManifest,
+			// Discovery intentionally absent
+			Lifecycle: &ResourceLifecycle{
+				Create: &LifecycleCreate{
+					When: &LifecycleWhen{Expression: "shouldCreate"},
+				},
+				Delete: &LifecycleDelete{
+					PropagationPolicy: "NotAValidPolicy",
+					When:              &LifecycleWhen{Expression: "shouldDelete"},
+				},
+			},
+		}}
+		err := newTaskValidator(cfg).ValidateSemantic()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "lifecycle.create requires a discovery config")
+		assert.Contains(t, err.Error(), "lifecycle.delete requires a discovery config")
+	})
 }

--- a/internal/configloader/validator_test.go
+++ b/internal/configloader/validator_test.go
@@ -1184,7 +1184,7 @@ func TestValidateLifecycleConfig(t *testing.T) {
 		require.NoError(t, v.ValidateSemantic())
 	})
 
-	t.Run("lifecycle create without when is valid", func(t *testing.T) {
+	t.Run("lifecycle create without when is rejected", func(t *testing.T) {
 		cfg := baseTaskConfig()
 		cfg.Resources = []Resource{{
 			Name:      "myResource",
@@ -1194,9 +1194,9 @@ func TestValidateLifecycleConfig(t *testing.T) {
 				Create: &LifecycleCreate{},
 			},
 		}}
-		v := newTaskValidator(cfg)
-		require.NoError(t, v.ValidateStructure())
-		require.NoError(t, v.ValidateSemantic())
+		err := newTaskValidator(cfg).ValidateSemantic()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "lifecycle.create.when.expression is required")
 	})
 
 	t.Run("lifecycle create with when but empty expression", func(t *testing.T) {
@@ -1213,8 +1213,7 @@ func TestValidateLifecycleConfig(t *testing.T) {
 		}}
 		err := newTaskValidator(cfg).ValidateSemantic()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(),
-			"lifecycle.create.when.expression is required when lifecycle.create.when is configured")
+		assert.Contains(t, err.Error(), "lifecycle.create.when.expression is required")
 	})
 
 	t.Run("lifecycle create with invalid CEL expression", func(t *testing.T) {

--- a/internal/executor/resource_executor.go
+++ b/internal/executor/resource_executor.go
@@ -128,8 +128,8 @@ func (re *ResourceExecutor) executeResource(
 		resourceFound := execCtx.Resources[resource.Name] != nil
 
 		if !resourceFound {
-			// Resource doesn't exist yet — evaluate the when condition. Absent when means
-			// "always create". Validator guarantees when.expression is non-empty when set.
+			// Resource doesn't exist yet — evaluate the when condition. Validator guarantees
+			// lifecycle.create.when and its expression are always set when lifecycle.create is present.
 			shouldCreate := true
 			var whenErr error
 			if resource.Lifecycle.Create.When != nil {
@@ -139,6 +139,7 @@ func (re *ResourceExecutor) executeResource(
 
 			if whenErr != nil {
 				result.Status = StatusFailed
+				result.Operation = manifest.OperationCreate
 				result.Error = whenErr
 				re.recordResourceError(execCtx, resource, whenErr)
 				return result, NewExecutorError(PhaseResources, resource.Name, "failed to evaluate lifecycle.create.when", whenErr)

--- a/internal/executor/resource_executor.go
+++ b/internal/executor/resource_executor.go
@@ -48,16 +48,15 @@ func (re *ResourceExecutor) ExecuteAll(
 		execCtx.Resources = make(map[string]interface{})
 	}
 
-	// Pre-discover all resources before evaluating any lifecycle.delete.when expression.
-	// This ensures that when conditions can reference sibling resources regardless of their
-	// position in the list. For example, a namespace's when can check
-	// !resources.?jobServiceAccount.hasValue() even if jobServiceAccount comes later.
+	// Pre-discover all resources before evaluating any lifecycle.create.when or lifecycle.delete.when expression.
+	// This ensures that:
+	// 1. lifecycle.create.when can check if the resource already exists (skip condition if it does)
+	// 2. lifecycle.delete.when conditions can reference sibling resources regardless of list position
 	// NotFound results are non-fatal and leave the resource absent from context.
 	// Any other error (RBAC, network, API server) is propagated to avoid incorrect
-	// "resource absent" conclusions that could trigger unwanted deletions.
-	// Skip the pass entirely when no resource has lifecycle.delete configured — avoids
-	// unnecessary discovery API calls for adapters that don't use this feature.
-	if hasLifecycleDelete(resources) {
+	// "resource absent" conclusions that could trigger unwanted deletions or skipped creations.
+	// Skip the pass entirely when no resource has lifecycle.create or lifecycle.delete configured.
+	if hasLifecycleConfig(resources) {
 		if err := re.preDiscoverAll(ctx, resources, execCtx); err != nil {
 			return nil, err
 		}
@@ -121,10 +120,58 @@ func (re *ResourceExecutor) executeResource(
 		}
 	}
 
+	// Step 1.5: Check lifecycle.create — if the resource doesn't exist yet AND the when-expression
+	// evaluates to false, skip creation. If the resource already exists (found in context from
+	// pre-discovery), ignore the when condition and apply normally (update flow).
+	if resource.Lifecycle != nil && resource.Lifecycle.Create != nil {
+		// Check if resource already exists in context (from pre-discovery)
+		resourceFound := execCtx.Resources[resource.Name] != nil
+
+		if !resourceFound {
+			// Resource doesn't exist yet — evaluate the when condition. Absent when means
+			// "always create". Validator guarantees when.expression is non-empty when set.
+			shouldCreate := true
+			var whenErr error
+			if resource.Lifecycle.Create.When != nil {
+				shouldCreate, whenErr = re.evaluateLifecycleWhen(
+					ctx, resource, execCtx, "lifecycle.create.when", resource.Lifecycle.Create.When.Expression)
+			}
+
+			if whenErr != nil {
+				result.Status = StatusFailed
+				result.Error = whenErr
+				re.recordResourceError(execCtx, resource, whenErr)
+				return result, NewExecutorError(PhaseResources, resource.Name, "failed to evaluate lifecycle.create.when", whenErr)
+			}
+
+			if !shouldCreate {
+				result.Status = StatusSkipped
+				result.Operation = manifest.OperationSkip
+				result.OperationReason = "lifecycle.create.when condition evaluated to false"
+
+				// Surface the skip in adapter metadata so downstream post-action when-gates
+				// (e.g. "adapter.?resourcesSkipped.orValue(false)") can observe it. First
+				// reason wins, mirroring recordResourceError's ExecutionError convention.
+				execCtx.Adapter.ResourcesSkipped = true
+				if execCtx.Adapter.SkipReason == "" {
+					execCtx.Adapter.SkipReason = fmt.Sprintf("%s: %s", resource.Name, result.OperationReason)
+				}
+
+				re.log.Infof(ctx, "Resource[%s] skipped: create.when condition is false", resource.Name)
+				return result, nil
+			}
+			re.log.Debugf(ctx, "Resource[%s] lifecycle.create.when evaluated to true, creating resource", resource.Name)
+		} else {
+			re.log.Debugf(ctx, "Resource[%s] already exists: ignoring lifecycle.create.when, applying normally", resource.Name)
+		}
+	}
+
 	// Step 2: Check lifecycle.delete — if the when-expression evaluates to true, delete the resource
 	// instead of applying it. This enables dependency-ordered deletion driven by CEL expressions.
-	if resource.Lifecycle != nil && resource.Lifecycle.Delete != nil {
-		shouldDelete, delErr := re.evaluateLifecycleDeleteWhen(ctx, resource, execCtx)
+	if resource.Lifecycle != nil && resource.Lifecycle.Delete != nil && resource.Lifecycle.Delete.When != nil {
+		// Validator guarantees when.expression is non-empty when lifecycle.delete.when is configured.
+		shouldDelete, delErr := re.evaluateLifecycleWhen(
+			ctx, resource, execCtx, "lifecycle.delete.when", resource.Lifecycle.Delete.When.Expression)
 		if delErr != nil {
 			result.Status = StatusFailed
 			result.Operation = manifest.OperationDelete
@@ -466,10 +513,10 @@ func (re *ResourceExecutor) resolveGVK(resource configloader.Resource) schema.Gr
 	return gv.WithKind(kind)
 }
 
-// hasLifecycleDelete reports whether any resource in the list has lifecycle.delete configured.
-func hasLifecycleDelete(resources []configloader.Resource) bool {
+// hasLifecycleConfig reports whether any resource in the list has lifecycle.create or lifecycle.delete configured.
+func hasLifecycleConfig(resources []configloader.Resource) bool {
 	for _, r := range resources {
-		if r.Lifecycle != nil && r.Lifecycle.Delete != nil {
+		if r.Lifecycle != nil && (r.Lifecycle.Create != nil || r.Lifecycle.Delete != nil) {
 			return true
 		}
 	}
@@ -531,24 +578,19 @@ func (re *ResourceExecutor) preDiscoverAll(
 	return nil
 }
 
-// evaluateLifecycleDeleteWhen evaluates the lifecycle.delete.when CEL expression
-// and returns true if the resource should be deleted.
+// evaluateLifecycleWhen evaluates a lifecycle when-expression (create or delete) against the
+// current execution context and records the result for observability.
 //
 // The evaluation uses the same CEL context as post-actions: params + adapter metadata + resources.
-// If when.expression is not set, returns false (no deletion).
-func (re *ResourceExecutor) evaluateLifecycleDeleteWhen(
+// A CEL evaluation error is surfaced (not swallowed) so the executor marks executionStatus=failed
+// and the operator sees Health=False. A common cause is a variable used in the expression that was
+// never captured in the precondition phase (e.g. a typo in a capture name).
+func (re *ResourceExecutor) evaluateLifecycleWhen(
 	ctx context.Context,
 	resource configloader.Resource,
 	execCtx *ExecutionContext,
+	kind, expression string,
 ) (bool, error) {
-	if resource.Lifecycle.Delete.When == nil {
-		return false, nil
-	}
-	if resource.Lifecycle.Delete.When.Expression == "" {
-		return false, fmt.Errorf("resource %q has lifecycle.delete.when configured but expression is empty", resource.Name)
-	}
-	expression := resource.Lifecycle.Delete.When.Expression
-
 	evalCtx := criteria.NewEvaluationContext()
 	evalCtx.SetVariablesFromMap(execCtx.GetCELVariables())
 
@@ -559,17 +601,12 @@ func (re *ResourceExecutor) evaluateLifecycleDeleteWhen(
 
 	celResult, err := evaluator.EvaluateCEL(expression)
 	if err != nil {
-		// Surface the error so the executor marks executionStatus=failed and the operator
-		// sees Health=False. A common cause is a variable used in the expression that was
-		// never captured in the precondition phase (e.g. a typo in a capture name).
-		// Failing loudly is safer than silently skipping deletion: the cluster would stay
-		// stuck in Finalizing with no visible signal.
-		return false, fmt.Errorf("lifecycle.delete.when expression %q failed to evaluate "+
-			"(check that all variables are captured in preconditions): %w", expression, err)
+		return false, fmt.Errorf("%s expression %q failed to evaluate "+
+			"(check that all variables are captured in preconditions): %w", kind, expression, err)
 	}
 
-	execCtx.AddCELEvaluation(PhaseResources, resource.Name+"/lifecycle.delete.when", expression, celResult.Matched)
-	re.log.Debugf(ctx, "Resource[%s] lifecycle.delete.when=%q → matched=%v", resource.Name, expression, celResult.Matched)
+	execCtx.AddCELEvaluation(PhaseResources, resource.Name+"/"+kind, expression, celResult.Matched)
+	re.log.Debugf(ctx, "Resource[%s] %s=%q → matched=%v", resource.Name, kind, expression, celResult.Matched)
 
 	return celResult.Matched, nil
 }

--- a/internal/executor/resource_executor_test.go
+++ b/internal/executor/resource_executor_test.go
@@ -783,7 +783,7 @@ func TestResourceExecutor_LifecycleCreate_WhenCELError_ExecutionFails(t *testing
 		Logger:          logger.NewTestLogger(),
 	})
 
-	// Invalid CEL syntax — evaluateLifecycleCreateWhen will error.
+	// Invalid CEL syntax — evaluateLifecycleWhen will error.
 	resource := newResourceWithLifecycleCreate("shouldCreate &&")
 	execCtx := NewExecutionContext(context.Background(), nil, nil)
 

--- a/internal/executor/resource_executor_test.go
+++ b/internal/executor/resource_executor_test.go
@@ -647,6 +647,258 @@ func newResourceWithLifecycle(expression, propagationPolicy string) configloader
 	return r
 }
 
+// newResourceWithLifecycleCreate is a helper that builds a Resource with lifecycle.create config.
+func newResourceWithLifecycleCreate(expression string) configloader.Resource {
+	r := configloader.Resource{
+		Name:      "test-resource",
+		Transport: &configloader.TransportConfig{Client: "kubernetes"},
+		Manifest: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":      "test-cm",
+				"namespace": "default",
+			},
+		},
+		Discovery: &configloader.DiscoveryConfig{
+			Namespace: "default",
+			ByName:    "test-cm",
+		},
+		Lifecycle: &configloader.ResourceLifecycle{
+			Create: &configloader.LifecycleCreate{
+				When: &configloader.LifecycleWhen{Expression: expression},
+			},
+		},
+	}
+	return r
+}
+
+// sequencedGetResourceMock returns GetResource results/errors in order (one entry per call),
+// repeating the last entry once exhausted. Used when pre-discovery and post-apply discovery
+// need different GetResource outcomes (e.g. NotFound, then the newly-applied resource).
+type sequencedGetResourceMock struct {
+	*k8sclient.MockK8sClient
+	results     []*unstructured.Unstructured
+	errs        []error
+	callCount   int
+	ApplyCalled bool
+}
+
+func (m *sequencedGetResourceMock) GetResource(
+	ctx context.Context,
+	gvk schema.GroupVersionKind,
+	namespace, name string,
+	target transportclient.TransportContext,
+) (*unstructured.Unstructured, error) {
+	idx := m.callCount
+	if idx >= len(m.results) {
+		idx = len(m.results) - 1
+	}
+	m.callCount++
+	return m.results[idx], m.errs[idx]
+}
+
+func (m *sequencedGetResourceMock) ApplyResource(
+	ctx context.Context,
+	data []byte,
+	opts *transportclient.ApplyOptions,
+	target transportclient.TransportContext,
+) (*transportclient.ApplyResult, error) {
+	m.ApplyCalled = true
+	return m.MockK8sClient.ApplyResource(ctx, data, opts, target)
+}
+
+func TestResourceExecutor_LifecycleCreate_WhenTrue_ResourceNotFound_Applied(t *testing.T) {
+	// Resource doesn't exist yet, create.when evaluates true → applied normally.
+	notFoundErr := apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "test-cm")
+	discovered := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]interface{}{"name": "test-cm", "namespace": "default"},
+	}}
+	mock := &sequencedGetResourceMock{
+		MockK8sClient: k8sclient.NewMockK8sClient(),
+		results:       []*unstructured.Unstructured{nil, discovered}, // pre-discovery: absent; post-apply: found
+		errs:          []error{notFoundErr, nil},
+	}
+	mock.ApplyResourceResult = &transportclient.ApplyResult{
+		Operation: manifest.OperationCreate,
+		Reason:    "mock create",
+	}
+
+	re := newResourceExecutor(&ExecutorConfig{
+		TransportClient: mock,
+		Logger:          logger.NewTestLogger(),
+	})
+
+	resource := newResourceWithLifecycleCreate("shouldCreate")
+	execCtx := NewExecutionContext(context.Background(), nil, nil)
+	execCtx.Params["shouldCreate"] = true
+
+	results, err := re.ExecuteAll(context.Background(), []configloader.Resource{resource}, execCtx)
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, StatusSuccess, results[0].Status)
+	assert.Equal(t, manifest.OperationCreate, results[0].Operation)
+	assert.False(t, execCtx.Adapter.ResourcesSkipped, "resource was applied, not skipped")
+}
+
+func TestResourceExecutor_LifecycleCreate_WhenFalse_ResourceNotFound_Skipped(t *testing.T) {
+	// Resource doesn't exist yet, create.when evaluates false → skipped, apply never called.
+	mock := &trackingApplyMockClient{MockK8sClient: k8sclient.NewMockK8sClient()}
+	mock.GetResourceError = apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "test-cm")
+
+	re := newResourceExecutor(&ExecutorConfig{
+		TransportClient: mock,
+		Logger:          logger.NewTestLogger(),
+	})
+
+	resource := newResourceWithLifecycleCreate("shouldCreate")
+	execCtx := NewExecutionContext(context.Background(), nil, nil)
+	execCtx.Params["shouldCreate"] = false
+
+	results, err := re.ExecuteAll(context.Background(), []configloader.Resource{resource}, execCtx)
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, StatusSkipped, results[0].Status)
+	assert.Equal(t, manifest.OperationSkip, results[0].Operation)
+	assert.False(t, mock.ApplyCalled, "ApplyResource should not be called when create.when is false")
+
+	// Verifies the fix: skipping a resource must be reflected in adapter metadata so
+	// post-action `when` gates can observe it.
+	assert.True(t, execCtx.Adapter.ResourcesSkipped, "adapter.resourcesSkipped must be set on skip")
+	assert.NotEmpty(t, execCtx.Adapter.SkipReason)
+}
+
+func TestResourceExecutor_LifecycleCreate_WhenCELError_ExecutionFails(t *testing.T) {
+	// Resource doesn't exist yet, create.when fails to evaluate → execution fails,
+	// resource is neither applied nor silently skipped.
+	mock := &trackingApplyMockClient{MockK8sClient: k8sclient.NewMockK8sClient()}
+	mock.GetResourceError = apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "test-cm")
+
+	re := newResourceExecutor(&ExecutorConfig{
+		TransportClient: mock,
+		Logger:          logger.NewTestLogger(),
+	})
+
+	// Invalid CEL syntax — evaluateLifecycleCreateWhen will error.
+	resource := newResourceWithLifecycleCreate("shouldCreate &&")
+	execCtx := NewExecutionContext(context.Background(), nil, nil)
+
+	results, err := re.ExecuteAll(context.Background(), []configloader.Resource{resource}, execCtx)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to evaluate")
+	require.Len(t, results, 1)
+	assert.Equal(t, StatusFailed, results[0].Status)
+	assert.False(t, mock.ApplyCalled, "ApplyResource should not be called when create.when errors")
+	assert.NotNil(t, execCtx.Adapter.ExecutionError)
+}
+
+func TestResourceExecutor_LifecycleCreate_ResourceAlreadyExists_IgnoresWhen(t *testing.T) {
+	// Resource already exists (pre-discovered) → create.when is ignored, normal apply (update flow).
+	discovered := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":      "test-cm",
+				"namespace": "default",
+			},
+		},
+	}
+	mock := k8sclient.NewMockK8sClient()
+	mock.GetResourceResult = discovered
+	mock.ApplyResourceResult = &transportclient.ApplyResult{
+		Operation: manifest.OperationUpdate,
+		Reason:    "mock update",
+	}
+
+	re := newResourceExecutor(&ExecutorConfig{
+		TransportClient: mock,
+		Logger:          logger.NewTestLogger(),
+	})
+
+	resource := newResourceWithLifecycleCreate("shouldCreate")
+	execCtx := NewExecutionContext(context.Background(), nil, nil)
+	execCtx.Params["shouldCreate"] = false
+
+	results, err := re.ExecuteAll(context.Background(), []configloader.Resource{resource}, execCtx)
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, StatusSuccess, results[0].Status)
+	assert.Equal(t, manifest.OperationUpdate, results[0].Operation,
+		"existing resource must be applied, ignoring create.when=false")
+	assert.False(t, execCtx.Adapter.ResourcesSkipped)
+}
+
+func TestResourceExecutor_LifecycleCreate_Absent_NormalApply(t *testing.T) {
+	// No lifecycle.create configured at all → resource applied normally (regression guard).
+	// No lifecycle configured means preDiscoverAll is skipped, so the only GetResource call
+	// is post-apply discovery — it must succeed for the apply flow to complete.
+	mock := k8sclient.NewMockK8sClient()
+	mock.GetResourceResult = &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]interface{}{"name": "test-cm", "namespace": "default"},
+	}}
+	mock.ApplyResourceResult = &transportclient.ApplyResult{
+		Operation: manifest.OperationCreate,
+		Reason:    "mock create",
+	}
+
+	re := newResourceExecutor(&ExecutorConfig{
+		TransportClient: mock,
+		Logger:          logger.NewTestLogger(),
+	})
+
+	resource := configloader.Resource{
+		Name:      "test-resource",
+		Transport: &configloader.TransportConfig{Client: "kubernetes"},
+		Manifest: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":      "test-cm",
+				"namespace": "default",
+			},
+		},
+		Discovery: &configloader.DiscoveryConfig{
+			Namespace: "default",
+			ByName:    "test-cm",
+		},
+	}
+	execCtx := NewExecutionContext(context.Background(), nil, nil)
+
+	results, err := re.ExecuteAll(context.Background(), []configloader.Resource{resource}, execCtx)
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, StatusSuccess, results[0].Status)
+	assert.Equal(t, manifest.OperationCreate, results[0].Operation)
+	assert.False(t, execCtx.Adapter.ResourcesSkipped)
+}
+
+// trackingApplyMockClient is a thin wrapper around MockK8sClient to capture whether
+// ApplyResource was called.
+type trackingApplyMockClient struct {
+	*k8sclient.MockK8sClient
+	ApplyCalled bool
+}
+
+func (m *trackingApplyMockClient) ApplyResource(
+	ctx context.Context,
+	data []byte,
+	opts *transportclient.ApplyOptions,
+	target transportclient.TransportContext,
+) (*transportclient.ApplyResult, error) {
+	m.ApplyCalled = true
+	return m.MockK8sClient.ApplyResource(ctx, data, opts, target)
+}
+
 // trackingMockClient is a thin wrapper around MockK8sClient to also capture DeleteResource calls.
 type trackingMockClient struct {
 	*k8sclient.MockK8sClient


### PR DESCRIPTION
## Summary

Adds a conditional creation gate for resources, symmetric to the existing conditional deletion gate. A resource can now declare `lifecycle.create.when` with a CEL expression that must hold before it is created for the first time; once the resource exists, the gate is ignored and it's reconciled normally like any other resource. This lets adapters express "only create this if X" (a feature flag, a sibling resource's discovered state, an event field) without making the whole resources phase all-or-nothing, the same way `lifecycle.delete.when` already does for deletion.

[HYPERFLEET-1295](https://redhat.atlassian.net/browse/HYPERFLEET-1295)

## Changes

- Added `lifecycle.create` / `LifecycleCreate` config type, mirroring the shape of `lifecycle.delete`
- Added a `create.when` check in `executeResource`: evaluated only when the resource is absent from pre-discovery; skips creation (operation `skip`) when it evaluates to `false`, is ignored entirely once the resource already exists
- Skipped creations now set `adapter.resourcesSkipped` / `adapter.skipReason`, the same signal precondition-skips already populate, so post-action `when` gates don't need to special-case which phase produced the skip
- Unified `create` and `delete` lifecycle validation into a single `validateLifecycleConfig` pass, and unified their CEL evaluation into one `evaluateLifecycleWhen` helper (previously delete-only)
- Pre-discovery (`preDiscoverAll`) now also runs when only `lifecycle.create` is configured, not just `lifecycle.delete`, since `create.when` needs to know whether the resource already exists
- Documented the new `lifecycle.create` block in the adapter authoring guide and the task config template

## Test Plan

- [x] Unit tests added/updated
- [ ] `make test-all` passes
- [ ] `make lint` passes
- [ ] Helm chart changes validated with `make test-helm` (if applicable)
- [ ] Deployed to a development cluster and verified (if Helm/config changes)
- [ ] E2E tests passed (if cross-component or major changes)


[HYPERFLEET-1295]: https://redhat.atlassian.net/browse/HYPERFLEET-1295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ