### PR TITLE
HYPERFLEET-1363 - feat: add Grafana dashboard provisioning to Helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ test-helm: verify-helm-docs ## Test Helm charts (lint, template, validate, kubec
 		--set broker.type=googlepubsub \
 		--set broker.googlepubsub.subscriptionId=test-sub \
 		--set broker.googlepubsub.topic=test-topic \
-		--set serviceMonitor.enabled=true \
+		--set monitoring.serviceMonitor.enabled=true \
 		--api-versions monitoring.coreos.com/v1/ServiceMonitor) \
 		&& echo "$$output" | grep -q 'kind: ServiceMonitor' \
 		|| { echo "ERROR: ServiceMonitor not rendered"; exit 1; }; \
@@ -237,7 +237,7 @@ test-helm: verify-helm-docs ## Test Helm charts (lint, template, validate, kubec
 		--set broker.type=googlepubsub \
 		--set broker.googlepubsub.subscriptionId=test-sub \
 		--set broker.googlepubsub.topic=test-topic \
-		--set serviceMonitor.enabled=true) \
+		--set monitoring.serviceMonitor.enabled=true) \
 		&& ! echo "$$output" | grep -q 'kind: ServiceMonitor' \
 		|| { echo "ERROR: ServiceMonitor rendered without CRD"; exit 1; }; \
 		echo "$$output" | $(call gotool,kubeconform) $(KUBECONFORM_FLAGS)
@@ -253,7 +253,7 @@ test-helm: verify-helm-docs ## Test Helm charts (lint, template, validate, kubec
 		--set broker.type=googlepubsub \
 		--set broker.googlepubsub.subscriptionId=test-sub \
 		--set broker.googlepubsub.topic=test-topic \
-		--set serviceMonitor.enabled=false \
+		--set monitoring.serviceMonitor.enabled=false \
 		--api-versions monitoring.coreos.com/v1/ServiceMonitor) \
 		&& ! echo "$$output" | grep -q 'kind: ServiceMonitor' \
 		|| { echo "ERROR: ServiceMonitor rendered while disabled"; exit 1; }; \

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyperfleet-adapter
 description: HyperFleet Adapter - Event-driven adapter services for HyperFleet cluster provisioning
 type: application
-version: 2.1.0
+version: 2.2.0
 appVersion: "0.0.0-dev"
 maintainers:
   - name: HyperFleet Team

--- a/charts/README.md
+++ b/charts/README.md
@@ -1,6 +1,6 @@
 # hyperfleet-adapter
 
-![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0-dev](https://img.shields.io/badge/AppVersion-0.0.0--dev-informational?style=flat-square)
+![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0-dev](https://img.shields.io/badge/AppVersion-0.0.0--dev-informational?style=flat-square)
 
 HyperFleet Adapter - Event-driven adapter services for HyperFleet cluster provisioning
 
@@ -126,23 +126,26 @@ helm install hyperfleet-adapter oci://REGISTRY/hyperfleet-adapter \
 | strategy.type | string | `"RollingUpdate"` | Strategy type (`RollingUpdate` or `Recreate`) |
 | terminationGracePeriodSeconds | int | `30` | Termination grace period in seconds |
 | tolerations | list | `[]` | Tolerations for pod scheduling |
-| serviceMonitor | object | `{"enabled":true,"honorLabels":true,"interval":"30s","labels":{},"metricRelabeling":[],"namespace":"","namespaceSelector":{},"scrapeTimeout":"10s"}` | ServiceMonitor for Prometheus Operator scrape configuration. Defaults to enabled. On clusters without Prometheus Operator CRDs, the resource is silently skipped. |
-| serviceMonitor.enabled | bool | `true` | Create a ServiceMonitor resource |
-| serviceMonitor.interval | string | `"30s"` | Scrape interval |
-| serviceMonitor.scrapeTimeout | string | `"10s"` | Scrape timeout (must be less than interval) |
-| serviceMonitor.labels | object | `{}` | Additional labels for ServiceMonitor discovery |
-| serviceMonitor.honorLabels | bool | `true` | Honor labels from the target to avoid overwriting |
-| serviceMonitor.metricRelabeling | list | `[]` | Metric relabel configs applied before ingestion |
-| serviceMonitor.namespaceSelector | object | `{}` | Namespace selector for cross-namespace monitoring |
-| serviceMonitor.namespace | string | `""` | Override the namespace where ServiceMonitor is created (defaults to release namespace) |
-| tracing | object | `{"enabled":false,"otlpEndpoint":"","otlpProtocol":"grpc","propagators":"tracecontext,baggage","sampler":"parentbased_traceidratio","samplerArg":"1.0","serviceName":"hyperfleet-adapter"}` | Distributed tracing configuration (OpenTelemetry) |
-| tracing.enabled | bool | `false` | Enable trace export |
-| tracing.serviceName | string | `"hyperfleet-adapter"` | Service name reported in traces |
-| tracing.otlpEndpoint | string | `""` | OTLP exporter endpoint (traces go to stdout when empty) |
-| tracing.otlpProtocol | string | `"grpc"` | OTLP protocol (`grpc` or `http/protobuf`) |
-| tracing.sampler | string | `"parentbased_traceidratio"` | Sampler type |
-| tracing.samplerArg | string | `"1.0"` | Sampling rate (`1.0` for dev, `0.01` for production) |
-| tracing.propagators | string | `"tracecontext,baggage"` | Context propagation formats |
+| monitoring | object | `{"dashboard":{"enabled":false},"serviceMonitor":{"enabled":false,"honorLabels":true,"interval":"30s","labels":{},"metricRelabeling":[],"namespace":"","namespaceSelector":{},"scrapeTimeout":"10s"},"tracing":{"enabled":false,"otlpEndpoint":"","otlpProtocol":"grpc","propagators":"tracecontext,baggage","sampler":"parentbased_always_on","samplerArg":"","serviceName":"hyperfleet-adapter"}}` | Monitoring and observability configuration |
+| monitoring.serviceMonitor | object | `{"enabled":false,"honorLabels":true,"interval":"30s","labels":{},"metricRelabeling":[],"namespace":"","namespaceSelector":{},"scrapeTimeout":"10s"}` | ServiceMonitor for Prometheus Operator scrape configuration. Disabled by default. On clusters without Prometheus Operator CRDs, the resource is silently skipped. |
+| monitoring.serviceMonitor.enabled | bool | `false` | Create a ServiceMonitor resource |
+| monitoring.serviceMonitor.interval | string | `"30s"` | Scrape interval |
+| monitoring.serviceMonitor.scrapeTimeout | string | `"10s"` | Scrape timeout (must be less than interval) |
+| monitoring.serviceMonitor.labels | object | `{}` | Additional labels for ServiceMonitor discovery |
+| monitoring.serviceMonitor.honorLabels | bool | `true` | Honor labels from the target to avoid overwriting |
+| monitoring.serviceMonitor.metricRelabeling | list | `[]` | Metric relabel configs applied before ingestion |
+| monitoring.serviceMonitor.namespaceSelector | object | `{}` | Namespace selector for cross-namespace monitoring |
+| monitoring.serviceMonitor.namespace | string | `""` | Override the namespace where ServiceMonitor is created (defaults to release namespace) |
+| monitoring.dashboard | object | `{"enabled":false}` | Grafana dashboard provisioning via sidecar ConfigMap |
+| monitoring.dashboard.enabled | bool | `false` | Create a ConfigMap with the Grafana dashboard JSON |
+| monitoring.tracing | object | `{"enabled":false,"otlpEndpoint":"","otlpProtocol":"grpc","propagators":"tracecontext,baggage","sampler":"parentbased_always_on","samplerArg":"","serviceName":"hyperfleet-adapter"}` | Distributed tracing configuration (OpenTelemetry) |
+| monitoring.tracing.enabled | bool | `false` | Enable trace export |
+| monitoring.tracing.serviceName | string | `"hyperfleet-adapter"` | Service name reported in traces |
+| monitoring.tracing.otlpEndpoint | string | `""` | OTLP exporter endpoint (traces go to stdout when empty) |
+| monitoring.tracing.otlpProtocol | string | `"grpc"` | OTLP protocol (`grpc` or `http/protobuf`) |
+| monitoring.tracing.sampler | string | `"parentbased_always_on"` | Sampler type |
+| monitoring.tracing.samplerArg | string | `""` | Sampling rate (only used with ratio-based samplers) |
+| monitoring.tracing.propagators | string | `"tracecontext,baggage"` | Context propagation formats |
 
 ----------------------------------------------
 Autogenerated from chart metadata using [helm-docs](https://github.com/norwoodj/helm-docs)

--- a/charts/templates/configmap-dashboard.yaml
+++ b/charts/templates/configmap-dashboard.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.monitoring.dashboard.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "hyperfleet-adapter.fullname" . }}-grafana-dashboard
+  labels:
+    {{- include "hyperfleet-adapter.labels" . | nindent 4 }}
+    grafana_dashboard: "1"
+data:
+  hyperfleet-adapter.json: |-
+    {{- .Files.Get "dashboards/hyperfleet-adapter.json" | nindent 4 }}
+{{- end }}

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -104,7 +104,7 @@ spec:
             - name: HYPERFLEET_BROKER_TOPIC
               value: {{ .Values.broker.googlepubsub.topic | quote }}
             {{- end }}
-            {{- with .Values.tracing }}
+            {{- with .Values.monitoring.tracing }}
             - name: HYPERFLEET_TRACING_ENABLED
               value: {{ .enabled | quote }}
             {{- if .enabled }}

--- a/charts/templates/servicemonitor.yaml
+++ b/charts/templates/servicemonitor.yaml
@@ -1,26 +1,26 @@
-{{- if and .Values.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor") }}
+{{- if and .Values.monitoring.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor") }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "hyperfleet-adapter.fullname" . }}
-  {{- if .Values.serviceMonitor.namespace | trim }}
-  namespace: {{ .Values.serviceMonitor.namespace | trim }}
+  {{- if .Values.monitoring.serviceMonitor.namespace | trim }}
+  namespace: {{ .Values.monitoring.serviceMonitor.namespace | trim }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
   labels:
     {{- include "hyperfleet-adapter.labels" . | nindent 4 }}
-    {{- with .Values.serviceMonitor.labels }}
+    {{- with .Values.monitoring.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   selector:
     matchLabels:
       {{- include "hyperfleet-adapter.selectorLabels" . | nindent 6 }}
-  {{- if not (empty .Values.serviceMonitor.namespaceSelector) }}
+  {{- if not (empty .Values.monitoring.serviceMonitor.namespaceSelector) }}
   namespaceSelector:
-    {{- toYaml .Values.serviceMonitor.namespaceSelector | nindent 4 }}
-  {{- else if .Values.serviceMonitor.namespace | trim }}
+    {{- toYaml .Values.monitoring.serviceMonitor.namespaceSelector | nindent 4 }}
+  {{- else if .Values.monitoring.serviceMonitor.namespace | trim }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}
@@ -28,10 +28,10 @@ spec:
   endpoints:
     - port: metrics
       path: /metrics
-      interval: {{ .Values.serviceMonitor.interval }}
-      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
-      honorLabels: {{ .Values.serviceMonitor.honorLabels }}
-      {{- with .Values.serviceMonitor.metricRelabeling }}
+      interval: {{ .Values.monitoring.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.monitoring.serviceMonitor.scrapeTimeout }}
+      honorLabels: {{ .Values.monitoring.serviceMonitor.honorLabels }}
+      {{- with .Values.monitoring.serviceMonitor.metricRelabeling }}
       metricRelabelings:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/values.schema.json
+++ b/charts/values.schema.json
@@ -860,82 +860,98 @@
         "type": "object"
       }
     },
-    "serviceMonitor": {
+    "monitoring": {
       "type": "object",
-      "description": "ServiceMonitor for Prometheus Operator discovery",
+      "description": "Monitoring and observability configuration",
       "properties": {
-        "enabled": {
-          "type": "boolean",
-          "description": "Enable ServiceMonitor creation (requires monitoring.coreos.com CRDs)"
-        },
-        "interval": {
-          "type": "string",
-          "description": "Scrape interval (e.g. 30s)"
-        },
-        "scrapeTimeout": {
-          "type": "string",
-          "description": "Scrape timeout, must be less than interval (e.g. 10s)"
-        },
-        "labels": {
+        "serviceMonitor": {
           "type": "object",
-          "description": "Additional labels for ServiceMonitor"
-        },
-        "honorLabels": {
-          "type": "boolean",
-          "description": "Honor labels from the target"
-        },
-        "metricRelabeling": {
-          "type": "array",
-          "description": "Metric relabel configs",
-          "items": {
-            "type": "object"
+          "description": "ServiceMonitor for Prometheus Operator discovery",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable ServiceMonitor creation (requires monitoring.coreos.com CRDs)"
+            },
+            "interval": {
+              "type": "string",
+              "description": "Scrape interval (e.g. 30s)"
+            },
+            "scrapeTimeout": {
+              "type": "string",
+              "description": "Scrape timeout, must be less than interval (e.g. 10s)"
+            },
+            "labels": {
+              "type": "object",
+              "description": "Additional labels for ServiceMonitor"
+            },
+            "honorLabels": {
+              "type": "boolean",
+              "description": "Honor labels from the target"
+            },
+            "metricRelabeling": {
+              "type": "array",
+              "description": "Metric relabel configs",
+              "items": {
+                "type": "object"
+              }
+            },
+            "namespaceSelector": {
+              "type": "object",
+              "description": "Namespace selector for cross-namespace monitoring"
+            },
+            "namespace": {
+              "type": "string",
+              "description": "Override namespace where ServiceMonitor is created"
+            }
           }
         },
-        "namespaceSelector": {
+        "dashboard": {
           "type": "object",
-          "description": "Namespace selector for cross-namespace monitoring"
+          "description": "Grafana dashboard provisioning via sidecar ConfigMap",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Create a ConfigMap with the Grafana dashboard JSON"
+            }
+          }
         },
-        "namespace": {
-          "type": "string",
-          "description": "Override namespace where ServiceMonitor is created"
-        }
-      }
-    },
-    "tracing": {
-      "type": "object",
-      "description": "OpenTelemetry tracing configuration",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "description": "Enable OpenTelemetry tracing"
-        },
-        "serviceName": {
-          "type": "string",
-          "description": "OTEL_SERVICE_NAME value"
-        },
-        "otlpEndpoint": {
-          "type": "string",
-          "description": "OTLP exporter endpoint"
-        },
-        "otlpProtocol": {
-          "type": "string",
-          "description": "OTLP protocol",
-          "enum": [
-            "grpc",
-            "http/protobuf"
-          ]
-        },
-        "sampler": {
-          "type": "string",
-          "description": "Sampler type"
-        },
-        "samplerArg": {
-          "type": "string",
-          "description": "Sampling rate (1.0 for dev, 0.01 for production)"
-        },
-        "propagators": {
-          "type": "string",
-          "description": "Trace context propagators (comma-separated)"
+        "tracing": {
+          "type": "object",
+          "description": "OpenTelemetry tracing configuration",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable OpenTelemetry tracing"
+            },
+            "serviceName": {
+              "type": "string",
+              "description": "OTEL_SERVICE_NAME value"
+            },
+            "otlpEndpoint": {
+              "type": "string",
+              "description": "OTLP exporter endpoint"
+            },
+            "otlpProtocol": {
+              "type": "string",
+              "description": "OTLP protocol",
+              "enum": [
+                "grpc",
+                "http/protobuf"
+              ]
+            },
+            "sampler": {
+              "type": "string",
+              "description": "Sampler type"
+            },
+            "samplerArg": {
+              "type": "string",
+              "description": "Sampling rate (only used with ratio-based samplers)"
+            },
+            "propagators": {
+              "type": "string",
+              "description": "Trace context propagators (comma-separated)"
+            }
+          }
         }
       }
     }

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -362,40 +362,47 @@ terminationGracePeriodSeconds: 30
 # -- Tolerations for pod scheduling
 tolerations: []
 
-# -- ServiceMonitor for Prometheus Operator scrape configuration.
-# Defaults to enabled. On clusters without Prometheus Operator CRDs,
-# the resource is silently skipped.
-serviceMonitor:
-  # -- Create a ServiceMonitor resource
-  enabled: true
-  # -- Scrape interval
-  interval: 30s
-  # -- Scrape timeout (must be less than interval)
-  scrapeTimeout: 10s
-  # -- Additional labels for ServiceMonitor discovery
-  labels: {}
-  # -- Honor labels from the target to avoid overwriting
-  honorLabels: true
-  # -- Metric relabel configs applied before ingestion
-  metricRelabeling: []
-  # -- Namespace selector for cross-namespace monitoring
-  namespaceSelector: {}
-  # -- Override the namespace where ServiceMonitor is created (defaults to release namespace)
-  namespace: ""
+# -- Monitoring and observability configuration
+monitoring:
+  # -- ServiceMonitor for Prometheus Operator scrape configuration.
+  # Disabled by default. On clusters without Prometheus Operator CRDs,
+  # the resource is silently skipped.
+  serviceMonitor:
+    # -- Create a ServiceMonitor resource
+    enabled: false
+    # -- Scrape interval
+    interval: 30s
+    # -- Scrape timeout (must be less than interval)
+    scrapeTimeout: 10s
+    # -- Additional labels for ServiceMonitor discovery
+    labels: {}
+    # -- Honor labels from the target to avoid overwriting
+    honorLabels: true
+    # -- Metric relabel configs applied before ingestion
+    metricRelabeling: []
+    # -- Namespace selector for cross-namespace monitoring
+    namespaceSelector: {}
+    # -- Override the namespace where ServiceMonitor is created (defaults to release namespace)
+    namespace: ""
 
-# -- Distributed tracing configuration (OpenTelemetry)
-tracing:
-  # -- Enable trace export
-  enabled: false
-  # -- Service name reported in traces
-  serviceName: "hyperfleet-adapter"
-  # -- OTLP exporter endpoint (traces go to stdout when empty)
-  otlpEndpoint: ""
-  # -- OTLP protocol (`grpc` or `http/protobuf`)
-  otlpProtocol: "grpc"
-  # -- Sampler type
-  sampler: "parentbased_traceidratio"
-  # -- Sampling rate (`1.0` for dev, `0.01` for production)
-  samplerArg: "1.0"
-  # -- Context propagation formats
-  propagators: "tracecontext,baggage"
+  # -- Grafana dashboard provisioning via sidecar ConfigMap
+  dashboard:
+    # -- Create a ConfigMap with the Grafana dashboard JSON
+    enabled: false
+
+  # -- Distributed tracing configuration (OpenTelemetry)
+  tracing:
+    # -- Enable trace export
+    enabled: false
+    # -- Service name reported in traces
+    serviceName: "hyperfleet-adapter"
+    # -- OTLP exporter endpoint (traces go to stdout when empty)
+    otlpEndpoint: ""
+    # -- OTLP protocol (`grpc` or `http/protobuf`)
+    otlpProtocol: "grpc"
+    # -- Sampler type
+    sampler: "parentbased_always_on"
+    # -- Sampling rate (only used with ratio-based samplers)
+    samplerArg: ""
+    # -- Context propagation formats
+    propagators: "tracecontext,baggage"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -196,12 +196,12 @@ When tracing is enabled, the adapter uses standard [OpenTelemetry environment va
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | Protocol: `grpc` or `http/protobuf` | `grpc` |
 | `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` | Signal-specific protocol override | — |
 | `OTEL_SERVICE_NAME` | Service name reported in spans | `adapter.name` from config |
-| `OTEL_TRACES_SAMPLER` | Sampler type (`always_on`, `always_off`, `traceidratio`, `parentbased_*`) | `parentbased_traceidratio` |
-| `OTEL_TRACES_SAMPLER_ARG` | Sampling ratio (0.0–1.0) | `1.0` |
+| `OTEL_TRACES_SAMPLER` | Sampler type (`always_on`, `always_off`, `traceidratio`, `parentbased_*`) | `parentbased_always_on` |
+| `OTEL_TRACES_SAMPLER_ARG` | Sampling ratio (only used with ratio-based samplers) | `""` |
 
 When no `OTEL_EXPORTER_OTLP_ENDPOINT` is set, traces are written to stdout for local development.
 
-The Helm chart exposes `tracing.enabled`, `tracing.otlpEndpoint`, `tracing.otlpProtocol`, `tracing.serviceName`, `tracing.sampler`, `tracing.samplerArg`, and `tracing.propagators` in `values.yaml` which map to these environment variables. For Helm deployment details, see the [Deployment Guide — Tracing](deployment.md#tracing).
+The Helm chart exposes `monitoring.tracing.enabled`, `monitoring.tracing.otlpEndpoint`, `monitoring.tracing.otlpProtocol`, `monitoring.tracing.serviceName`, `monitoring.tracing.sampler`, `monitoring.tracing.samplerArg`, and `monitoring.tracing.propagators` in `values.yaml` which map to these environment variables. For Helm deployment details, see the [Deployment Guide — Tracing](deployment.md#tracing).
 
 ## Command-line parameters
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -197,13 +197,13 @@ The chart automatically sets these environment variables from Helm values:
 | `HYPERFLEET_BROKER_TOPIC` | `broker.googlepubsub.topic` | When broker type is `googlepubsub` |
 | `BROKER_URL` | `broker.rabbitmq.url` | When broker type is `rabbitmq` |
 | `BROKER_QUEUE` | `broker.rabbitmq.queue` | When broker type is `rabbitmq` |
-| `HYPERFLEET_TRACING_ENABLED` | `tracing.enabled` | Always |
-| `OTEL_SERVICE_NAME` | `tracing.serviceName` | When tracing is enabled |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | `tracing.otlpEndpoint` | When tracing is enabled |
-| `OTEL_EXPORTER_OTLP_PROTOCOL` | `tracing.otlpProtocol` | When tracing is enabled |
-| `OTEL_TRACES_SAMPLER` | `tracing.sampler` | When tracing is enabled |
-| `OTEL_TRACES_SAMPLER_ARG` | `tracing.samplerArg` | When tracing is enabled |
-| `OTEL_PROPAGATORS` | `tracing.propagators` | When tracing is enabled |
+| `HYPERFLEET_TRACING_ENABLED` | `monitoring.tracing.enabled` | Always |
+| `OTEL_SERVICE_NAME` | `monitoring.tracing.serviceName` | When tracing is enabled |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `monitoring.tracing.otlpEndpoint` | When tracing is enabled |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `monitoring.tracing.otlpProtocol` | When tracing is enabled |
+| `OTEL_TRACES_SAMPLER` | `monitoring.tracing.sampler` | When tracing is enabled |
+| `OTEL_TRACES_SAMPLER_ARG` | `monitoring.tracing.samplerArg` | When tracing is enabled |
+| `OTEL_PROPAGATORS` | `monitoring.tracing.propagators` | When tracing is enabled |
 | `K8S_NAMESPACE` | Pod field `metadata.namespace` | When tracing is enabled |
 | `OTEL_RESOURCE_ATTRIBUTES` | Hardcoded `k8s.namespace.name=$(K8S_NAMESPACE)` | When tracing is enabled |
 
@@ -337,9 +337,10 @@ env:
       fieldRef:
         fieldPath: metadata.namespace
 
-tracing:
-  enabled: true
-  otlpEndpoint: http://otel-collector:4317
+monitoring:
+  tracing:
+    enabled: true
+    otlpEndpoint: http://otel-collector:4317
 
 rbac:
   resources:

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -4,7 +4,7 @@
 
 All metrics are exposed on the `/metrics` endpoint (port 9090) in Prometheus format. No additional configuration is needed.
 
-The Helm chart includes a **ServiceMonitor** template for automatic discovery by the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator). It is enabled by default (`serviceMonitor.enabled: true`) and scrapes the `/metrics` endpoint every 30s with `honorLabels: true` to preserve the adapter's `component`, `version`, and `adapter_name` labels. The template is only rendered when the Prometheus Operator CRDs (`monitoring.coreos.com/v1/ServiceMonitor`) are available on the cluster; otherwise it is silently skipped. See the Helm `values.yaml` for configuration options (interval, scrapeTimeout, labels, namespaceSelector).
+The Helm chart includes a **ServiceMonitor** template for automatic discovery by the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator). It is disabled by default (`monitoring.serviceMonitor.enabled: false`) and scrapes the `/metrics` endpoint every 30s with `honorLabels: true` to preserve the adapter's `component`, `version`, and `adapter_name` labels. The template is only rendered when the Prometheus Operator CRDs (`monitoring.coreos.com/v1/ServiceMonitor`) are available on the cluster; otherwise it is silently skipped. See the Helm `values.yaml` for configuration options (interval, scrapeTimeout, labels, namespaceSelector).
 
 ## Adapter Metrics
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -258,7 +258,7 @@ Non-retryable: forbidden, unauthorized, bad request, invalid, gone, method not s
    ```bash
    kubectl exec <pod> -- curl -s http://otel-collector:4317
    ```
-4. Check Helm values: `tracing.enabled`, `tracing.otlpEndpoint`, `tracing.otlpProtocol`
+4. Check Helm values: `monitoring.tracing.enabled`, `monitoring.tracing.otlpEndpoint`, `monitoring.tracing.otlpProtocol`
 
 ---
 


### PR DESCRIPTION
## Why

Part of HYPERFLEET-1363 — unify observability values under `monitoring:` across all HyperFleet component charts and consolidate dashboard provisioning.

> **Note:** This PR moves `serviceMonitor` under `monitoring:`. The infra repo (`base-adapter.yaml.gotmpl`) currently passes `serviceMonitor.enabled` at the top level — the corresponding infra PR must merge together with this one.

## Changes

- Move `serviceMonitor` and `tracing` under `monitoring:` section
- Add `configmap-dashboard.yaml` for Grafana sidecar provisioning (`grafana_dashboard: "1"`)
- Default `serviceMonitor.enabled` to `false` (infra enables via helmfile)
- Default sampler to `parentbased_always_on`
- Update `values.schema.json` to match new paths
- Update docs (`metrics.md`, `configuration.md`, `deployment.md`, `runbook.md`) and `Makefile` test commands

## Test plan

- [ ] `make test-helm` passes
- [ ] Deploy with infra PR using `OBSERVABILITY_ENABLED=true` — dashboard appears in Grafana