### PR TITLE
HYPERFLEET-1351 - fix: disable gomod digest updates in manager-scoped config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,25 +3,23 @@
   "schedule": [
     "on monday"
   ],
+  "gomod": {
+    "packageRules": [
+      {
+        "matchUpdateTypes": [
+          "digest"
+        ],
+        "enabled": false
+      },
+      {
+        "matchDepTypes": [
+          "indirect"
+        ],
+        "enabled": false
+      }
+    ]
+  },
   "packageRules": [
-    {
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchUpdateTypes": [
-        "digest"
-      ],
-      "enabled": false
-    },
-    {
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchDepTypes": [
-        "indirect"
-      ],
-      "enabled": false
-    },
     {
       "matchManagers": [
         "gomod"


### PR DESCRIPTION
## Summary

- Moved gomod digest and indirect disable rules from top-level `packageRules` to manager-scoped `gomod.packageRules`
- This fixes an issue where MintMaker's global config was overriding the repo's disable rules due to Renovate's specificity hierarchy (manager-scoped rules take precedence over top-level rules)
- No functional changes to minor/patch grouping or docker image grouping

## JIRA

https://redhat.atlassian.net/browse/HYPERFLEET-1351