### PR TITLE
HYPERFLEET-1294 - feat: add file source type to params for reading filesystem values

### DIFF
--- a/configs/adapter-task-config-template.yaml
+++ b/configs/adapter-task-config-template.yaml
@@ -98,7 +98,7 @@ params:
 
   # API call source fetches data from the HyperFleet API as a named param.
   # The full JSON response is stored under the param name and can be referenced
-  # by later params using dot-notation (e.g. "clusterData.generation") 
+  # by later params using dot-notation (e.g. "clusterData.generation")
   - name: "clusterData"
     source:
       api_call:
@@ -125,6 +125,17 @@ params:
 
   - name: "generationId"
     source: "clusterData.generation"
+
+  # File source reads a value from a filesystem path at reconciliation time.
+  # The file is read fresh on every event (tokens rotate). Whitespace is
+  # trimmed by default (trim: true).
+  # - name: "k8sToken"
+  #   source:
+  #     file:
+  #       path: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  #       trim: true
+  #   required: true
+  #   description: "Kubernetes service account token"
 
   # DELETION SUPPORT — capture these two params when lifecycle.delete is used
   # deleted_time: raw timestamp from the API (null when resource is not pending deletion).

--- a/docs/adapter-authoring-guide.md
+++ b/docs/adapter-authoring-guide.md
@@ -223,8 +223,7 @@ params:
 |--------|--------|---------|
 | `event.` | CloudEvent data fields | `event.id`, `event.generation`, `event.kind` |
 | `env.` | Environment variables | `env.REGION`, `env.NAMESPACE` |
-| `secret.` | Kubernetes Secret | `secret.my-ns.my-secret.api-key` |
-| `configmap.` | Kubernetes ConfigMap | `configmap.my-ns.my-config.setting` |
+| `config.` | Adapter deployment config fields | `config.adapter.name` |
 | `<param>.` | Dot-notation into an earlier api_call param | `clusterData.generation`, `clusterData.status.phase` |
 
 **Structured sources** - use a mapping value under `source:`:
@@ -253,6 +252,31 @@ params:
         : "False"
 ```
 
+`file` - reads the content of a file from the local filesystem at reconciliation time. The file is read fresh on every event (not cached). Leading and trailing whitespace is trimmed by default (`trim: true`). Useful for service account tokens and mounted secrets that rotate.
+
+```yaml
+- name: "k8sToken"
+  source:
+    file:
+      path: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+      trim: true   # default; set to false if whitespace is significant
+```
+
+File-sourced params can be referenced in `api_call` headers via Go Templates:
+
+```yaml
+- name: "clusterData"
+  source:
+    api_call:
+      method: "GET"
+      url: "/clusters/{{ .clusterId }}"
+      headers:
+        - name: "Authorization"
+          value: "Bearer {{ .k8sToken }}"
+```
+
+> **Security:** File-sourced tokens rendered into headers carry credentials. Ensure request/response logging (including reverse proxies and service meshes) does not capture `Authorization` or other sensitive headers.
+
 ### Types and conversion
 
 | Type | Accepts |
@@ -262,7 +286,7 @@ params:
 | `float`, `float64` | Numeric values |
 | `bool` | `true/false`, `yes/no`, `on/off`, `1/0` |
 
-Type conversion applies to string sources only. `api_call` params hold a structured map and `expression` params hold whatever the CEL expression returns — no conversion is applied.
+Type conversion applies to string and file sources. `api_call` params hold a structured map and `expression` params hold whatever the CEL expression returns — no conversion is applied.
 
 If type conversion fails on a **required** param, execution stops. On an optional param, the `default` value is used.
 
@@ -730,7 +754,7 @@ resources:
     lifecycle:
       create: # optional block; when present, `when` is required
         when:
-          expression: "params.?enableOptionalFeature.orValue(false)"  
+          expression: "params.?enableOptionalFeature.orValue(false)"
 ```
 
 **Requirements:**

--- a/internal/configloader/loader_test.go
+++ b/internal/configloader/loader_test.go
@@ -1756,7 +1756,7 @@ params:
       expression: "true"
 `), &cfg)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "mutually exclusive")
+		assert.Contains(t, err.Error(), "only one of")
 	})
 
 	t.Run("mapping with neither api_call nor expression is an error", func(t *testing.T) {
@@ -1768,6 +1768,32 @@ params:
       unknown_key: value
 `), &cfg)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "mapping must contain either")
+		assert.Contains(t, err.Error(), "mapping must contain one of")
+	})
+
+	t.Run("empty expression is an error", func(t *testing.T) {
+		var cfg AdapterTaskConfig
+		err := yaml.Unmarshal([]byte(`
+params:
+  - name: bad
+    source:
+      expression: ""
+`), &cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expression must not be empty")
+	})
+
+	t.Run("empty expression with file triggers mutual exclusivity", func(t *testing.T) {
+		var cfg AdapterTaskConfig
+		err := yaml.Unmarshal([]byte(`
+params:
+  - name: bad
+    source:
+      expression: ""
+      file:
+        path: "/some/file"
+`), &cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "only one of")
 	})
 }

--- a/internal/configloader/types.go
+++ b/internal/configloader/types.go
@@ -179,17 +179,19 @@ type KubernetesConfig struct {
 // ParameterSource is the source field on Parameter
 // It unmarshals from either a YAML scalar (string) or a YAML mapping (api_call / expression)
 type ParameterSource struct {
-	// Kind is one of "string", "api_call", or "expression".
-	Kind       string   `yaml:"-"`
-	StringVal  string   `yaml:"-"`
-	APICall    *APICall `yaml:"api_call"`
-	Expression string   `yaml:"expression"`
+	// Kind is one of "string", "api_call", "expression", or "file".
+	Kind       string            `yaml:"-"`
+	StringVal  string            `yaml:"-"`
+	APICall    *APICall          `yaml:"api_call"`
+	File       *FileSourceConfig `yaml:"file"`
+	Expression string            `yaml:"expression"`
 }
 
 const (
 	paramSourceKindString     = "string"
 	paramSourceKindAPICall    = "api_call"
 	paramSourceKindExpression = "expression"
+	paramSourceKindFile       = "file"
 )
 
 // StringSource constructs a string-literal ParameterSource.
@@ -207,6 +209,11 @@ func ExpressionSource(expr string) ParameterSource {
 	return ParameterSource{Kind: paramSourceKindExpression, Expression: expr}
 }
 
+// FileSource constructs a file ParameterSource.
+func FileSource(fs *FileSourceConfig) ParameterSource {
+	return ParameterSource{Kind: paramSourceKindFile, File: fs}
+}
+
 func (ps ParameterSource) IsZero() bool { return ps.Kind == "" }
 
 func (ps ParameterSource) IsString() bool { return ps.Kind == paramSourceKindString }
@@ -214,6 +221,8 @@ func (ps ParameterSource) IsString() bool { return ps.Kind == paramSourceKindStr
 func (ps ParameterSource) IsAPICall() bool { return ps.Kind == paramSourceKindAPICall }
 
 func (ps ParameterSource) IsExpression() bool { return ps.Kind == paramSourceKindExpression }
+
+func (ps ParameterSource) IsFile() bool { return ps.Kind == paramSourceKindFile }
 
 // Describe returns a human-readable description for use in error messages
 func (ps ParameterSource) Describe() string {
@@ -225,6 +234,11 @@ func (ps ParameterSource) Describe() string {
 		return "api_call"
 	case paramSourceKindExpression:
 		return fmt.Sprintf("expression(%q)", strings.TrimSpace(ps.Expression))
+	case paramSourceKindFile:
+		if ps.File != nil {
+			return fmt.Sprintf("file(%s)", ps.File.Path)
+		}
+		return "file"
 	default:
 		return ps.StringVal
 	}
@@ -238,6 +252,8 @@ func (ps ParameterSource) MarshalYAML() (interface{}, error) {
 		return map[string]interface{}{"api_call": ps.APICall}, nil
 	case paramSourceKindExpression:
 		return map[string]interface{}{"expression": ps.Expression}, nil
+	case paramSourceKindFile:
+		return map[string]interface{}{"file": ps.File}, nil
 	default:
 		return nil, nil
 	}
@@ -251,26 +267,46 @@ func (ps *ParameterSource) UnmarshalYAML(node *yaml.Node) error {
 		return nil
 	case yaml.MappingNode:
 		var raw struct {
-			APICall    *APICall `yaml:"api_call"`
-			Expression string   `yaml:"expression"`
+			APICall    *APICall          `yaml:"api_call"`
+			File       *FileSourceConfig `yaml:"file"`
+			Expression *string           `yaml:"expression"`
 		}
 		if err := node.Decode(&raw); err != nil {
 			return fmt.Errorf("source: %w", err)
 		}
-		if raw.APICall != nil && raw.Expression != "" {
-			return fmt.Errorf("source: 'api_call' and 'expression' are mutually exclusive")
+		// Mutual exclusivity checks — count YAML keys present, not values
+		setCount := 0
+		if raw.APICall != nil {
+			setCount++
+		}
+		if raw.Expression != nil {
+			setCount++
+		}
+		if raw.File != nil {
+			setCount++
+		}
+		if setCount > 1 {
+			return fmt.Errorf("source: only one of 'api_call', 'expression', or 'file' may be set")
 		}
 		if raw.APICall != nil {
 			ps.Kind = paramSourceKindAPICall
 			ps.APICall = raw.APICall
 			return nil
 		}
-		if raw.Expression != "" {
+		if raw.Expression != nil {
+			if strings.TrimSpace(*raw.Expression) == "" {
+				return fmt.Errorf("source: expression must not be empty")
+			}
 			ps.Kind = paramSourceKindExpression
-			ps.Expression = raw.Expression
+			ps.Expression = *raw.Expression
 			return nil
 		}
-		return fmt.Errorf("source: mapping must contain either 'api_call' or 'expression'")
+		if raw.File != nil {
+			ps.Kind = paramSourceKindFile
+			ps.File = raw.File
+			return nil
+		}
+		return fmt.Errorf("source: mapping must contain one of 'api_call', 'expression', or 'file'")
 	default:
 		return fmt.Errorf("source: expected string or mapping, got %v", node.Tag)
 	}
@@ -351,6 +387,14 @@ type APICall struct {
 	Body          string   `yaml:"body,omitempty"`
 	Headers       []Header `yaml:"headers,omitempty"`
 	RetryAttempts int      `yaml:"retry_attempts,omitempty"`
+}
+
+// FileSourceConfig defines a file-based parameter source.
+// Path is the filesystem path to read. Trim controls whether leading/trailing
+// whitespace is stripped (defaults to true when nil).
+type FileSourceConfig struct {
+	Trim *bool  `yaml:"trim,omitempty"` // defaults to true when nil
+	Path string `yaml:"path" validate:"required"`
 }
 
 // Header represents an HTTP header

--- a/internal/configloader/validator.go
+++ b/internal/configloader/validator.go
@@ -191,6 +191,7 @@ func (v *TaskConfigValidator) ValidateSemantic() error {
 	v.validatePreconditionAPICallForbidden()
 	v.validateParamSources()
 	v.validateParamAPICallTemplates()
+	v.validateParamFileSources()
 	v.validateTransportConfig()
 	v.validateConditionValues()
 	v.validateCaptureFieldExpressions()
@@ -227,6 +228,24 @@ func (v *TaskConfigValidator) validateParamSources() {
 	for i, param := range v.config.Params {
 		if param.Source.IsZero() || (param.Source.IsString() && strings.TrimSpace(param.Source.StringVal) == "") {
 			v.errors.Add(fmt.Sprintf("%s[%d].%s", FieldParams, i, FieldSource), "source is required")
+		}
+	}
+}
+
+func (v *TaskConfigValidator) validateParamFileSources() {
+	for i, param := range v.config.Params {
+		if !param.Source.IsFile() {
+			continue
+		}
+		base := fmt.Sprintf("%s[%d].%s.file", FieldParams, i, FieldSource)
+		if param.Source.File == nil || param.Source.File.Path == "" {
+			v.errors.Add(base+".path", "path is required for file source")
+			continue
+		}
+		if !strings.HasPrefix(param.Source.File.Path, "/") {
+			v.warnings = append(v.warnings, fmt.Sprintf(
+				"%s.path: file source path %q is not absolute; in container deployments, use absolute paths for mounted volumes",
+				base, param.Source.File.Path))
 		}
 	}
 }

--- a/internal/configloader/validator_test.go
+++ b/internal/configloader/validator_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift-hyperfleet/hyperfleet-adapter/internal/criteria"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 // baseTaskConfig returns a minimal valid AdapterTaskConfig for testing.
@@ -1347,6 +1348,96 @@ func TestValidateParamsAPICallSource(t *testing.T) {
 		err := v.ValidateSemantic()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "source is required")
+	})
+}
+
+func TestValidateParamsFileSource(t *testing.T) {
+	boolPtr := func(b bool) *bool { return &b }
+
+	t.Run("file source passes validation", func(t *testing.T) {
+		cfg := baseTaskConfig()
+		cfg.Params = []Parameter{
+			{Name: "token", Source: FileSource(&FileSourceConfig{
+				Path: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+			})},
+		}
+		v := newTaskValidator(cfg)
+		require.NoError(t, v.ValidateStructure())
+		require.NoError(t, v.ValidateSemantic())
+	})
+
+	t.Run("file source with explicit trim passes validation", func(t *testing.T) {
+		cfg := baseTaskConfig()
+		cfg.Params = []Parameter{
+			{Name: "token", Source: FileSource(&FileSourceConfig{
+				Path: "/var/run/secrets/token",
+				Trim: boolPtr(false),
+			})},
+		}
+		v := newTaskValidator(cfg)
+		require.NoError(t, v.ValidateStructure())
+		require.NoError(t, v.ValidateSemantic())
+	})
+
+	t.Run("file source with empty path rejected", func(t *testing.T) {
+		cfg := baseTaskConfig()
+		cfg.Params = []Parameter{
+			{Name: "token", Source: FileSource(&FileSourceConfig{Path: ""})},
+		}
+		v := newTaskValidator(cfg)
+		_ = v.ValidateStructure()
+		err := v.ValidateSemantic()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "path is required for file source")
+	})
+
+	t.Run("file source mutual exclusivity with api_call", func(t *testing.T) {
+		cfg := baseTaskConfig()
+		// Construct via YAML to hit UnmarshalYAML mutual exclusivity
+		yamlStr := `
+params:
+  - name: "bad"
+    source:
+      api_call:
+        method: "GET"
+        url: "/clusters/x"
+      file:
+        path: "/some/file"
+`
+		var taskCfg AdapterTaskConfig
+		err := yaml.Unmarshal([]byte(yamlStr), &taskCfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "only one of")
+		_ = cfg // suppress unused
+	})
+
+	t.Run("file source mutual exclusivity with expression", func(t *testing.T) {
+		yamlStr := `
+params:
+  - name: "bad"
+    source:
+      expression: "1 + 1"
+      file:
+        path: "/some/file"
+`
+		var taskCfg AdapterTaskConfig
+		err := yaml.Unmarshal([]byte(yamlStr), &taskCfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "only one of")
+	})
+
+	t.Run("file source with relative path emits warning", func(t *testing.T) {
+		cfg := baseTaskConfig()
+		cfg.Params = []Parameter{
+			{Name: "token", Source: FileSource(&FileSourceConfig{
+				Path: "relative/path/token",
+			})},
+		}
+		v := newTaskValidator(cfg)
+		require.NoError(t, v.ValidateStructure())
+		require.NoError(t, v.ValidateSemantic())
+		require.Len(t, v.Warnings(), 1)
+		assert.Contains(t, v.Warnings()[0], "not absolute")
 	})
 }
 

--- a/internal/executor/README.md
+++ b/internal/executor/README.md
@@ -126,6 +126,7 @@ Extracts parameters from various sources:
 
 - **Environment Variables**: `source: "env.VARIABLE_NAME"`
 - **Event Data**: `source: "event.field.path"`
+- **File**: `source: { file: { path: "/path/to/file" } }` (read at reconciliation time)
 - **Secrets**: `source: "secret.namespace.name.key"` (requires K8s client)
 - **ConfigMaps**: `source: "configmap.namespace.name.key"` (requires K8s client)
 
@@ -183,11 +184,11 @@ preconditions:
           status.conditions.filter(c, c.type == "Reconciled").size() > 0
             ? status.conditions.filter(c, c.type == "Reconciled")[0].status
             : "False"
-      
+
       # JSONPath for complex extraction
       - name: "lzStatus"
         field: "{.items[?(@.adapter=='landing-zone-adapter')].data.namespace.status}"
-      
+
       # CEL expression for computed values
       - name: "activeCount"
         expression: "items.filter(i, i.status == 'active').size()"
@@ -196,7 +197,7 @@ preconditions:
       - field: "reconciledConditionStatus"
         operator: "equals"
         value: "True"
-      
+
       # Or dig directly into API response using precondition name
       - field: "checkClusterStatus.status.nodeCount"
         operator: "greaterThan"
@@ -341,7 +342,7 @@ post:
         errorMessage:
           field: "adapter.errorMessage"   # JSONPath extraction
           default: ""                     # Fallback if field not found
-  
+
   post_actions:
     - name: "reportStatus"
       api_call:

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/cloudevents/sdk-go/v2/event"
@@ -757,6 +759,183 @@ func TestParamExtractor_APICallSource(t *testing.T) {
 		_, err := runParamExtraction(t, config, mockClient, eventData)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "is not a map")
+	})
+}
+
+// TestParamExtractor_FileSource tests params with source: file
+func TestParamExtractor_FileSource(t *testing.T) {
+	boolPtr := func(b bool) *bool { return &b }
+	eventData := map[string]interface{}{"id": "cluster-123"}
+	mockClient := newMockAPIClient()
+
+	t.Run("successful file read", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tokenPath := filepath.Join(tmpDir, "token")
+		require.NoError(t, os.WriteFile(tokenPath, []byte("my-secret-token"), 0o600))
+
+		config := &configloader.Config{
+			Params: []configloader.Parameter{
+				{Name: "token", Source: configloader.FileSource(&configloader.FileSourceConfig{
+					Path: tokenPath,
+				}), Required: true},
+			},
+		}
+		execCtx, err := runParamExtraction(t, config, mockClient, eventData)
+		require.NoError(t, err)
+		assert.Equal(t, "my-secret-token", execCtx.Params["token"])
+	})
+
+	t.Run("file read with trim=true (default) strips whitespace", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tokenPath := filepath.Join(tmpDir, "token")
+		require.NoError(t, os.WriteFile(tokenPath, []byte("  my-token\n"), 0o600))
+
+		config := &configloader.Config{
+			Params: []configloader.Parameter{
+				{Name: "token", Source: configloader.FileSource(&configloader.FileSourceConfig{
+					Path: tokenPath,
+				})},
+			},
+		}
+		execCtx, err := runParamExtraction(t, config, mockClient, eventData)
+		require.NoError(t, err)
+		assert.Equal(t, "my-token", execCtx.Params["token"])
+	})
+
+	t.Run("file read with trim=false preserves whitespace", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tokenPath := filepath.Join(tmpDir, "token")
+		require.NoError(t, os.WriteFile(tokenPath, []byte("  my-token\n"), 0o600))
+
+		config := &configloader.Config{
+			Params: []configloader.Parameter{
+				{Name: "token", Source: configloader.FileSource(&configloader.FileSourceConfig{
+					Path: tokenPath,
+					Trim: boolPtr(false),
+				})},
+			},
+		}
+		execCtx, err := runParamExtraction(t, config, mockClient, eventData)
+		require.NoError(t, err)
+		assert.Equal(t, "  my-token\n", execCtx.Params["token"])
+	})
+
+	t.Run("file not found returns error", func(t *testing.T) {
+		config := &configloader.Config{
+			Params: []configloader.Parameter{
+				{Name: "token", Source: configloader.FileSource(&configloader.FileSourceConfig{
+					Path: "/nonexistent/path/token",
+				}), Required: true},
+			},
+		}
+		_, err := runParamExtraction(t, config, mockClient, eventData)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "/nonexistent/path/token")
+		assert.Contains(t, err.Error(), "token")
+	})
+
+	t.Run("required empty file returns error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tokenPath := filepath.Join(tmpDir, "empty")
+		require.NoError(t, os.WriteFile(tokenPath, []byte(""), 0o600))
+
+		config := &configloader.Config{
+			Params: []configloader.Parameter{
+				{Name: "token", Source: configloader.FileSource(&configloader.FileSourceConfig{
+					Path: tokenPath,
+				}), Required: true},
+			},
+		}
+		_, err := runParamExtraction(t, config, mockClient, eventData)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty")
+	})
+
+	t.Run("optional empty file returns empty string", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tokenPath := filepath.Join(tmpDir, "empty")
+		require.NoError(t, os.WriteFile(tokenPath, []byte(""), 0o600))
+
+		config := &configloader.Config{
+			Params: []configloader.Parameter{
+				{Name: "token", Source: configloader.FileSource(&configloader.FileSourceConfig{
+					Path: tokenPath,
+				}), Required: false},
+			},
+		}
+		execCtx, err := runParamExtraction(t, config, mockClient, eventData)
+		require.NoError(t, err)
+		// Empty string is stored (value is not nil, no default to override)
+		val, ok := execCtx.Params["token"]
+		assert.True(t, ok, "empty optional file value should be stored")
+		assert.Equal(t, "", val)
+	})
+
+	t.Run("file exceeds max size returns error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		bigPath := filepath.Join(tmpDir, "big")
+		// Write 1MB + 1 byte
+		data := make([]byte, 1<<20+1)
+		require.NoError(t, os.WriteFile(bigPath, data, 0o600))
+
+		config := &configloader.Config{
+			Params: []configloader.Parameter{
+				{Name: "bigFile", Source: configloader.FileSource(&configloader.FileSourceConfig{
+					Path: bigPath,
+				}), Required: true},
+			},
+		}
+		_, err := runParamExtraction(t, config, mockClient, eventData)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds maximum size")
+	})
+
+	t.Run("non-required file failure falls back to default", func(t *testing.T) {
+		config := &configloader.Config{
+			Params: []configloader.Parameter{
+				{Name: "token", Source: configloader.FileSource(&configloader.FileSourceConfig{
+					Path: "/nonexistent/path/token",
+				}), Required: false, Default: "fallback-token"},
+			},
+		}
+		execCtx, err := runParamExtraction(t, config, mockClient, eventData)
+		require.NoError(t, err)
+		assert.Equal(t, "fallback-token", execCtx.Params["token"])
+	})
+
+	t.Run("file source with type conversion", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		numPath := filepath.Join(tmpDir, "count")
+		require.NoError(t, os.WriteFile(numPath, []byte("42\n"), 0o600))
+
+		config := &configloader.Config{
+			Params: []configloader.Parameter{
+				{Name: "count", Source: configloader.FileSource(&configloader.FileSourceConfig{
+					Path: numPath,
+				}), Type: "int", Required: true},
+			},
+		}
+		execCtx, err := runParamExtraction(t, config, mockClient, eventData)
+		require.NoError(t, err)
+		assert.Equal(t, int64(42), execCtx.Params["count"])
+	})
+
+	t.Run("required whitespace-only file with trim=false returns error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		wsPath := filepath.Join(tmpDir, "whitespace")
+		require.NoError(t, os.WriteFile(wsPath, []byte("  \n\t"), 0o600))
+
+		config := &configloader.Config{
+			Params: []configloader.Parameter{
+				{Name: "token", Source: configloader.FileSource(&configloader.FileSourceConfig{
+					Path: wsPath,
+					Trim: boolPtr(false),
+				}), Required: true},
+			},
+		}
+		_, err := runParamExtraction(t, config, mockClient, eventData)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty")
 	})
 }
 

--- a/internal/executor/param_extractor.go
+++ b/internal/executor/param_extractor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -47,7 +48,7 @@ func extractConfigParams(
 			value = param.Default
 		}
 
-		if value != nil && param.Type != "" && param.Source.IsString() {
+		if value != nil && param.Type != "" && (param.Source.IsString() || param.Source.IsFile()) {
 			converted, convErr := convertParamType(value, param.Type)
 			if convErr != nil {
 				if param.Required {
@@ -84,6 +85,8 @@ func extractParam(
 		return extractFromAPICall(ctx, param, execCtx, apiClient, log)
 	case param.Source.IsExpression():
 		return extractFromCELExpression(ctx, param, execCtx, log)
+	case param.Source.IsFile():
+		return extractFromFile(param)
 	case param.Source.IsString():
 		return extractFromStringSource(param, execCtx.EventData, configMap, execCtx.Params)
 	default:
@@ -171,6 +174,44 @@ func extractFromCELExpression(
 		return nil, fmt.Errorf("param %q: CEL expression error: %w", param.Name, result.Error)
 	}
 	return result.Value, nil
+}
+
+// maxFileSourceSize is a defensive cap for file-based parameter sources (1 MB).
+const maxFileSourceSize = 1 << 20
+
+// extractFromFile reads a parameter value from a filesystem path.
+// The file is read fresh on every call (not cached between reconciliations).
+func extractFromFile(param configloader.Parameter) (interface{}, error) {
+	fs := param.Source.File
+	if fs == nil {
+		return nil, fmt.Errorf("param %q: file source has nil configuration", param.Name)
+	}
+
+	f, err := os.Open(fs.Path)
+	if err != nil {
+		return nil, fmt.Errorf("param %q: opening %q: %w", param.Name, fs.Path, err)
+	}
+	defer f.Close() //nolint:errcheck // best-effort close on read-only file
+
+	limited := io.LimitReader(f, maxFileSourceSize+1)
+	raw, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, fmt.Errorf("param %q: reading %q: %w", param.Name, fs.Path, err)
+	}
+	if len(raw) > maxFileSourceSize {
+		return nil, fmt.Errorf("param %q: file %q exceeds maximum size of %d bytes", param.Name, fs.Path, maxFileSourceSize)
+	}
+
+	content := string(raw)
+	if fs.Trim == nil || *fs.Trim {
+		content = strings.TrimSpace(content)
+	}
+
+	if param.Required && strings.TrimSpace(content) == "" {
+		return nil, fmt.Errorf("param %q: file %q is empty", param.Name, fs.Path)
+	}
+
+	return content, nil
 }
 
 // configToMap converts a Config to map[string]interface{} using the yaml struct tags for key names.


### PR DESCRIPTION
## What

Add `file` source type to the adapter params phase DSL, allowing adapter authors to read parameter values from filesystem paths at reconciliation time (e.g., service account tokens at `/var/run/secrets/kubernetes.io/serviceaccount/token`).

**Ticket:** [HYPERFLEET-1294](https://redhat.atlassian.net/browse/HYPERFLEET-1294)

## Why

Adapters need to consume values from mounted files — projected SA tokens, mounted secrets, config files — without requiring the HyperFleet API or K8s client as intermediaries. The `file` source provides a direct, simple mechanism consistent with the existing `api_call` and `expression` structured sources.

## Changes

### `internal/configloader/types.go`
- `FileSourceConfig` struct with `path` (required) and `trim` (optional, defaults true) fields
- `paramSourceKindFile` constant, `FileSource()` constructor, `IsFile()` predicate
- `Describe()`, `MarshalYAML()`, `UnmarshalYAML()` cases with mutual exclusivity enforcement

### `internal/executor/param_extractor.go`
- `extractFromFile()` — reads file fresh per event, trims whitespace by default, 1MB size cap via `io.LimitReader`, errors on empty when `required: true`
- Type conversion guard extended to cover file sources (same as string)

### `internal/configloader/validator.go`
- `validateParamFileSources()` — path required, warning on non-absolute paths

### Documentation
- `docs/adapter-authoring-guide.md` — `file` source docs, `config.` prefix added to sources table, fixed "via CEL" → "via Go Templates"
- `configs/adapter-task-config-template.yaml` — commented file source example
- `internal/executor/README.md` — added file source to source list

## AC → Test Coverage

| Acceptance Criteria | Test |
|---|---|
| File source accepted in config schema | `TestValidateParamsFileSource/file_source_passes_validation` |
| File read at reconciliation time | `TestParamExtractor_FileSource/successful_file_read` |
| Whitespace trimming (default + configurable) | `TestParamExtractor_FileSource/trim=true`, `trim=false` |
| Mutual exclusivity with api_call/expression | `TestValidateParamsFileSource/mutual_exclusivity_*` (2 cases) |
| Error on missing file | `TestParamExtractor_FileSource/file_not_found_returns_error` |
| Error on empty file (required) | `TestParamExtractor_FileSource/required_empty_file_returns_error` |
| Optional empty file stores empty string | `TestParamExtractor_FileSource/optional_empty_file_returns_empty_string` |
| File exceeds max size | `TestParamExtractor_FileSource/file_exceeds_max_size_returns_error` |
| Fallback to default on error | `TestParamExtractor_FileSource/non-required_file_failure_falls_back_to_default` |
| Type conversion for file source | `TestParamExtractor_FileSource/file_source_with_type_conversion` |
| Relative path warning | `TestValidateParamsFileSource/file_source_with_relative_path_emits_warning` |
| Empty path rejected | `TestValidateParamsFileSource/file_source_with_empty_path_rejected` |

## Gates

build ✓ · lint ✓ · tests all pass (race) · dry-run ✓

## Usage

```yaml
params:
  - name: "k8sToken"
    source:
      file:
        path: "/var/run/secrets/kubernetes.io/serviceaccount/token"
        trim: true   # default; set to false if whitespace is significant
    required: true
```

[HYPERFLEET-1294]: https://redhat.atlassian.net/browse/HYPERFLEET-1294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ