### PR TITLE
HYPERFLEET-1290 - fix: restore backward compat for precondition api_call

### DIFF
--- a/internal/configloader/loader.go
+++ b/internal/configloader/loader.go
@@ -181,6 +181,9 @@ func LoadConfig(opts ...LoadOption) (*Config, error) {
 		if err := taskValidator.ValidateSemantic(); err != nil {
 			return nil, fmt.Errorf("task config semantic validation failed: %w", err)
 		}
+		for _, w := range taskValidator.Warnings() {
+			o.logger.Warn(o.ctx, w)
+		}
 	}
 
 	// 3. Merge into unified Config

--- a/internal/configloader/validator.go
+++ b/internal/configloader/validator.go
@@ -58,6 +58,7 @@ func (v *AdapterConfigValidator) ValidateStructure() error {
 type TaskConfigValidator struct {
 	config      *AdapterTaskConfig
 	errors      *ValidationErrors
+	warnings    []string
 	definedVars map[string]bool
 	celEnv      *cel.Env
 	baseDir     string
@@ -70,6 +71,11 @@ func NewTaskConfigValidator(config *AdapterTaskConfig, baseDir string) *TaskConf
 		baseDir: baseDir,
 		errors:  &ValidationErrors{},
 	}
+}
+
+// Warnings returns deprecation warnings collected during validation.
+func (v *TaskConfigValidator) Warnings() []string {
+	return v.warnings
 }
 
 // ValidateStructure validates the structural requirements of AdapterTaskConfig
@@ -182,15 +188,16 @@ func (v *TaskConfigValidator) validatePreconditionAPICallForbidden() {
 	for i, precond := range v.config.Preconditions {
 		if precond.APICall != nil {
 			path := fmt.Sprintf("%s[%d].%s", FieldPreconditions, i, FieldAPICall)
-			v.errors.Add(path, fmt.Sprintf(
-				"precondition %q contains api_call. api_call is no longer valid in the precondition phase.\n"+
-					"Move the api_call block to a params entry:\n"+
+			v.warnings = append(v.warnings, fmt.Sprintf(
+				"%s: DEPRECATED: precondition %q uses api_call directly. "+
+					"Move the api_call block to a params entry with source.api_call instead. "+
+					"Direct api_call on preconditions will be removed in a future release.\n"+
 					"  params:\n"+
 					"    - name: %q\n"+
 					"      source:\n"+
 					"        api_call:\n"+
 					"          ...",
-				precond.Name, precond.Name))
+				path, precond.Name, precond.Name))
 		}
 	}
 }

--- a/internal/configloader/validator_test.go
+++ b/internal/configloader/validator_test.go
@@ -1228,7 +1228,7 @@ func TestValidateParamsAPICallSource(t *testing.T) {
 }
 
 func TestValidatePreconditionAPICallForbidden(t *testing.T) {
-	t.Run("precondition with api_call produces migration error", func(t *testing.T) {
+	t.Run("precondition with api_call produces deprecation warning not error", func(t *testing.T) {
 		cfg := baseTaskConfig()
 		cfg.Preconditions = []Precondition{{
 			ActionBase: ActionBase{
@@ -1239,12 +1239,15 @@ func TestValidatePreconditionAPICallForbidden(t *testing.T) {
 		v := newTaskValidator(cfg)
 		_ = v.ValidateStructure()
 		err := v.ValidateSemantic()
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "api_call is no longer valid in the precondition phase")
-		assert.Contains(t, err.Error(), "fetchCluster")
+		require.NoError(t, err)
+		warnings := v.Warnings()
+		require.Len(t, warnings, 1)
+		assert.Contains(t, warnings[0], "DEPRECATED")
+		assert.Contains(t, warnings[0], "fetchCluster")
+		assert.Contains(t, warnings[0], "source.api_call")
 	})
 
-	t.Run("precondition without api_call passes", func(t *testing.T) {
+	t.Run("precondition without api_call passes with no warnings", func(t *testing.T) {
 		cfg := baseTaskConfig()
 		cfg.Preconditions = []Precondition{{
 			ActionBase: ActionBase{Name: "check"},
@@ -1253,5 +1256,6 @@ func TestValidatePreconditionAPICallForbidden(t *testing.T) {
 		v := newTaskValidator(cfg)
 		require.NoError(t, v.ValidateStructure())
 		require.NoError(t, v.ValidateSemantic())
+		assert.Empty(t, v.Warnings())
 	})
 }


### PR DESCRIPTION
## Summary

- HYPERFLEET-1290 introduced a hard validation error when `api_call` is used directly on a precondition, breaking existing adapter configs without a migration path
- The precondition executor already handles `api_call` at runtime (code was not removed), so only the validator was rejecting it
- This PR downgrades the error to a **deprecation warning** logged at startup, keeping existing configs working while steering authors toward the new `params[].source.api_call` pattern

## Changes

- `internal/configloader/validator.go`: Added `warnings []string` field and `Warnings()` method to `TaskConfigValidator`; changed `validatePreconditionAPICallForbidden` to append to `warnings` instead of `errors`
- `internal/configloader/loader.go`: Log collected warnings via the instance logger after semantic validation
- `internal/configloader/validator_test.go`: Updated test to assert a deprecation warning is emitted (not an error) when a precondition uses `api_call`

## Test plan

- [ ] `make build` — binary compiles cleanly
- [ ] `make test` — all unit tests pass
- [ ] Adapter config with old-style precondition `api_call` loads and logs a `DEPRECATED` warning at startup instead of refusing to start
- [ ] Adapter config using new-style `params[].source.api_call` continues to work with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)