### PR TITLE
HYPERFLEET-1355 - fix: Add expirationttl and message retention to bro…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,8 @@ test-helm: $(KUBECONFORM) verify-helm-docs ## Test Helm charts (lint, template, 
 		--set broker.create=true \
 		--set broker.googlepubsub.subscriptionId=test-sub \
 		--set broker.googlepubsub.topic=test-topic \
+		--set broker.googlepubsub.expirationTTL=1d \
+		--set broker.googlepubsub.messageRetentionDuration=12h \
 		--set broker.type=googlepubsub) \
 		&& echo "$$output" | grep -q 'type: googlepubsub' \
 		|| { echo "ERROR: expected googlepubsub broker type in rendered output"; exit 1; }; \

--- a/charts/README.md
+++ b/charts/README.md
@@ -44,16 +44,18 @@ helm install hyperfleet-adapter oci://REGISTRY/hyperfleet-adapter \
 | autoscaling.minReplicas | int | `1` | Minimum number of replicas |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization percentage |
 | autoscaling.targetMemoryUtilizationPercentage | int | `80` | Target memory utilization percentage |
-| broker | object | `{"create":true,"googlepubsub":{"createSubscriptionIfMissing":false,"createTopicIfMissing":false,"deadLetterTopic":"","projectId":"","subscriptionId":"","topic":""},"rabbitmq":{"exchange":"","exchangeType":"topic","queue":"","url":""},"type":""}` | Broker configuration for event consumption. Supports RabbitMQ and Google Pub/Sub. Use `broker.yaml` for inline config, or set `create: false` and provide `configMapName` to reference an existing ConfigMap. |
+| broker | object | `{"create":true,"googlepubsub":{"createSubscriptionIfMissing":false,"createTopicIfMissing":false,"deadLetterTopic":"","expirationTTL":"","messageRetentionDuration":"","projectId":"","subscriptionId":"","topic":""},"rabbitmq":{"exchange":"","exchangeType":"topic","queue":"","url":""},"type":""}` | Broker configuration for event consumption. Supports RabbitMQ and Google Pub/Sub. Use `broker.yaml` for inline config, or set `create: false` and provide `configMapName` to reference an existing ConfigMap. |
 | broker.create | bool | `true` | Create the broker ConfigMap |
 | broker.type | string | `""` | Broker type (must be `googlepubsub` or `rabbitmq`) |
-| broker.googlepubsub | object | `{"createSubscriptionIfMissing":false,"createTopicIfMissing":false,"deadLetterTopic":"","projectId":"","subscriptionId":"","topic":""}` | Google Pub/Sub configuration |
+| broker.googlepubsub | object | `{"createSubscriptionIfMissing":false,"createTopicIfMissing":false,"deadLetterTopic":"","expirationTTL":"","messageRetentionDuration":"","projectId":"","subscriptionId":"","topic":""}` | Google Pub/Sub configuration |
 | broker.googlepubsub.projectId | string | `""` | GCP project ID |
 | broker.googlepubsub.topic | string | `""` | Pub/Sub topic name |
 | broker.googlepubsub.subscriptionId | string | `""` | Subscription ID |
 | broker.googlepubsub.deadLetterTopic | string | `""` | Dead letter topic name |
 | broker.googlepubsub.createTopicIfMissing | bool | `false` | Auto-create topic if missing (use `false` in production) |
 | broker.googlepubsub.createSubscriptionIfMissing | bool | `false` | Auto-create subscription if missing (use `false` in production) |
+| broker.googlepubsub.messageRetentionDuration | string | `""` | Length to retain unacknowledged messages (e.g. "1d", "12h", "604800s"). Min 10m, max 31d. |
+| broker.googlepubsub.expirationTTL | string | `""` | Inactivity period before subscription is auto-deleted (e.g. "1d"). Must be "0" (never expire) or >= "1d". |
 | broker.rabbitmq | object | `{"exchange":"","exchangeType":"topic","queue":"","url":""}` | RabbitMQ configuration |
 | broker.rabbitmq.url | string | `""` | Connection URL |
 | broker.rabbitmq.queue | string | `""` | Queue name prefix (derived from topic+subscriptionId if omitted) |

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -300,7 +300,19 @@ Validate that required fields are set for the resolved broker type.
 */}}
 {{- define "hyperfleet-adapter.validateBrokerConfig" -}}
 {{- $brokerType := include "hyperfleet-adapter.brokerType" . -}}
-{{- if eq $brokerType "rabbitmq" -}}
+{{- if eq $brokerType "googlepubsub" -}}
+  {{- $ttl := .Values.broker.googlepubsub.expirationTTL | toString -}}
+  {{- if ne $ttl "" -}}
+    {{- if not (regexMatch "^(0|[1-9][0-9]*[smhd])$" $ttl) -}}
+      {{- fail "broker.googlepubsub.expirationTTL must be \"0\" (never expire) or a duration like \"1d\", \"12h\", \"30m\", \"604800s\"" -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if .Values.broker.googlepubsub.messageRetentionDuration -}}
+    {{- if not (regexMatch "^[1-9][0-9]*[smhd]$" (.Values.broker.googlepubsub.messageRetentionDuration | toString)) -}}
+      {{- fail "broker.googlepubsub.messageRetentionDuration must be a duration like \"1d\", \"12h\", \"30m\", \"604800s\"" -}}
+    {{- end -}}
+  {{- end -}}
+{{- else if eq $brokerType "rabbitmq" -}}
   {{- if not .Values.broker.rabbitmq.url -}}
     {{- fail "broker.rabbitmq.url is required when broker type is rabbitmq" -}}
   {{- end -}}

--- a/charts/templates/configmap-broker.yaml
+++ b/charts/templates/configmap-broker.yaml
@@ -39,6 +39,12 @@ data:
         dead_letter_topic: {{ .Values.broker.googlepubsub.deadLetterTopic | quote }}
         create_topic_if_missing: {{ .Values.broker.googlepubsub.createTopicIfMissing }}
         create_subscription_if_missing: {{ .Values.broker.googlepubsub.createSubscriptionIfMissing }}
+        {{- if .Values.broker.googlepubsub.messageRetentionDuration }}
+        message_retention_duration: {{ .Values.broker.googlepubsub.messageRetentionDuration | quote }}
+        {{- end }}
+        {{- if or .Values.broker.googlepubsub.expirationTTL (eq (.Values.broker.googlepubsub.expirationTTL | toString) "0") }}
+        expiration_ttl: {{ .Values.broker.googlepubsub.expirationTTL | toString | quote }}
+        {{- end }}
       subscriber:
         parallelism: 1
   {{- else if eq $brokerType "rabbitmq" }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -115,6 +115,10 @@ broker:
     createTopicIfMissing: false
     # -- Auto-create subscription if missing (use `false` in production)
     createSubscriptionIfMissing: false
+    # -- Length to retain unacknowledged messages (e.g. "1d", "12h", "604800s"). Min 10m, max 31d.
+    messageRetentionDuration: ""
+    # -- Inactivity period before subscription is auto-deleted (e.g. "1d"). Must be "0" (never expire) or >= "1d".
+    expirationTTL: ""
   # -- RabbitMQ configuration
   rabbitmq:
     # -- Connection URL


### PR DESCRIPTION
## Summary

Add messageRetentionDuration and expirationTTL as values in configmap-broker.yaml

[HYPERFLEET-1355](https://redhat.atlassian.net/browse/HYPERFLEET-1355)

## Test Plan

- [ ] Helm chart changes validated with `make test-helm` (if applicable)



[HYPERFLEET-1355]: https://redhat.atlassian.net/browse/HYPERFLEET-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ