### PR TITLE
HYPERFLEET-1354 - feat: add env and event namespaces to Go template execution context

### DIFF
--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -2386,6 +2386,86 @@ func TestCELExpression_EventInParamExpression(t *testing.T) {
 	assert.Equal(t, "cluster-abc", result.Params["derivedID"])
 }
 
+// TestGoTemplate_EnvInManifest verifies that {{ .env.X }} resolves in resource manifest templates.
+func TestGoTemplate_EnvInManifest(t *testing.T) {
+	t.Setenv("TPL_REGION", "us-east-1")
+
+	mockClient := k8sclient.NewMockK8sClient()
+	config := &configloader.Config{
+		Adapter: configloader.AdapterInfo{Name: "test", Version: "1.0.0"},
+		Resources: []configloader.Resource{
+			{
+				Name: "testResource",
+				Manifest: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name":      "test-cm",
+						"namespace": "{{ .env.TPL_REGION }}",
+					},
+				},
+			},
+		},
+	}
+
+	exec, err := NewBuilder().
+		WithConfig(config).
+		WithAPIClient(newMockAPIClient()).
+		WithTransportClient(mockClient).
+		WithLogger(logger.NewTestLogger()).
+		Build()
+	require.NoError(t, err)
+
+	result := exec.Execute(context.Background(), map[string]interface{}{"id": "cluster-123"})
+
+	require.Equal(t, StatusSuccess, result.Status, "errors=%v", result.Errors)
+	applied := mockClient.Resources["us-east-1/test-cm"]
+	require.NotNil(t, applied, "resource should be applied with rendered namespace")
+	assert.Equal(t, "us-east-1", applied.GetNamespace())
+	assert.Equal(t, "test-cm", applied.GetName())
+}
+
+// TestGoTemplate_EventInManifest verifies that {{ .event.X }} resolves in resource manifest templates.
+func TestGoTemplate_EventInManifest(t *testing.T) {
+	mockClient := k8sclient.NewMockK8sClient()
+	config := &configloader.Config{
+		Adapter: configloader.AdapterInfo{Name: "test", Version: "1.0.0"},
+		Resources: []configloader.Resource{
+			{
+				Name: "testResource",
+				Manifest: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name":      "{{ .event.id }}",
+						"namespace": "default",
+					},
+				},
+			},
+		},
+	}
+
+	exec, err := NewBuilder().
+		WithConfig(config).
+		WithAPIClient(newMockAPIClient()).
+		WithTransportClient(mockClient).
+		WithLogger(logger.NewTestLogger()).
+		Build()
+	require.NoError(t, err)
+
+	eventData := map[string]interface{}{
+		"id":   "cluster-123",
+		"kind": "ManagedCluster",
+	}
+	result := exec.Execute(context.Background(), eventData)
+
+	require.Equal(t, StatusSuccess, result.Status, "errors=%v", result.Errors)
+	applied := mockClient.Resources["default/cluster-123"]
+	require.NotNil(t, applied, "resource should be applied with rendered name")
+	assert.Equal(t, "default", applied.GetNamespace())
+	assert.Equal(t, "cluster-123", applied.GetName())
+}
+
 func getCounterValue(t *testing.T, families []*dto.MetricFamily, metricName, labelName, labelValue string) float64 {
 	t.Helper()
 	family := findFamily(families, metricName)

--- a/internal/executor/param_extractor.go
+++ b/internal/executor/param_extractor.go
@@ -241,13 +241,15 @@ func extractFromEnv(envVar string) (interface{}, error) {
 	return value, nil
 }
 
-// addAdapterParams adds adapter info and the full config map to execCtx.Params
+// addAdapterParams adds adapter info, config, env, and event to execCtx.Params
 func addAdapterParams(config *configloader.Config, execCtx *ExecutionContext, configMap map[string]interface{}) {
 	execCtx.Params["adapter"] = map[string]interface{}{
 		"name":    config.Adapter.Name,
 		"version": config.Adapter.Version,
 	}
 	execCtx.Params["config"] = configMap
+	execCtx.Params["env"] = buildEnvMap()
+	execCtx.Params["event"] = execCtx.EventData
 }
 
 // convertParamType converts a value to the specified type.


### PR DESCRIPTION
## Summary

- HYPERFLEET-1293 added `env` and `event` to `builtinVariables` (template validation) and `GetCELVariables()` (CEL runtime), but not to `execCtx.Params` — the data root for Go template rendering
- Templates using `{{ .env.X }}` or `{{ .event.X }}` passed config validation but failed at runtime with `map has no entry for key "env"`
- Fix: inject `env` (all OS env vars) and `event` (raw event data) into `execCtx.Params` in `addAdapterParams()`

## Test plan

- [x] `TestGoTemplate_EnvInManifest` — `{{ .env.X }}` resolves in resource manifest
- [x] `TestGoTemplate_EventInManifest` — `{{ .event.X }}` resolves in resource manifest
- [x] Existing CEL tests for env/event continue to pass
- [x] Full unit test suite passes (`make test`)

Fixes: https://redhat.atlassian.net/browse/HYPERFLEET-1354

🤖 Generated with [Claude Code](https://claude.com/claude-code)