### PR TITLE
HYPERFLEET-1253 - docs: fix RabbitMQ URL and add skeleton deploy command

### DIFF
--- a/docs/adapter-authoring-guide.md
+++ b/docs/adapter-authoring-guide.md
@@ -1767,12 +1767,25 @@ clients:
    broker:
      type: rabbitmq
      rabbitmq:
-       url: "amqp://user:pass@rabbitmq:5672/"
+       url: "amqp://<user>:<password>@rabbitmq.<rabbitmq-namespace>.svc.cluster.local:5672/<vhost>" # namespace is where RabbitMQ is deployed
        exchange: "hyperfleet-clusters"   # must match sentinel's clients.broker.topic
        exchange_type: "topic"
    ```
 
 1. **Deploy using the Helm chart** — the generic `adapter/` chart mounts your task config as a ConfigMap and sets the environment variables.
+
+   ```bash
+   helm install my-adapter oci://quay.io/redhat-services-prod/hyperfleet-tenant/hyperfleet/hyperfleet-adapter-chart \
+     --namespace my-adapter-namespace \
+     --create-namespace \
+     -f my-values.yaml \
+     --set broker.type=rabbitmq \
+     --set broker.rabbitmq.url="amqp://<user>:<password>@rabbitmq.<rabbitmq-namespace>.svc.cluster.local:5672/<vhost>" \
+     --set broker.rabbitmq.exchange="hyperfleet-clusters" \
+     --set-file adapterTaskConfig.external.task-config=./my-task-config.yaml
+   ```
+
+   Where `my-values.yaml` contains image and adapter config (see [Deployment Guide](deployment.md) for full values reference).
 
 2. **Set up broker subscription** — for Google Pub/Sub, ensure your adapter has a dedicated subscription on the cluster events topic so it receives events independently of other adapters (fan-out pattern). For RabbitMQ, fan-out is achieved automatically by giving each adapter a unique `subscription_id` — the broker library creates a separate queue per adapter.
 


### PR DESCRIPTION
## Summary

Fixes incomplete broker URL in the authoring guide and added copy-paste helm install command.

- Ticket: [HYPERFLEET-1253](https://redhat.atlassian.net/browse/HYPERFLEET-1253)

## Test Plan

- [x] `docs/adapter-authoring-guide.md` renders correctly


[HYPERFLEET-1253]: https://redhat.atlassian.net/browse/HYPERFLEET-1253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ