### PR TITLE
HYPERFLEET-1195 - docs: add common when patterns and combination guide

### DIFF
--- a/charts/examples/kubernetes/adapter-task-config.yaml
+++ b/charts/examples/kubernetes/adapter-task-config.yaml
@@ -65,6 +65,8 @@ resources:
 post:
   payloads:
     - name: "clusterStatusPayload"
+      when:
+        expression: "!adapter.resourcesSkipped"
       build:
         adapter: "{{ .adapter.name }}"
         conditions:
@@ -163,6 +165,38 @@ post:
           expression: "generation"
         observed_time: "{{ now | date \"2006-01-02T15:04:05Z07:00\" }}"
 
+    # Skipped path: preconditions not met — report simplified status without
+    # evaluating resources.* (which may not exist in this context)
+    - name: "skippedStatusPayload"
+      when:
+        expression: "adapter.resourcesSkipped"
+      build:
+        adapter: "{{ .adapter.name }}"
+        conditions:
+          - type: "Applied"
+            status: "False"
+            reason: "PreconditionsNotMet"
+            message:
+              expression: |
+                "Resources skipped: " + adapter.?skipReason.orValue("preconditions not met")
+          - type: "Available"
+            status: "False"
+            reason: "PreconditionsNotMet"
+            message:
+              expression: |
+                "Resources not available: " + adapter.?skipReason.orValue("preconditions not met")
+          - type: "Health"
+            status: "True"
+            reason: "NoErrors"
+            message: "Adapter is healthy, no work performed due to preconditions"
+          - type: "Finalized"
+            status: "False"
+            reason: ""
+            message: ""
+        observed_generation:
+          expression: "generation"
+        observed_time: "{{ now | date \"2006-01-02T15:04:05Z07:00\" }}"
+
   post_actions:
     - name: "reportClusterStatus"
       when:
@@ -174,3 +208,14 @@ post:
           - name: "Content-Type"
             value: "application/json"
         body: "{{ .clusterStatusPayload }}"
+
+    - name: "reportClusterStatusSkipped"
+      when:
+        expression: "adapter.resourcesSkipped"
+      api_call:
+        method: "PUT"
+        url: "/clusters/{{ .clusterId }}/statuses"
+        headers:
+          - name: "Content-Type"
+            value: "application/json"
+        body: "{{ .skippedStatusPayload }}"

--- a/docs/adapter-authoring-guide.md
+++ b/docs/adapter-authoring-guide.md
@@ -1227,6 +1227,38 @@ post:
 
 The `when` expression has access to the full execution context: all `adapter.*` metadata, extracted params, and `resources.*`. If `when` is omitted, the payload is always built (existing behavior). If the expression fails to parse or evaluate, the payload build is marked as **failed**. Evaluation order: payload `when` → build → post-action `when` → execute. Both gates are independent.
 
+### Common `when` patterns
+
+| Pattern | Expression | Use case |
+|---------|-----------|----------|
+| Run when work was done | `!adapter.resourcesSkipped` | Most common — gate status reporting on whether resources were actually applied |
+| Success-only | `adapter.?executionStatus.orValue('') == 'success'` | Run only when all phases succeeded |
+| Failure-only | `adapter.?executionStatus.orValue('') != 'success'` | Send a different status report on failure |
+| Deletion path | `is_deleting` | Run only during cluster deletion (requires `is_deleting` param) |
+| Resource exists | `resources.?myResource.hasValue()` | Gate on whether a specific resource was discovered |
+
+#### Combining `when` on payloads and post-actions
+
+You can use `when` at both levels. A post-action that references a skipped payload is automatically skipped, so adding `when` to the post-action is redundant in that case. However, using both makes intent explicit in the config and avoids relying on the implicit auto-skip behavior:
+
+```yaml
+post:
+  payloads:
+    - name: "statusPayload"
+      when:
+        expression: "!adapter.resourcesSkipped"    # prevents CEL evaluation of missing resources.*
+      build: { ... }
+
+  post_actions:
+    - name: "reportClusterStatus"
+      when:
+        expression: "!adapter.resourcesSkipped"    # explicit gate — also auto-skipped via payload
+      api_call:
+        body: "{{ .statusPayload }}"
+```
+
+> For a complete working example of conditional payloads and post-actions, see the `adapter1` configuration in [hyperfleet-infra](https://github.com/openshift-hyperfleet/hyperfleet-infra/tree/main/helmfile/configs/base/adapters/adapter1/adapter-task-config.yaml).
+
 ### Building payloads
 
 A payload is a JSON structure built from CEL expressions and Go Templates. Each field can be specified in three ways:


### PR DESCRIPTION
## Summary

- Add skipped-path example (`adapter.resourcesSkipped`) to the `kubernetes/` example adapter, complementing the existing normal-path `when` gate — demonstrates both conditional payloads and conditional post-actions
- Add "Common `when` patterns" quick-reference table with 5 common expressions
- Add "Combining `when` on payloads and post-actions" subsection explaining the dual-gate pattern vs. auto-skip behavior
- Add cross-reference to the kubernetes example

## Context

[HYPERFLEET-1195](https://redhat.atlassian.net/browse/HYPERFLEET-1195)

## Test plan

- [ ] Verify YAML syntax is valid
- [ ] Review that skipped payload follows the status contract "Preconditions NOT Met" pattern
- [ ] Confirm `when` expressions use standard CEL patterns
- [ ] Verify markdown formatting renders correctly

[HYPERFLEET-1195]: https://redhat.atlassian.net/browse/HYPERFLEET-1195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ