### PR TITLE
HYPERFLEET-1293 - feat: validate and document CEL variable namespaces

### DIFF
--- a/docs/adapter-authoring-guide.md
+++ b/docs/adapter-authoring-guide.md
@@ -1790,6 +1790,19 @@ More information about deployment can be found in [Architecture repository - Hyp
 
 > For the full CEL reference including implementation details, see [CEL Conventions](conventions/cel.md).
 
+### Available namespaces
+
+| Namespace | Description | Example |
+|---|---|---|
+| _(param names)_ | Extracted params as top-level names — write `clusterID`, not `params.clusterID` | `clusterID`, `region` |
+| `resources.*` | Discovered K8s resources by alias (empty during precondition phase) | `resources.managedCluster.status` |
+| `adapter.*` | Adapter execution metadata; meaningful values only in post-phase expressions | `adapter.executionStatus`, `adapter.errorMessage` |
+| `env.*` | OS environment variables accessible to the process | `env.REGION`, `env.NAMESPACE` |
+| `event.*` | Triggering CloudEvent payload fields | `event.id`, `event.kind` |
+| `config.*` | Full adapter deployment config as a nested map | `config.clients.hyperfleetApi.baseUrl` |
+
+See [CEL Conventions — Variable Reference](conventions/cel.md#variable-reference) for per-context availability and reserved name rules.
+
 ```cel
 # Optional chaining — safe access to fields that may not exist
 resources.?clusterNamespace.?status.?phase.orValue("")

--- a/docs/conventions/cel.md
+++ b/docs/conventions/cel.md
@@ -6,10 +6,37 @@ Used in precondition expressions, lifecycle delete conditions, and post-action `
 
 ## Variables
 
-Extracted params are injected as **top-level** names — write `clusterID`, not `params.clusterID`.
+### Namespace availability by evaluation context
 
-- `resources.*` — discovered resources by alias (e.g., `resources.myCluster`)
-- `adapter.*` — adapter metadata (executionStatus, resourcesSkipped, skipReason, errorReason, errorMessage, executionError, resourceErrors). See `adapterMetadataToMap()` in `internal/executor/utils.go` for current fields.
+| Variable | Type | Available in | Description |
+|---|---|---|---|
+| _(param names)_ | any | all contexts[¹](#footnotes) | Extracted params injected as **top-level names** (eg. `clusterID`). Includes api_call result maps, event-derived values, env-derived values, and expression results. |
+| _(capture names)_ | any | resources, post payloads, post_action when, payload when | Named captures from `precondition.capture` are stored in params and promoted to top-level names in all downstream contexts. |
+| `resources.*` | map | resources (pre-discovery state), post payloads, post_action when, payload when | Discovered resources by alias. Empty during precondition phase. Deleted resources are absent (use optional access: `resources.?name.hasValue()`). |
+| `adapter.*` | map | all contexts[¹](#footnotes) | Adapter execution metadata. See fields below. Values are only meaningful in post-phase expressions - during params and preconditions `executionStatus` is always `"success"` and error fields are empty. |
+| `env.*` | map | all contexts[¹](#footnotes) | All OS environment variables accessible to the process (`env.MY_VAR`). No declaration needed. |
+| `event.*` | map | all contexts[¹](#footnotes) | Full triggering event payload (`event.id`, `event.kind`, etc.). No declaration needed. |
+| `config.*` | map | all contexts[¹](#footnotes) | Full adapter deployment config as a nested map. |
+
+#### Footnotes
+
+¹ "All contexts" means: param CEL expressions, precondition expressions/conditions, lifecycle create/delete when, payload when, payload build expressions, post_action when.
+
+#### adapter.* fields
+
+| Field | Type | Description |
+|---|---|---|
+| `adapter.executionStatus` | string | `"success"` or `"failed"` |
+| `adapter.resourcesSkipped` | bool | `true` when resources were intentionally skipped |
+| `adapter.skipReason` | string | why resources were skipped |
+| `adapter.errorReason` | string | error category if failed |
+| `adapter.errorMessage` | string | error message if failed |
+| `adapter.executionError` | map or null | `{phase, step, message}` for the first failure, nil otherwise |
+| `adapter.resourceErrors` | map | per-resource error maps keyed by resource name |
+
+#### Reserved names
+
+`adapter`, `resources`, `env`, and `event` are **reserved** — they are overwritten by the runtime at evaluation time regardless of any param with the same name. `config` is also set by the runtime but a param named `config` would take precedence in earlier phases.
 
 ## Custom Functions
 

--- a/internal/configloader/accessors.go
+++ b/internal/configloader/accessors.go
@@ -10,7 +10,7 @@ import (
 
 // builtinVariables is the list of built-in variables always available in templates/CEL
 var builtinVariables = []string{
-	"adapter", "config", "now", "date",
+	"adapter", "config", "env", "event", "now", "date",
 }
 
 // BuiltinVariables returns the list of built-in variables always available in templates/CEL

--- a/internal/configloader/constants.go
+++ b/internal/configloader/constants.go
@@ -13,6 +13,8 @@ const (
 	FieldPreconditions = "preconditions"
 	FieldResources     = "resources"
 	FieldPost          = "post"
+	FieldEnv           = "env"
+	FieldEvent         = "event"
 )
 
 // Adapter field names

--- a/internal/configloader/validator.go
+++ b/internal/configloader/validator.go
@@ -379,6 +379,14 @@ func (v *TaskConfigValidator) initCELEnv() error {
 		options = append(options, cel.Variable(FieldAdapter, cel.MapType(cel.StringType, cel.DynType)))
 	}
 
+	if !addedRoots[FieldEnv] {
+		options = append(options, cel.Variable(FieldEnv, cel.MapType(cel.StringType, cel.DynType)))
+	}
+
+	if !addedRoots[FieldEvent] {
+		options = append(options, cel.Variable(FieldEvent, cel.MapType(cel.StringType, cel.DynType)))
+	}
+
 	env, err := cel.NewEnv(options...)
 	if err != nil {
 		return err

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -2158,6 +2158,234 @@ func TestPostActionBrokenURL404_ReportsError(t *testing.T) {
 		"post-action error should be recorded for a broken URL 404")
 }
 
+// TestGetCELVariables_AllNamespaces verifies that GetCELVariables includes all required namespaces
+func TestGetCELVariables_AllNamespaces(t *testing.T) {
+	t.Setenv("CEL_TEST_VAR", "cel-test-value")
+
+	eventData := map[string]interface{}{
+		"id":   "cluster-abc",
+		"kind": "ManagedCluster",
+	}
+	execCtx := NewExecutionContext(context.Background(), eventData, nil)
+	execCtx.Params["myParam"] = "param-value"
+
+	vars := execCtx.GetCELVariables()
+
+	require.Contains(t, vars, "event", "GetCELVariables must include 'event'")
+	eventMap, ok := vars["event"].(map[string]interface{})
+	require.True(t, ok, "event must be a map")
+	assert.Equal(t, "cluster-abc", eventMap["id"])
+	assert.Equal(t, "ManagedCluster", eventMap["kind"])
+
+	require.Contains(t, vars, "env", "GetCELVariables must include 'env'")
+	envMap, ok := vars["env"].(map[string]interface{})
+	require.True(t, ok, "env must be a map")
+	assert.Equal(t, "cel-test-value", envMap["CEL_TEST_VAR"])
+
+	// params are available as top-level names
+	assert.Equal(t, "param-value", vars["myParam"])
+
+	// existing namespaces must still be present
+	assert.Contains(t, vars, "adapter")
+	assert.Contains(t, vars, "resources")
+}
+
+// TestCELExpression_EnvVariable verifies env.* is accessible in a precondition CEL expression
+func TestCELExpression_EnvVariable(t *testing.T) {
+	t.Setenv("EXPECTED_REGION", "us-east-1")
+
+	config := &configloader.Config{
+		Adapter: configloader.AdapterInfo{Name: "test-adapter", Version: "1.0.0"},
+		Preconditions: []configloader.Precondition{
+			{
+				ActionBase: configloader.ActionBase{Name: "checkRegion"},
+				Expression: `env.EXPECTED_REGION == "us-east-1"`,
+			},
+		},
+	}
+
+	exec, err := NewBuilder().
+		WithConfig(config).
+		WithAPIClient(newMockAPIClient()).
+		WithTransportClient(k8sclient.NewMockK8sClient()).
+		WithLogger(logger.NewTestLogger()).
+		Build()
+	require.NoError(t, err)
+
+	result := exec.Execute(context.Background(), map[string]interface{}{"id": "cluster-env-test"})
+
+	require.Equal(t, StatusSuccess, result.Status, "errors=%v", result.Errors)
+	require.Len(t, result.PreconditionResults, 1)
+	assert.True(t, result.PreconditionResults[0].Matched, "env.EXPECTED_REGION CEL expression should match")
+}
+
+// TestCELExpression_EventVariable verifies event.* is accessible in a precondition CEL expression
+func TestCELExpression_EventVariable(t *testing.T) {
+	config := &configloader.Config{
+		Adapter: configloader.AdapterInfo{Name: "test-adapter", Version: "1.0.0"},
+		Preconditions: []configloader.Precondition{
+			{
+				ActionBase: configloader.ActionBase{Name: "checkEventKind"},
+				Expression: `event.kind == "ManagedCluster"`,
+			},
+		},
+	}
+
+	exec, err := NewBuilder().
+		WithConfig(config).
+		WithAPIClient(newMockAPIClient()).
+		WithTransportClient(k8sclient.NewMockK8sClient()).
+		WithLogger(logger.NewTestLogger()).
+		Build()
+	require.NoError(t, err)
+
+	eventData := map[string]interface{}{
+		"id":   "cluster-event-test",
+		"kind": "ManagedCluster",
+	}
+	result := exec.Execute(context.Background(), eventData)
+
+	require.Equal(t, StatusSuccess, result.Status, "errors=%v", result.Errors)
+	require.Len(t, result.PreconditionResults, 1)
+	assert.True(t, result.PreconditionResults[0].Matched, "event.kind CEL expression should match")
+}
+
+// TestCELExpression_EnvInPostActionWhen verifies env.* works in a post-action when gate
+func TestCELExpression_EnvInPostActionWhen(t *testing.T) {
+	t.Setenv("SKIP_POST_ACTION", "true")
+
+	mockClient := newMockAPIClient()
+	mockClient.PutResponse = &hyperfleetapi.Response{StatusCode: 200, Body: []byte(`{}`)}
+
+	config := &configloader.Config{
+		Adapter: configloader.AdapterInfo{Name: "test-adapter", Version: "1.0.0"},
+		Post: &configloader.PostConfig{
+			PostActions: []configloader.PostAction{
+				{
+					ActionBase: configloader.ActionBase{
+						Name: "conditionalAction",
+						APICall: &configloader.APICall{
+							Method: "PUT",
+							URL:    "/clusters/test/status",
+							Body:   `{}`,
+						},
+					},
+					When: &configloader.PostActionWhen{Expression: `env.SKIP_POST_ACTION == "false"`},
+				},
+			},
+		},
+	}
+
+	exec, err := NewBuilder().
+		WithConfig(config).
+		WithAPIClient(mockClient).
+		WithTransportClient(k8sclient.NewMockK8sClient()).
+		WithLogger(logger.NewTestLogger()).
+		Build()
+	require.NoError(t, err)
+
+	result := exec.Execute(context.Background(), map[string]interface{}{"id": "cluster-env-when"})
+
+	require.Equal(t, StatusSuccess, result.Status, "errors=%v", result.Errors)
+	require.Len(t, result.PostActionResults, 1)
+	assert.True(t, result.PostActionResults[0].Skipped,
+		"post-action should be skipped when env.SKIP_POST_ACTION != \"false\"")
+	assert.Empty(t, mockClient.Requests, "API call should not be made when action is skipped")
+}
+
+// TestCELExpression_EventInPostActionWhen verifies event.* works in a post-action when gate
+func TestCELExpression_EventInPostActionWhen(t *testing.T) {
+	mockClient := newMockAPIClient()
+	mockClient.PutResponse = &hyperfleetapi.Response{StatusCode: 200, Body: []byte(`{}`)}
+
+	config := &configloader.Config{
+		Adapter: configloader.AdapterInfo{Name: "test-adapter", Version: "1.0.0"},
+		Post: &configloader.PostConfig{
+			PostActions: []configloader.PostAction{
+				{
+					ActionBase: configloader.ActionBase{
+						Name: "gatedAction",
+						APICall: &configloader.APICall{
+							Method: "PUT",
+							URL:    "/clusters/test/status",
+							Body:   `{}`,
+						},
+					},
+					When: &configloader.PostActionWhen{Expression: `event.kind == "ManagedCluster"`},
+				},
+			},
+		},
+	}
+
+	exec, err := NewBuilder().
+		WithConfig(config).
+		WithAPIClient(mockClient).
+		WithTransportClient(k8sclient.NewMockK8sClient()).
+		WithLogger(logger.NewTestLogger()).
+		Build()
+	require.NoError(t, err)
+
+	eventData := map[string]interface{}{
+		"id":   "cluster-event-when",
+		"kind": "ManagedCluster",
+	}
+	result := exec.Execute(context.Background(), eventData)
+
+	require.Equal(t, StatusSuccess, result.Status, "errors=%v", result.Errors)
+	require.Len(t, result.PostActionResults, 1)
+	assert.False(t, result.PostActionResults[0].Skipped,
+		"post-action should NOT be skipped when event.kind matches")
+	assert.Len(t, mockClient.Requests, 1, "API call should be made when when-condition is true")
+}
+
+// TestCELExpression_EnvInParamExpression verifies env.* works in a param source.expression
+func TestCELExpression_EnvInParamExpression(t *testing.T) {
+	t.Setenv("CLUSTER_REGION", "eu-west-1")
+
+	config := &configloader.Config{
+		Adapter: configloader.AdapterInfo{Name: "test-adapter", Version: "1.0.0"},
+		Params: []configloader.Parameter{
+			{Name: "region", Source: configloader.ExpressionSource(`env.CLUSTER_REGION`)},
+		},
+	}
+
+	exec, err := NewBuilder().
+		WithConfig(config).
+		WithAPIClient(newMockAPIClient()).
+		WithTransportClient(k8sclient.NewMockK8sClient()).
+		WithLogger(logger.NewTestLogger()).
+		Build()
+	require.NoError(t, err)
+
+	result := exec.Execute(context.Background(), map[string]interface{}{"id": "cluster-env-param"})
+
+	require.Equal(t, StatusSuccess, result.Status, "errors=%v", result.Errors)
+	assert.Equal(t, "eu-west-1", result.Params["region"])
+}
+
+// TestCELExpression_EventInParamExpression verifies event.* works in a param source.expression
+func TestCELExpression_EventInParamExpression(t *testing.T) {
+	config := &configloader.Config{
+		Adapter: configloader.AdapterInfo{Name: "test-adapter", Version: "1.0.0"},
+		Params: []configloader.Parameter{
+			{Name: "derivedID", Source: configloader.ExpressionSource(`"cluster-" + event.id`)},
+		},
+	}
+
+	exec, err := NewBuilder().
+		WithConfig(config).
+		WithAPIClient(newMockAPIClient()).
+		WithTransportClient(k8sclient.NewMockK8sClient()).
+		WithLogger(logger.NewTestLogger()).
+		Build()
+	require.NoError(t, err)
+
+	result := exec.Execute(context.Background(), map[string]interface{}{"id": "abc"})
+
+	require.Equal(t, StatusSuccess, result.Status, "errors=%v", result.Errors)
+	assert.Equal(t, "cluster-abc", result.Params["derivedID"])
+}
+
 func getCounterValue(t *testing.T, families []*dto.MetricFamily, metricName, labelName, labelValue string) float64 {
 	t.Helper()
 	family := findFamily(families, metricName)

--- a/internal/executor/types.go
+++ b/internal/executor/types.go
@@ -398,6 +398,8 @@ func (ec *ExecutionContext) GetCELVariables() map[string]interface{} {
 		}
 	}
 	result["resources"] = resources
+	result["event"] = ec.EventData
+	result["env"] = buildEnvMap()
 
 	return result
 }

--- a/internal/executor/utils.go
+++ b/internal/executor/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"strings"
 	"time"
@@ -364,6 +365,17 @@ func executionErrorToMap(execErr *ExecutionError) interface{} {
 		"step":    execErr.Step,
 		"message": execErr.Message,
 	}
+}
+
+// buildEnvMap returns all OS environment variables as a map[string]interface{} for CEL evaluation.
+func buildEnvMap() map[string]interface{} {
+	envMap := make(map[string]interface{})
+	for _, kv := range os.Environ() {
+		if i := strings.Index(kv, "="); i > 0 {
+			envMap[kv[:i]] = kv[i+1:]
+		}
+	}
+	return envMap
 }
 
 // adapterMetadataToMap converts AdapterMetadata struct to a map for CEL evaluation

--- a/test/integration/executor/executor_integration_test.go
+++ b/test/integration/executor/executor_integration_test.go
@@ -37,6 +37,18 @@ func getK8sEnvForTest(t *testing.T) *K8sTestEnv {
 	return nil
 }
 
+// createTestEventPayload returns just the data payload bytes for a test event.
+func createTestEventPayload(clusterID string) []byte {
+	eventData := map[string]interface{}{
+		"id":            clusterID,
+		"resource_type": "cluster",
+		"generation":    int64(1),
+		"href":          "/api/v1/clusters/" + clusterID,
+	}
+	bytes, _ := json.Marshal(eventData)
+	return bytes
+}
+
 // createTestEvent creates a CloudEvent for testing
 func createTestEvent(clusterID string) *event.Event {
 	evt := event.New()
@@ -1682,4 +1694,348 @@ func TestExecutor_PayloadWhenCondition(t *testing.T) {
 	assert.Equal(t, 1, statusPUTs, "Only one status PUT should be made")
 
 	t.Logf("Payload when condition test completed: skipped payload correctly prevented post-action execution")
+}
+
+// TestExecutor_CELNamespaces_EnvAndEvent verifies that env.* and event.* are available
+// as CEL variables in every supported evaluation context:
+// precondition expression, resource lifecycle when, payload when, post_action when, post payload build.
+func TestExecutor_CELNamespaces_EnvAndEvent(t *testing.T) {
+	mockAPI := testutil.NewMockAPIServer(t)
+	defer mockAPI.Close()
+
+	t.Setenv("HYPERFLEET_API_BASE_URL", mockAPI.URL())
+	t.Setenv("HYPERFLEET_API_VERSION", "v1")
+	t.Setenv("CEL_NS_TEST_VAR", "cel-namespace-test")
+
+	k8sEnv := getK8sEnvForTest(t)
+
+	ns := "cel-ns-env"
+	k8sEnv.CreateTestNamespace(t, ns)
+	defer k8sEnv.CleanupTestNamespace(t, ns)
+
+	config := &configloader.Config{
+		Adapter: configloader.AdapterInfo{Name: "cel-ns-test", Version: "1.0.0"},
+		Clients: configloader.ClientsConfig{
+			HyperfleetAPI: configloader.HyperfleetAPIConfig{
+				Timeout: 10 * time.Second, RetryAttempts: 1, RetryBackoff: hyperfleetapi.BackoffConstant,
+			},
+		},
+		Params: []configloader.Parameter{
+			{Name: "hyperfleetApiBaseUrl", Source: configloader.StringSource("env.HYPERFLEET_API_BASE_URL"), Required: true},
+			{Name: "hyperfleetApiVersion", Default: "v1"},
+			{Name: "clusterID", Source: configloader.StringSource("event.id"), Required: true},
+		},
+		// Context: precondition expression — env.* and event.* referenced directly (no APICall)
+		Preconditions: []configloader.Precondition{
+			{
+				ActionBase: configloader.ActionBase{Name: "envAndEventCheck"},
+				Expression: `env.CEL_NS_TEST_VAR == "cel-namespace-test" && event.resource_type == "cluster"`,
+			},
+		},
+		// Context: resource lifecycle when — env.* gates resource creation
+		Resources: []configloader.Resource{
+			{
+				Name: "testConfigMap",
+				Manifest: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name":      "cel-ns-test-cm",
+						"namespace": ns,
+					},
+					"data": map[string]interface{}{
+						"created-by": "cel-ns-test",
+					},
+				},
+				Lifecycle: &configloader.ResourceLifecycle{
+					Create: &configloader.LifecycleCreate{
+						When: &configloader.LifecycleWhen{
+							Expression: `env.CEL_NS_TEST_VAR == "cel-namespace-test"`,
+						},
+					},
+				},
+			},
+		},
+		Post: &configloader.PostConfig{
+			Payloads: []configloader.Payload{
+				{
+					// Context: payload when — env.* gates payload construction
+					Name: "envGatedPayload",
+					When: &configloader.PostActionWhen{
+						Expression: `env.CEL_NS_TEST_VAR == "cel-namespace-test"`,
+					},
+					// Context: post payload build — env.* and event.* in expression fields
+					Build: map[string]interface{}{
+						"envValue": map[string]interface{}{
+							"expression": `env.CEL_NS_TEST_VAR`,
+						},
+						"eventResourceType": map[string]interface{}{
+							"expression": `event.resource_type`,
+						},
+						"clusterID": map[string]interface{}{
+							"value": "{{ .clusterID }}",
+						},
+					},
+				},
+			},
+			PostActions: []configloader.PostAction{
+				{
+					ActionBase: configloader.ActionBase{
+						Name: "reportStatus",
+						APICall: &configloader.APICall{
+							Method:  "PUT",
+							URL:     "{{ .hyperfleetApiBaseUrl }}/api/{{ .hyperfleetApiVersion }}/clusters/{{ .clusterID }}/statuses",
+							Body:    "{{ .envGatedPayload }}",
+							Timeout: "5s",
+						},
+					},
+					// Context: post_action when — event.* gates execution
+					When: &configloader.PostActionWhen{
+						Expression: `event.resource_type == "cluster"`,
+					},
+				},
+			},
+		},
+	}
+
+	apiClient, err := hyperfleetapi.NewClient(testLog(), hyperfleetapi.WithRetryAttempts(1))
+	require.NoError(t, err)
+
+	exec, err := executor.NewBuilder().
+		WithConfig(config).
+		WithAPIClient(apiClient).
+		WithLogger(k8sEnv.Log).
+		WithTransportClient(k8sEnv.Client).
+		Build()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result := exec.Execute(ctx, createTestEventPayload("cel-ns-cluster"))
+
+	require.Equal(t, executor.StatusSuccess, result.Status,
+		"Expected success; errors=%v", result.Errors)
+
+	require.Len(t, result.PreconditionResults, 1)
+	assert.True(t, result.PreconditionResults[0].Matched,
+		"Precondition using env.* and event.* should match")
+
+	require.Len(t, result.ResourceResults, 1)
+	assert.NotEqual(t, executor.StatusFailed, result.ResourceResults[0].Status,
+		"Resource with env.* lifecycle create.when should not fail")
+
+	require.Len(t, result.PostActionResults, 1)
+	assert.Equal(t, executor.StatusSuccess, result.PostActionResults[0].Status,
+		"Post-action gated on event.* should execute")
+	assert.True(t, result.PostActionResults[0].APICallMade,
+		"Post-action should make API call when event.* when condition is true")
+
+	// Payload was built (payload when using env.* evaluated to true)
+	requests := mockAPI.GetRequests()
+	var statusPUT map[string]interface{}
+	for _, req := range requests {
+		if req.Method == http.MethodPut {
+			_ = json.Unmarshal([]byte(req.Body), &statusPUT)
+		}
+	}
+	require.NotNil(t, statusPUT, "Expected a PUT request with the built payload")
+	assert.Equal(t, "cel-namespace-test", statusPUT["envValue"],
+		"Payload build expression using env.* should resolve correctly")
+	assert.Equal(t, "cluster", statusPUT["eventResourceType"],
+		"Payload build expression using event.* should resolve correctly")
+
+	t.Logf("CEL namespace test completed: env.* and event.* verified in " +
+		"precondition, lifecycle when, payload when, payload build, post_action when")
+}
+
+// TestExecutor_CELNamespaces_ResourcesAdapterCaptures verifies that resources.*, adapter.*,
+// and precondition capture names are available as CEL variables in every supported post-phase context:
+// resource lifecycle when, payload when, post_action when, post payload build.
+func TestExecutor_CELNamespaces_ResourcesAdapterCaptures(t *testing.T) {
+	mockAPI := testutil.NewMockAPIServer(t)
+	defer mockAPI.Close()
+
+	t.Setenv("HYPERFLEET_API_BASE_URL", mockAPI.URL())
+	t.Setenv("HYPERFLEET_API_VERSION", "v1")
+
+	k8sEnv := getK8sEnvForTest(t)
+
+	const ns = "cel-ns-rac"
+	k8sEnv.CreateTestNamespace(t, ns)
+	defer k8sEnv.CleanupTestNamespace(t, ns)
+
+	config := &configloader.Config{
+		Adapter: configloader.AdapterInfo{Name: "cel-ns-rac-test", Version: "1.0.0"},
+		Clients: configloader.ClientsConfig{
+			HyperfleetAPI: configloader.HyperfleetAPIConfig{
+				Timeout: 10 * time.Second, RetryAttempts: 1, RetryBackoff: hyperfleetapi.BackoffConstant,
+			},
+		},
+		Params: []configloader.Parameter{
+			{Name: "hyperfleetApiBaseUrl", Source: configloader.StringSource("env.HYPERFLEET_API_BASE_URL"), Required: true},
+			{Name: "hyperfleetApiVersion", Default: "v1"},
+			{Name: "clusterID", Source: configloader.StringSource("event.id"), Required: true},
+		},
+		Preconditions: []configloader.Precondition{
+			{
+				ActionBase: configloader.ActionBase{
+					Name: "clusterStatus",
+					APICall: &configloader.APICall{
+						Method:  "GET",
+						URL:     "{{ .hyperfleetApiBaseUrl }}/api/{{ .hyperfleetApiVersion }}/clusters/{{ .clusterID }}",
+						Timeout: "5s",
+					},
+				},
+				// Capture clusterName for use in post-phase CEL expressions
+				Capture: []configloader.CaptureField{
+					{Name: "clusterName", FieldExpressionDef: configloader.FieldExpressionDef{Field: "name"}},
+				},
+				Conditions: []configloader.Condition{
+					{Field: "clusterName", Operator: "equals", Value: "test-cluster"},
+				},
+			},
+		},
+		Resources: []configloader.Resource{
+			{
+				Name: "racConfigMap",
+				Manifest: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name":      "cel-ns-rac-cm",
+						"namespace": ns,
+					},
+					"data": map[string]interface{}{"created-by": "cel-ns-rac-test"},
+				},
+				// Context: resource lifecycle when — event.* gates resource creation
+				Lifecycle: &configloader.ResourceLifecycle{
+					Create: &configloader.LifecycleCreate{
+						When: &configloader.LifecycleWhen{
+							Expression: `event.resource_type == "cluster"`,
+						},
+					},
+				},
+				Discovery: &configloader.DiscoveryConfig{
+					Namespace: ns,
+					ByName:    "cel-ns-rac-cm",
+				},
+			},
+		},
+		Post: &configloader.PostConfig{
+			Payloads: []configloader.Payload{
+				{
+					Name: "racPayload",
+					// Context: payload when — captures gate payload construction
+					When: &configloader.PostActionWhen{
+						Expression: `clusterName == "test-cluster"`,
+					},
+					Build: map[string]interface{}{
+						// Context: post payload build — capture name in CEL expression
+						"capturedClusterName": map[string]interface{}{
+							"expression": `clusterName`,
+						},
+						// Context: post payload build — resources.* in CEL expression
+						"k8sResourceName": map[string]interface{}{
+							"expression": `resources.?racConfigMap.?metadata.?name.orValue("")`,
+						},
+						// Context: post payload build — adapter.* in CEL expression
+						"executionOk": map[string]interface{}{
+							"expression": `adapter.executionStatus == "success"`,
+						},
+					},
+				},
+			},
+			PostActions: []configloader.PostAction{
+				{
+					ActionBase: configloader.ActionBase{
+						Name: "reportViaResources",
+						APICall: &configloader.APICall{
+							Method:  "PUT",
+							URL:     "{{ .hyperfleetApiBaseUrl }}/api/{{ .hyperfleetApiVersion }}/clusters/{{ .clusterID }}/statuses",
+							Body:    "{{ .racPayload }}",
+							Timeout: "5s",
+						},
+					},
+					// Context: post_action when — resources.* gates execution
+					When: &configloader.PostActionWhen{
+						Expression: `resources.?racConfigMap.hasValue()`,
+					},
+				},
+				{
+					ActionBase: configloader.ActionBase{
+						Name: "reportViaAdapter",
+						APICall: &configloader.APICall{
+							Method:  "PUT",
+							URL:     "{{ .hyperfleetApiBaseUrl }}/api/{{ .hyperfleetApiVersion }}/clusters/{{ .clusterID }}/statuses",
+							Body:    `{"adapterGated":true}`,
+							Timeout: "5s",
+						},
+					},
+					// Context: post_action when — adapter.* gates execution
+					When: &configloader.PostActionWhen{
+						Expression: `adapter.executionStatus == "success"`,
+					},
+				},
+			},
+		},
+	}
+
+	apiClient, err := hyperfleetapi.NewClient(testLog(), hyperfleetapi.WithRetryAttempts(1))
+	require.NoError(t, err)
+
+	exec, err := executor.NewBuilder().
+		WithConfig(config).
+		WithAPIClient(apiClient).
+		WithLogger(k8sEnv.Log).
+		WithTransportClient(k8sEnv.Client).
+		Build()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result := exec.Execute(ctx, createTestEventPayload("cel-rac-cluster"))
+
+	require.Equal(t, executor.StatusSuccess, result.Status,
+		"Expected success; errors=%v", result.Errors)
+
+	require.Len(t, result.PreconditionResults, 1)
+	assert.True(t, result.PreconditionResults[0].Matched, "Precondition should match")
+	assert.Equal(t, "test-cluster", result.PreconditionResults[0].CapturedFields["clusterName"],
+		"clusterName capture should contain API response value")
+
+	require.Len(t, result.ResourceResults, 1)
+	assert.NotEqual(t, executor.StatusFailed, result.ResourceResults[0].Status,
+		"Resource with event.* lifecycle create.when should not fail")
+
+	// Both post-actions ran
+	require.Len(t, result.PostActionResults, 2)
+
+	assert.Equal(t, executor.StatusSuccess, result.PostActionResults[0].Status,
+		"post_action when using resources.* should execute")
+	assert.True(t, result.PostActionResults[0].APICallMade)
+
+	assert.Equal(t, executor.StatusSuccess, result.PostActionResults[1].Status,
+		"post_action when using adapter.* should execute")
+	assert.True(t, result.PostActionResults[1].APICallMade)
+
+	// Verify payload contents: captures, resources.*, adapter.* resolved correctly in build expressions
+	requests := mockAPI.GetRequests()
+	var racPayload map[string]interface{}
+	for _, req := range requests {
+		if req.Method == http.MethodPut && strings.Contains(req.Body, "capturedClusterName") {
+			_ = json.Unmarshal([]byte(req.Body), &racPayload)
+		}
+	}
+	require.NotNil(t, racPayload, "Expected PUT request containing racPayload")
+	assert.Equal(t, "test-cluster", racPayload["capturedClusterName"],
+		"Payload build CEL expression using capture name should resolve correctly")
+	assert.Equal(t, "cel-ns-rac-cm", racPayload["k8sResourceName"],
+		"Payload build CEL expression using resources.* should resolve correctly")
+	assert.Equal(t, true, racPayload["executionOk"],
+		"Payload build CEL expression using adapter.* should resolve correctly")
+
+	t.Logf("CEL namespace test completed: resources.*, adapter.*, and captures verified in " +
+		"resource lifecycle when, payload when, post_action when, post payload build")
 }


### PR DESCRIPTION
## Summary
HYPERFLEET-1293 audits the CEL evaluation context across all adapter phases. `env.*` and `event.*` were missing from every context - both are now injected, registered as reserved names, documented, and covered by integration tests.

- Ticket: [HYPERFLEET-1293](https://redhat.atlassian.net/browse/HYPERFLEET-1293)

 ### Audit table (state before this PR)

Variable group | param expr | precondition | lifecycle when | payload when  | payload build  | post_action when
--- | --- | --- | --- |--- |--- |--- 
param names | ✓  | ✓ | ✓ | ✓ | ✓ | ✓
capture names | — | —  | ✓ | ✓ | ✓ | ✓
`resources.*` | — | —  | ✓ | ✓ | ✓ | ✓
`adapter.*` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓
`env.*` | ✗ | ✗ | ✗ | ✗ | ✗| ✗
`event.*` | ✗ | ✗ | ✗ | ✗ | ✗| ✗
`config.*` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓

## Test Plan

- [x] Unit tests added/updated
- [x] `make test-all` passes
- [x] `make lint` passes
- [ ] Helm chart changes validated with `make test-helm` (if applicable)
- [ ] Deployed to a development cluster and verified (if Helm/config changes)
- [ ] E2E tests passed (if cross-component or major changes)


[HYPERFLEET-1293]: https://redhat.atlassian.net/browse/HYPERFLEET-1293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ